### PR TITLE
Overclock lightx2v LoRA strengths to fix slow motion

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     unet_low_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors"
     lightx2v_lora_high: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors"
     lightx2v_lora_low: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
+    lightx2v_strength_high: float = 5.6  # Overclocked motion strength for high noise lightx2v LoRA
+    lightx2v_strength_low: float = 2.0  # Overclocked motion strength for low noise lightx2v LoRA
     clip_vision_model: str = "clip_vision_h.safetensors"
 
     model_config = {"env_file": ".env"}

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -188,6 +188,9 @@ async def run():
         settings.clip_model, settings.vae_model,
         settings.unet_high_model, settings.unet_low_model,
     )
+    logger.info("LightX2V strengths: high=%.1f low=%.1f",
+        settings.lightx2v_strength_high, settings.lightx2v_strength_low,
+    )
 
     # Check and install required ComfyUI custom nodes
     nodes_ok = await check_and_install_nodes(comfyui)

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -327,7 +327,9 @@ def build_workflow(
     workflow["95"]["inputs"]["unet_name"] = settings.unet_high_model
     workflow["96"]["inputs"]["unet_name"] = settings.unet_low_model
     workflow["101"]["inputs"]["lora_name"] = settings.lightx2v_lora_high
+    workflow["101"]["inputs"]["strength_model"] = settings.lightx2v_strength_high
     workflow["102"]["inputs"]["lora_name"] = settings.lightx2v_lora_low
+    workflow["102"]["inputs"]["strength_model"] = settings.lightx2v_strength_low
 
     # Positive prompt
     workflow["93"]["inputs"]["text"] = segment.prompt


### PR DESCRIPTION
## Summary
- Make lightx2v LoRA strengths configurable via `LIGHTX2V_STRENGTH_HIGH` and `LIGHTX2V_STRENGTH_LOW` env vars
- Default to community "Enhanced Motions" values: high=5.6, low=2.0 (previously hardcoded at 1.0/1.0)
- Log strengths at daemon startup for visibility

## Context
The lightx2v 4-step acceleration LoRA at strength 1.0 is a [well-documented cause of slow motion](https://huggingface.co/lightx2v/Wan2.2-Lightning/discussions/26) in Wan2.2 generations. The community fix is to overclock the strengths (5.6 high / 2.0 low), which dramatically improves motion dynamics without changing steps, CFG, or scheduler.

## Test plan
- [ ] Start daemon — verify new log line shows `LightX2V strengths: high=5.6 low=2.0`
- [ ] Run a generation — compare motion to previous 1.0/1.0 output
- [ ] Override via .env (e.g. `LIGHTX2V_STRENGTH_HIGH=4.0`) — verify it takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)