### PR TITLE
Add graceful drain with RunPod auto-stop

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     lightx2v_strength_low: float = 1.0  # Strength for low noise lightx2v LoRA (community range: 1.0–2.0)
     clip_vision_model: str = "clip_vision_h.safetensors"
 
+    # RunPod auto-stop (set by RunPod environment + user config)
+    runpod_pod_id: str | None = None
+    runpod_api_key: str | None = None
+
     model_config = {"env_file": ".env"}
 
 

--- a/daemon/registry_client.py
+++ b/daemon/registry_client.py
@@ -29,12 +29,13 @@ class RegistryClient:
         resp.raise_for_status()
         return uuid.UUID(resp.json()["id"])
 
-    async def heartbeat(self, worker_id: uuid.UUID, comfyui_running: bool):
+    async def heartbeat(self, worker_id: uuid.UUID, comfyui_running: bool) -> dict:
         resp = await self.client.post(
             f"/workers/{worker_id}/heartbeat",
             json={"comfyui_running": comfyui_running},
         )
         resp.raise_for_status()
+        return resp.json()
 
     async def update_status(self, worker_id: uuid.UUID, status: str):
         resp = await self.client.patch(


### PR DESCRIPTION
## Summary
- Daemon checks heartbeat response for `"draining"` status from registry
- Sets internal drain flag → stops claiming new jobs
- If executing, finishes current segment then exits cleanly
- On RunPod: calls API to stop the pod after deregistration
- New config: `RUNPOD_POD_ID` (auto-set by RunPod) + `RUNPOD_API_KEY` (user sets in pod template)

## Test plan
- [ ] Drain idle worker → daemon exits within ~30s
- [ ] Drain busy worker → daemon finishes segment, then exits
- [ ] Local 3090 (no RunPod env vars) → daemon exits without calling RunPod API
- [ ] RunPod (with env vars) → pod stops after drain

🤖 Generated with [Claude Code](https://claude.com/claude-code)