### PR TITLE
Swap to PainterLongVideo for identity anchoring

### DIFF
--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -32,6 +32,7 @@ class SegmentClaim(BaseModel):
     faceswap_image: Optional[str] = None
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
+    initial_reference_image: Optional[str] = None
     width: int
     height: int
     fps: int


### PR DESCRIPTION
## Summary
- Adds `initial_reference_image` field to `SegmentClaim` schema
- Downloads and uploads the original input image to ComfyUI in the executor (segment > 0 only)
- Swaps node 98 from `WanImageToVideo` to `PainterLongVideo` with dual-reference inputs: last frame for continuity + original image as identity anchor
- Uses `motion_amplitude=1.15` to counteract lightx2v slow-motion and `motion_frames=3`

## Context
Chained video segments drift from the original character by segment 3-4. PainterLongVideo solves this by injecting the job's original input image as a reference alongside the continuity frame. Segment 0 behavior is unchanged (still uses WanImageToVideo).

Companion PR: DavidJBarnes/wanly-api (feature/painter-long-video)

Requires: ComfyUI-PainterLongVideo custom node installed on GPU workers.

## Test plan
- [ ] Generate 5+ segments of the same character — compare segment 1 vs 5 for identity consistency
- [ ] Verify segment 0 still uses WanImageToVideo (no PainterLongVideo)
- [ ] Check ComfyUI logs show PainterLongVideo for segments > 0
- [ ] Verify graceful fallback: if `initial_reference_image` is null, falls back to WanImageToVideo

🤖 Generated with [Claude Code](https://claude.com/claude-code)