### PR TITLE
Add daemon safeguards and GPU stats heartbeat

### DIFF
--- a/daemon/registry_client.py
+++ b/daemon/registry_client.py
@@ -30,11 +30,19 @@ class RegistryClient:
         data = resp.json()
         return uuid.UUID(data["id"]), data["friendly_name"]
 
-    async def heartbeat(self, worker_id: uuid.UUID, comfyui_running: bool) -> dict:
+    async def heartbeat(
+        self,
+        worker_id: uuid.UUID,
+        comfyui_running: bool,
+        gpu_stats: dict | None = None,
+    ) -> dict:
         """Send heartbeat. Returns full worker data including current friendly_name."""
+        payload: dict = {"comfyui_running": comfyui_running}
+        if gpu_stats is not None:
+            payload["gpu_stats"] = gpu_stats
         resp = await self.client.post(
             f"/workers/{worker_id}/heartbeat",
-            json={"comfyui_running": comfyui_running},
+            json=payload,
         )
         resp.raise_for_status()
         return resp.json()


### PR DESCRIPTION
## Summary
- Kill stale `daemon.main` processes on startup via `/proc` scan
- Clear ComfyUI queue on startup to prevent orphaned jobs from previous runs
- Replace flat 30-min execution timeout with 5-min progress-based timeout (detects stuck jobs faster)
- Log VRAM usage after each segment execution to spot memory leaks
- Collect GPU stats (VRAM used/total, GPU name) and send with each heartbeat to registry

## Test plan
- [ ] Start daemon with stale processes running — verify they get killed
- [ ] Start daemon with orphaned ComfyUI queue items — verify queue is cleared
- [ ] Verify normal segment execution still works with new progress timeout
- [ ] Check logs for VRAM usage after segment completion
- [ ] Verify heartbeat sends gpu_stats to registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)