### PR TITLE
Tune PainterLongVideo: stronger identity anchoring

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     unet_low_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors"
     lightx2v_lora_high: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors"
     lightx2v_lora_low: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
+    clip_vision_model: str = "clip_vision_h.safetensors"
 
     model_config = {"env_file": ".env"}
 

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -356,6 +356,22 @@ def build_workflow(
             "inputs": {"image": initial_reference_image_filename},
             "_meta": {"title": "Initial Reference Image"},
         }
+        # Node 301: CLIP Vision model loader
+        workflow["301"] = {
+            "class_type": "CLIPVisionLoader",
+            "inputs": {"clip_name": settings.clip_vision_model},
+            "_meta": {"title": "CLIP Vision Loader"},
+        }
+        # Node 302: Encode reference image with CLIP Vision
+        workflow["302"] = {
+            "class_type": "CLIPVisionEncode",
+            "inputs": {
+                "clip_vision": ["301", 0],
+                "image": ["300", 0],
+                "crop": "center",
+            },
+            "_meta": {"title": "CLIP Vision Encode Reference"},
+        }
         # Replace WanImageToVideo with PainterLongVideo
         workflow["98"] = {
             "class_type": "PainterLongVideo",
@@ -368,16 +384,19 @@ def build_workflow(
                 "length": gen["wan_frames"],
                 "batch_size": 1,
                 "previous_video": ["97", 0],
-                "motion_frames": 3,
-                "motion_amplitude": 1.15,
+                "motion_frames": 5,
+                "motion_amplitude": 1.3,
                 "initial_reference_image": ["300", 0],
+                "clip_vision_output": ["302", 0],
+                "start_image": ["97", 0],
             },
             "_meta": {"title": "PainterLongVideo Identity Anchor"},
         }
         logger.info(
-            "Swapped to PainterLongVideo (segment %d, ref=%s)",
+            "Swapped to PainterLongVideo (segment %d, ref=%s, clip_vision=%s)",
             segment.index,
             initial_reference_image_filename,
+            settings.clip_vision_model,
         )
 
     # User LoRAs


### PR DESCRIPTION
## Summary
- `motion_frames`: 3 → 5 (node default, smoother segment transitions)
- `motion_amplitude`: 1.15 → 1.3 (stronger compensation for lightx2v slow motion)
- Added CLIP vision pipeline: `CLIPVisionLoader` → `CLIPVisionEncode` → feeds `clip_vision_output` on PainterLongVideo for additional identity conditioning from the original reference image
- Connected `start_image` input (last frame) for explicit first-frame anchoring
- New config setting `clip_vision_model` (default: `clip_vision_h.safetensors`)

## Test plan
- [ ] Run 3+ segment job, confirm CLIP vision nodes appear in ComfyUI execution
- [ ] Compare identity preservation vs previous PainterLongVideo run (motion_frames=3, no CLIP vision)
- [ ] Verify motion isn't sluggish with amplitude=1.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)