### PR TITLE
Reset lightx2v strength defaults to 1.0

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -19,8 +19,8 @@ class Settings(BaseSettings):
     unet_low_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors"
     lightx2v_lora_high: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors"
     lightx2v_lora_low: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
-    lightx2v_strength_high: float = 5.6  # Overclocked motion strength for high noise lightx2v LoRA
-    lightx2v_strength_low: float = 2.0  # Overclocked motion strength for low noise lightx2v LoRA
+    lightx2v_strength_high: float = 1.0  # Strength for high noise lightx2v LoRA (community range: 1.0–5.6)
+    lightx2v_strength_low: float = 1.0  # Strength for low noise lightx2v LoRA (community range: 1.0–2.0)
     clip_vision_model: str = "clip_vision_h.safetensors"
 
     model_config = {"env_file": ".env"}


### PR DESCRIPTION
## Summary
- Reset `lightx2v_strength_high` and `lightx2v_strength_low` defaults back to 1.0
- The 5.6/2.0 values from PR #7 produced completely incoherent output with our workflow
- Strengths remain configurable via env vars for per-machine experimentation

## Test plan
- [ ] Restart daemon — verify defaults are 1.0/1.0
- [ ] Run a generation — verify coherent output
- [ ] Test higher values via .env incrementally (1.5, 2.0, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)