### PR TITLE
fix: use node IDs 350+ for reference frames to avoid collision

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -426,10 +426,11 @@ def build_workflow(
         )
 
     # Multi-frame identity anchoring with reference frames
+    # Use node IDs 350+ to avoid conflict with PainterLongVideo nodes (300-312)
     if reference_frame_filenames and segment.index > 0:
-        ref_node_id = 310
-        clip_vision_ref_node_id = 311
-        clip_vision_encode_node_id = 312
+        ref_node_id = 350
+        clip_vision_ref_node_id = 351
+        clip_vision_encode_node_id = 352
 
         ref_clip_vision_loaders = []
         ref_clip_vision_encodes = []


### PR DESCRIPTION
## Summary

- Change reference frame node IDs from 310-332 to 350-372 to avoid collision with PainterLongVideo nodes (300-312)
- Fixes: `Bad linked input, must be a length-2 list of [node_id, slot_index]` for `clip_vision_output` when both identity anchoring and reference frames are used