### PR TITLE
Inject CFG High/Low into KSampler workflow nodes

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
     lightx2v_lora_low: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
     lightx2v_strength_high: float = 2.0  # Strength for high noise lightx2v LoRA (community range: 1.0–5.6)
     lightx2v_strength_low: float = 1.0  # Strength for low noise lightx2v LoRA (community range: 1.0–2.0)
+    cfg_high: float = 1.0  # CFG for high noise KSampler (node 86)
+    cfg_low: float = 1.0  # CFG for low noise KSampler (node 85)
     clip_vision_model: str = "clip_vision_h.safetensors"
 
     # RunPod auto-stop (set by RunPod environment + user config)

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -36,6 +36,8 @@ class SegmentClaim(BaseModel):
     initial_reference_image: Optional[str] = None
     lightx2v_strength_high: Optional[float] = None
     lightx2v_strength_low: Optional[float] = None
+    cfg_high: Optional[float] = None
+    cfg_low: Optional[float] = None
     width: int
     height: int
     fps: int

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -343,6 +343,10 @@ def build_workflow(
     workflow["102"]["inputs"]["lora_name"] = settings.lightx2v_lora_low
     workflow["102"]["inputs"]["strength_model"] = segment.lightx2v_strength_low if segment.lightx2v_strength_low is not None else settings.lightx2v_strength_low
 
+    # CFG values for KSampler nodes
+    workflow["86"]["inputs"]["cfg"] = segment.cfg_high if segment.cfg_high is not None else settings.cfg_high
+    workflow["85"]["inputs"]["cfg"] = segment.cfg_low if segment.cfg_low is not None else settings.cfg_low
+
     # Positive prompt
     workflow["93"]["inputs"]["text"] = segment.prompt
 


### PR DESCRIPTION
## Summary
- Added `cfg_high`/`cfg_low` to SegmentClaim schema and config defaults
- Workflow builder injects CFG into nodes 86 (high noise) and 85 (low noise)
- Falls back to config defaults (1.0) when not set on the segment claim

## Test plan
- [ ] Claim segment with CFG values set — verify workflow JSON has correct cfg values
- [ ] Claim segment without CFG values — verify fallback to config defaults
- [ ] End-to-end: generate video with non-default CFG and compare output quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)