### PR TITLE
Use registry friendly name when claiming segments

### DIFF
--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -25,11 +25,11 @@ class QueueClient:
         self.base_url = settings.queue_url
         self.client = httpx.AsyncClient(base_url=self.base_url, timeout=10)
 
-    async def claim_next(self, worker_id: uuid.UUID) -> Optional[SegmentClaim]:
+    async def claim_next(self, worker_id: uuid.UUID, worker_name: str | None = None) -> Optional[SegmentClaim]:
         """Claim the next available segment. Returns None if no work available."""
         resp = await self.client.get(
             "/segments/next",
-            params={"worker_id": str(worker_id), "worker_name": settings.friendly_name},
+            params={"worker_id": str(worker_id), "worker_name": worker_name or settings.friendly_name},
         )
         if not resp.is_success:
             _raise_with_details(resp, "claim_next")

--- a/daemon/registry_client.py
+++ b/daemon/registry_client.py
@@ -16,7 +16,7 @@ class RegistryClient:
         hostname: str,
         ip_address: str,
         comfyui_running: bool,
-    ) -> uuid.UUID:
+    ) -> tuple[uuid.UUID, str]:
         resp = await self.client.post(
             "/workers",
             json={
@@ -27,9 +27,11 @@ class RegistryClient:
             },
         )
         resp.raise_for_status()
-        return uuid.UUID(resp.json()["id"])
+        data = resp.json()
+        return uuid.UUID(data["id"]), data["friendly_name"]
 
     async def heartbeat(self, worker_id: uuid.UUID, comfyui_running: bool) -> dict:
+        """Send heartbeat. Returns full worker data including current friendly_name."""
         resp = await self.client.post(
             f"/workers/{worker_id}/heartbeat",
             json={"comfyui_running": comfyui_running},


### PR DESCRIPTION
The daemon was passing settings.friendly_name (the config/hostname) when claiming segments, so hostnames like "runpod-0m7cxyniorxoqy" appeared in the UI. Now it captures the friendly_name returned by the registry on registration and uses that instead. The heartbeat loop also picks up renames, so name changes made via the console take effect within ~30s.