### PR TITLE
Add API key auth for wanly-api endpoints

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -10,6 +10,7 @@ class Settings(BaseSettings):
     comfyui_path: str = ""  # Path to ComfyUI installation (for custom node management)
     lora_cache_dir: str = ""  # Override LoRA download dir (e.g. /workspace/models/loras for persistence)
     queue_url: str = "http://localhost:8001"
+    queue_api_key: str = ""
     poll_interval: int = 5
 
     # Model filenames (vary per GPU worker — override in .env)

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -21,9 +21,14 @@ def _raise_with_details(resp: httpx.Response, context: str) -> None:
 
 
 class QueueClient:
+    """HTTP client for the wanly-api queue endpoints."""
+
     def __init__(self):
         self.base_url = settings.queue_url
-        self.client = httpx.AsyncClient(base_url=self.base_url, timeout=10)
+        headers = {}
+        if settings.queue_api_key:
+            headers["X-API-Key"] = settings.queue_api_key
+        self.client = httpx.AsyncClient(base_url=self.base_url, timeout=10, headers=headers)
 
     async def claim_next(self, worker_id: uuid.UUID, worker_name: str | None = None) -> Optional[SegmentClaim]:
         """Claim the next available segment. Returns None if no work available."""


### PR DESCRIPTION
## Summary
- Add `queue_api_key` setting to daemon config (`QUEUE_API_KEY` env var)
- `QueueClient` sends `X-API-Key` header on all HTTP requests to wanly-api
- Required because wanly-api daemon routes now enforce API key authentication (see DavidJBarnes/wanly-api PR)

## Deployment notes
- Set `QUEUE_API_KEY` in daemon `.env` to match the `API_KEY` value in wanly-api's `.env`
- Deploy wanly-api first, then update daemon config and restart

## Test plan
- [ ] Verify daemon can claim segments with API key configured
- [ ] Verify daemon rejects (logs error) if API key is wrong/missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)