### PR TITLE
Use negative prompt from segment claim

### DIFF
--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -38,6 +38,7 @@ class SegmentClaim(BaseModel):
     lightx2v_strength_low: Optional[float] = None
     cfg_high: Optional[float] = None
     cfg_low: Optional[float] = None
+    negative_prompt: Optional[str] = None
     width: int
     height: int
     fps: int

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -347,6 +347,10 @@ def build_workflow(
     workflow["86"]["inputs"]["cfg"] = segment.cfg_high if segment.cfg_high is not None else settings.cfg_high
     workflow["85"]["inputs"]["cfg"] = segment.cfg_low if segment.cfg_low is not None else settings.cfg_low
 
+    # Negative prompt
+    if segment.negative_prompt is not None:
+        workflow["89"]["inputs"]["text"] = segment.negative_prompt
+
     # Positive prompt
     workflow["93"]["inputs"]["text"] = segment.prompt
 


### PR DESCRIPTION
## Summary
- `SegmentClaim` schema accepts optional `negative_prompt`
- Workflow builder sets node 89 (negative CLIPTextEncode) from `segment.negative_prompt` when provided
- Falls back to hardcoded template default if not provided (backward compatible)

## Test plan
- [ ] Daemon receives `negative_prompt` from API and applies it to workflow
- [ ] Without `negative_prompt`, hardcoded default is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)