### PR TITLE
Add PainterLongVideo to node checker

### DIFF
--- a/daemon/node_checker.py
+++ b/daemon/node_checker.py
@@ -31,6 +31,10 @@ CUSTOM_NODE_PACKAGES: dict[str, dict] = {
         "nodes": ["ReActorFaceSwapOpt", "ReActorOptions"],
         "alt_dirs": ["comfyui-reactor", "ComfyUI-ReActor", "ComfyUI-ReActor-NSFW"],
     },
+    "ComfyUI-PainterLongVideo": {
+        "repo": "https://github.com/princepainter/ComfyUI-PainterLongVideo",
+        "nodes": ["PainterLongVideo"],
+    },
 }
 
 


### PR DESCRIPTION
## Summary
- Adds PainterLongVideo to `CUSTOM_NODE_PACKAGES` in `node_checker.py`
- Daemon will auto-install the custom node on startup if missing from ComfyUI

## Test plan
- [ ] Start daemon without PainterLongVideo installed — verify it auto-clones
- [ ] Start daemon with PainterLongVideo installed — verify it skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)