### PR TITLE
Guard minimum frame count to prevent RIFE error

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -166,9 +166,9 @@ WAN_I2V_API_WORKFLOW: dict[str, Any] = {
 
 
 def _calculate_generation_params(target_fps: int, duration_sec: float, speed: float = 1.0) -> dict[str, Any]:
-    adjusted_duration = duration_sec / speed
+    adjusted_duration = duration_sec / max(speed, 0.25)
     rife_multiplier = target_fps // GENERATION_FPS
-    wan_frames = int(adjusted_duration * GENERATION_FPS) + 1
+    wan_frames = max(int(adjusted_duration * GENERATION_FPS) + 1, 5)
     return {
         "wan_frames": wan_frames,
         "rife_multiplier": rife_multiplier,


### PR DESCRIPTION
## Summary
- Clamps `wan_frames` to minimum of 5 in `_calculate_generation_params`
- Clamps speed divisor to minimum 0.25 as defense-in-depth
- Prevents 'RIFE VFI requires at least 2 frames' ComfyUI error

## Context
RunPod workers were hitting this error, costing money on failed jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)