### PR TITLE
Support per-job LightX2V strengths

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     unet_low_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors"
     lightx2v_lora_high: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors"
     lightx2v_lora_low: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
-    lightx2v_strength_high: float = 1.0  # Strength for high noise lightx2v LoRA (community range: 1.0–5.6)
+    lightx2v_strength_high: float = 2.0  # Strength for high noise lightx2v LoRA (community range: 1.0–5.6)
     lightx2v_strength_low: float = 1.0  # Strength for low noise lightx2v LoRA (community range: 1.0–2.0)
     clip_vision_model: str = "clip_vision_h.safetensors"
 

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -34,6 +34,8 @@ class SegmentClaim(BaseModel):
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
     initial_reference_image: Optional[str] = None
+    lightx2v_strength_high: Optional[float] = None
+    lightx2v_strength_low: Optional[float] = None
     width: int
     height: int
     fps: int

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -338,9 +338,9 @@ def build_workflow(
     workflow["95"]["inputs"]["unet_name"] = settings.unet_high_model
     workflow["96"]["inputs"]["unet_name"] = settings.unet_low_model
     workflow["101"]["inputs"]["lora_name"] = settings.lightx2v_lora_high
-    workflow["101"]["inputs"]["strength_model"] = settings.lightx2v_strength_high
+    workflow["101"]["inputs"]["strength_model"] = segment.lightx2v_strength_high if segment.lightx2v_strength_high is not None else settings.lightx2v_strength_high
     workflow["102"]["inputs"]["lora_name"] = settings.lightx2v_lora_low
-    workflow["102"]["inputs"]["strength_model"] = settings.lightx2v_strength_low
+    workflow["102"]["inputs"]["strength_model"] = segment.lightx2v_strength_low if segment.lightx2v_strength_low is not None else settings.lightx2v_strength_low
 
     # Positive prompt
     workflow["93"]["inputs"]["text"] = segment.prompt


### PR DESCRIPTION
## Summary
- Change default `lightx2v_strength_high` from 1.0 to 2.0 in daemon config
- Add optional `lightx2v_strength_high/low` fields to SegmentClaim schema
- Use per-job values in workflow_builder when set, fall back to daemon defaults

## Test plan
- [ ] Verify daemon starts with new default (high=2.0, low=1.0)
- [ ] Claim segment with lightx2v values — verify workflow uses job values
- [ ] Claim segment without lightx2v values — verify workflow uses daemon defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)