### PR TITLE
Add lora_cache_dir setting for persistent LoRA storage

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     comfyui_url: str = "http://localhost:8188"
     comfyui_api_key: str = ""  # Bearer token for ComfyUI auth (RunPod sets this)
     comfyui_path: str = ""  # Path to ComfyUI installation (for custom node management)
+    lora_cache_dir: str = ""  # Override LoRA download dir (e.g. /workspace/models/loras for persistence)
     queue_url: str = "http://localhost:8001"
     poll_interval: int = 5
 

--- a/daemon/lora_sync.py
+++ b/daemon/lora_sync.py
@@ -18,7 +18,13 @@ PARTIAL_EXTENSIONS = (".aria2", ".tmp", ".part")
 
 
 def _loras_dir() -> str:
-    """Return the ComfyUI loras directory path."""
+    """Return the LoRA download directory path.
+
+    Uses ``lora_cache_dir`` when set (e.g. a persistent volume on RunPod),
+    otherwise falls back to ``comfyui_path/models/loras``.
+    """
+    if settings.lora_cache_dir:
+        return settings.lora_cache_dir
     return os.path.join(settings.comfyui_path, "models", "loras")
 
 


### PR DESCRIPTION
## Summary
- Adds `lora_cache_dir` config setting to override where LoRA files are downloaded
- When set, LoRA sync uses this directory instead of `comfyui_path/models/loras`
- Enables persistent LoRA caching on RunPod (e.g. `/workspace/models/loras` survives restarts)

## Test plan
- [ ] Verify daemon starts with `LORA_CACHE_DIR=/workspace/models/loras` on RunPod
- [ ] Verify LoRA files download to the cache dir
- [ ] Verify daemon still works without the setting (falls back to comfyui_path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)