### PR TITLE
feat: Add A1111 status monitoring

### DIFF
--- a/daemon/a1111_monitor.py
+++ b/daemon/a1111_monitor.py
@@ -1,0 +1,41 @@
+"""Monitor A1111 Stable Diffusion via its systemd unit (sd)."""
+
+import logging
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def _is_unit_active(unit: str) -> bool:
+    """Return True if the given systemd unit is active (running)."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", "--quiet", unit],
+            timeout=5,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def _unit_exists(unit: str) -> bool:
+    """Return True if the systemd unit file exists (installed)."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "cat", unit],
+            capture_output=True,
+            timeout=5,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def get_status() -> dict:
+    """Return A1111 status for heartbeat payload."""
+    installed = _unit_exists("sd")
+    running = _is_unit_active("sd") if installed else False
+    return {
+        "a1111_installed": installed,
+        "a1111_running": running,
+    }

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -15,6 +15,7 @@ from daemon.registry_client import RegistryClient
 from daemon.gpu_stats import get_gpu_stats
 from daemon.resource_sync import sync_resources
 from daemon.sd_scripts_monitor import get_status as get_sd_scripts_status
+from daemon.a1111_monitor import get_status as get_a1111_status
 
 logging.basicConfig(
     level=logging.INFO,
@@ -107,11 +108,14 @@ async def heartbeat_loop(registry, comfyui, worker_id, friendly_name_ref, shutdo
         sd_scripts_status = get_sd_scripts_status()
         sd_scripts_training = sd_scripts_status.get("sd_scripts_training", False)
 
+        # Collect A1111 status
+        a1111_status = get_a1111_status()
+
         # Worker is busy if either ComfyUI is processing or sd-scripts is training
         is_busy = comfyui_busy or sd_scripts_training
 
         try:
-            data = await registry.heartbeat(worker_id, comfyui_running, gpu_stats, sd_scripts_status)
+            data = await registry.heartbeat(worker_id, comfyui_running, gpu_stats, sd_scripts_status, a1111_status)
             beat_count += 1
 
             # Pick up renames from the registry
@@ -323,6 +327,12 @@ async def run():
         sd_status["sd_scripts_installed"],
         sd_status["sd_scripts_training"],
         f" ({sd_status['sd_scripts_training_info']['output_name']})" if sd_status.get("sd_scripts_training_info") else "",
+    )
+
+    a1111_stat = get_a1111_status()
+    logger.info("A1111: installed=%s, running=%s",
+        a1111_stat["a1111_installed"],
+        a1111_stat["a1111_running"],
     )
 
     # Clear any orphaned ComfyUI queue items from previous daemon runs

--- a/daemon/registry_client.py
+++ b/daemon/registry_client.py
@@ -36,6 +36,7 @@ class RegistryClient:
         comfyui_running: bool,
         gpu_stats: dict | None = None,
         sd_scripts_status: dict | None = None,
+        a1111_status: dict | None = None,
     ) -> dict:
         """Send heartbeat. Returns full worker data including current friendly_name."""
         payload: dict = {"comfyui_running": comfyui_running}
@@ -43,6 +44,8 @@ class RegistryClient:
             payload["gpu_stats"] = gpu_stats
         if sd_scripts_status is not None:
             payload["sd_scripts"] = sd_scripts_status
+        if a1111_status is not None:
+            payload["a1111"] = a1111_status
         resp = await self.client.post(
             f"/workers/{worker_id}/heartbeat",
             json=payload,


### PR DESCRIPTION
## Summary
- Add `a1111_monitor.py` that checks the `sd` systemd unit for installed/running status
- Include A1111 status in heartbeat payloads sent to the registry
- Log A1111 status on daemon startup

## Test plan
- [ ] Deploy daemon on 3090 and verify A1111 status appears in heartbeat logs
- [ ] Confirm status updates when `sd` unit is started/stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)