### PR TITLE
Add per-segment speed parameter

### DIFF
--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -24,6 +24,7 @@ class SegmentClaim(BaseModel):
     index: int
     prompt: str
     duration_seconds: float
+    speed: float = 1.0
     start_image: Optional[str] = None
     loras: Optional[list[LoraItem]] = None
     faceswap_enabled: bool

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -165,9 +165,10 @@ WAN_I2V_API_WORKFLOW: dict[str, Any] = {
 }
 
 
-def _calculate_generation_params(target_fps: int, duration_sec: float) -> dict[str, Any]:
+def _calculate_generation_params(target_fps: int, duration_sec: float, speed: float = 1.0) -> dict[str, Any]:
+    adjusted_duration = duration_sec / speed
     rife_multiplier = target_fps // GENERATION_FPS
-    wan_frames = int(duration_sec * GENERATION_FPS) + 1
+    wan_frames = int(adjusted_duration * GENERATION_FPS) + 1
     return {
         "wan_frames": wan_frames,
         "rife_multiplier": rife_multiplier,
@@ -318,7 +319,7 @@ def build_workflow(
             When provided (segment > 0), node 98 is swapped from WanImageToVideo
             to PainterLongVideo with dual-reference inputs.
     """
-    gen = _calculate_generation_params(segment.fps, segment.duration_seconds)
+    gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
     workflow = copy.deepcopy(WAN_I2V_API_WORKFLOW)
 
     # Inject model filenames from config
@@ -447,12 +448,13 @@ def build_workflow(
     }
 
     logger.info(
-        "Built workflow: %dx%d, %d frames @ %dfps, RIFE %dx, seed=%d, faceswap=%s",
+        "Built workflow: %dx%d, %d frames @ %dfps, RIFE %dx, speed=%.1fx, seed=%d, faceswap=%s",
         segment.width,
         segment.height,
         gen["wan_frames"],
         GENERATION_FPS,
         rife_multiplier,
+        segment.speed,
         segment.seed,
         faceswap,
     )


### PR DESCRIPTION
## Summary
- Adds `speed` field to SegmentClaim schema (default 1.0)
- Updates `_calculate_generation_params` to compute `adjusted_duration = duration / speed`
- Fewer native frames at higher speed, RIFE multiplier unchanged
- Logs speed in workflow build output

## Test plan
- [ ] speed=1.0 → 76 frames for 5s @ 30fps (unchanged)
- [ ] speed=1.5 → 51 frames for 5s @ 30fps
- [ ] speed=2.0 → 38 frames for 5s @ 30fps
- [ ] Verify RIFE multiplier stays at 2x for 30fps regardless of speed

🤖 Generated with [Claude Code](https://claude.com/claude-code)