### PR TITLE
Parse training log for live progress metrics

### DIFF
--- a/daemon/sd_scripts_monitor.py
+++ b/daemon/sd_scripts_monitor.py
@@ -1,15 +1,29 @@
 """Monitor sd-scripts (kohya-ss) LoRA training status.
 
 Checks whether the sd-scripts git repo exists on disk and whether
-a training process (train_network.py) is currently running.
+a training process (train_network.py) is currently running.  When a
+training process is found, its log output is parsed (via the file
+descriptor in /proc) to extract real-time progress metrics.
 """
 
+import logging
 import os
+import re
 
 from daemon.config import settings
 
+logger = logging.getLogger(__name__)
+
 # Substrings that identify an sd-scripts training process in /proc cmdline.
 TRAINING_SIGNATURES = ("train_network.py",)
+
+# --- Log-parsing regexes (same patterns as musubi-tuner-ui) ---
+# tqdm: " 45%|████      | 9/20 [02:15<02:45, 15.00s/it]"
+_TQDM_RE = re.compile(r"(\d+)%\|.*?\|\s*(\d+)/(\d+)")
+# epoch header: "epoch 1/10"
+_EPOCH_RE = re.compile(r"epoch\s+(\d+)/(\d+)")
+# average loss: "avr_loss=0.0812"
+_AVR_LOSS_RE = re.compile(r"avr_loss=([\d.]+)")
 
 
 def _resolve_path() -> str | None:
@@ -23,6 +37,68 @@ def _resolve_path() -> str | None:
 def check_installed() -> bool:
     """Return True if the sd-scripts directory exists."""
     return _resolve_path() is not None
+
+
+def _extract_cmdline_arg(parts: list[str], flag: str) -> str | None:
+    """Extract a --flag value from a NUL-split cmdline."""
+    for i, part in enumerate(parts):
+        if part == flag and i + 1 < len(parts):
+            return parts[i + 1]
+        if part.startswith(f"{flag}="):
+            return part.split("=", 1)[1]
+    return None
+
+
+def _find_log_path(pid: int) -> str | None:
+    """Follow /proc/{pid}/fd/1 to find the training log file, if any."""
+    try:
+        target = os.readlink(f"/proc/{pid}/fd/1")
+        if os.path.isfile(target):
+            return target
+    except (OSError, PermissionError):
+        pass
+    return None
+
+
+def _parse_log_tail(log_path: str) -> dict:
+    """Read the tail of a training log and extract progress metrics."""
+    result: dict = {}
+    try:
+        with open(log_path, "rb") as f:
+            f.seek(0, 2)
+            size = f.tell()
+            f.seek(max(0, size - 32768))
+            tail = f.read().decode("utf-8", errors="replace")
+    except OSError:
+        return result
+
+    # tqdm uses \r for in-place updates, so split on both \r and \n
+    lines = re.split(r"[\r\n]+", tail)
+
+    for line in lines:
+        tm = _TQDM_RE.search(line)
+        if tm:
+            result["current_step"] = int(tm.group(2))
+            result["total_steps"] = int(tm.group(3))
+
+        em = _EPOCH_RE.search(line)
+        if em:
+            result["current_epoch"] = int(em.group(1))
+            result["max_epochs"] = int(em.group(2))
+
+        lm = _AVR_LOSS_RE.search(line)
+        if lm:
+            result["current_loss"] = float(lm.group(1))
+
+    # Calculate percentage
+    current = result.get("current_step", 0)
+    total = result.get("total_steps", 0)
+    if total > 0:
+        result["pct_complete"] = round(current / total * 100, 2)
+    else:
+        result["pct_complete"] = 0.0
+
+    return result
 
 
 def check_training_active() -> dict | None:
@@ -51,21 +127,28 @@ def check_training_active() -> dict | None:
         if "compile_worker" in cmdline or "accelerate" in cmdline:
             continue
 
-        # Extract output_name from cmdline if present
-        output_name = None
         parts = cmdline.split("\x00")
-        for i, part in enumerate(parts):
-            if part == "--output_name" and i + 1 < len(parts):
-                output_name = parts[i + 1]
-                break
-            if part.startswith("--output_name="):
-                output_name = part.split("=", 1)[1]
-                break
 
-        return {
+        # Extract output_name from cmdline if present
+        output_name = _extract_cmdline_arg(parts, "--output_name")
+
+        info: dict = {
             "pid": pid,
             "output_name": output_name,
         }
+
+        # Try to parse the training log for live progress metrics
+        log_path = _find_log_path(pid)
+        if log_path:
+            progress = _parse_log_tail(log_path)
+            info.update(progress)
+        else:
+            # Fall back to cmdline args for max_epochs if no log available
+            max_epochs_str = _extract_cmdline_arg(parts, "--max_train_epochs")
+            if max_epochs_str and max_epochs_str.isdigit():
+                info["max_epochs"] = int(max_epochs_str)
+
+        return info
 
     return None
 


### PR DESCRIPTION
## Summary
- The sd-scripts monitor only sent `pid` and `output_name` to the registry, so the console showed 0% progress and missing epoch/step/loss despite training being active
- Now follows `/proc/{pid}/fd/1` to locate the training log file (written by musubi-tuner-ui) and parses the tqdm output tail for `current_step`, `current_epoch`, `max_epochs`, `current_loss`, and `pct_complete`
- Falls back to extracting `--max_train_epochs` from the cmdline when no log file is available

## Test plan
- [ ] Start a training job via musubi-tuner-ui and verify the worker detail page shows live progress %, epoch, step, and loss
- [ ] Confirm values update every heartbeat interval (30s)
- [ ] Test with a manually-started training (no log file redirect) — should gracefully show only cmdline-derived fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)