### PR TITLE
Fix parent-check filter skipping real training process

### DIFF
--- a/daemon/sd_scripts_monitor.py
+++ b/daemon/sd_scripts_monitor.py
@@ -127,18 +127,21 @@ def check_training_active() -> dict | None:
         if "compile_worker" in cmdline or "accelerate" in cmdline:
             continue
 
-        # Skip child processes spawned by the main training process
-        # (e.g. torch DataLoader workers). The main process is its own
-        # session leader or direct child of accelerate.
+        # Skip DataLoader/compile worker children of the main training process.
+        # The real trainer's parent is the accelerate launcher (which we
+        # already filter above), so only skip when the parent is itself a
+        # direct training invocation (no "accelerate" in its cmdline).
         try:
             with open(f"/proc/{pid}/stat", "rb") as f:
                 stat_fields = f.read().decode().split()
                 ppid = int(stat_fields[3])
-            # If parent is also a matching training script, this is a worker child
             try:
                 with open(f"/proc/{ppid}/cmdline", "rb") as f:
                     parent_cmd = f.read().decode("utf-8", errors="replace")
-                if any(sig in parent_cmd for sig in TRAINING_SIGNATURES):
+                if (
+                    any(sig in parent_cmd for sig in TRAINING_SIGNATURES)
+                    and "accelerate" not in parent_cmd
+                ):
                     continue
             except (OSError, PermissionError):
                 pass


### PR DESCRIPTION
## Summary
- The accelerate launcher cmdline contains `train_network.py`, so the parent-check was incorrectly classifying the actual trainer as a child worker
- Now only skips a process when its parent is a direct training invocation (no `accelerate` in parent cmdline)

## Test plan
- [ ] Start SDXL training via accelerate and confirm the main training PID is detected
- [ ] Verify child DataLoader workers are still filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)