### PR TITLE
feat: Add optical flow motion matching for segment continuity

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -30,6 +30,12 @@ class Settings(BaseSettings):
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion
     painter_motion_frames: int = 5  # Range: 1-20, controls motion cycle length
 
+    # Motion matching (optical flow based)
+    motion_matching_enabled: bool = True  # Enable automatic motion amplitude matching
+    motion_amplitude_default: float = 1.3  # Default motion_amplitude for segment 0
+    motion_amplitude_min: float = 1.0  # Minimum motion_amplitude (no motion boost)
+    motion_amplitude_max: float = 2.0  # Maximum motion_amplitude (extreme motion)
+
     # sd-scripts LoRA training monitor
     sd_scripts_path: str = "~/projects/sd-scripts"
 

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -26,6 +26,7 @@ from PIL import Image
 from daemon.comfyui_client import ComfyUIClient, ComfyUIExecutionError
 from daemon.lora_sync import ensure_loras_available
 from daemon.motion_extractor import _augment_prompt_with_motion, extract_motion_keywords
+from daemon.motion_analyzer import measure_motion_magnitude
 from daemon.progress import ProgressLog
 from daemon.queue_client import QueueClient
 from daemon.schemas import SegmentClaim, SegmentResult
@@ -249,11 +250,13 @@ async def execute_segment(
                 comfyui_filename = await comfyui.upload_image(ref_data, ref_filename)
                 reference_frames_filenames.append(comfyui_filename)
                 logger.info("Uploaded reference frame to ComfyUI: %s", comfyui_filename)
+        # Pass previous segment's motion magnitude for motion matching
         workflow = build_workflow(
             segment,
             start_image_filename=start_image_filename,
             initial_reference_image_filename=initial_ref_filename,
             reference_frame_filenames=reference_frames_filenames if reference_frames_filenames else None,
+            previous_motion_magnitude=segment.previous_motion_magnitude,
         )
         await progress.log(f"[3/7] Workflow built ({len(workflow)} nodes)")
         step_times.append(("build", time.monotonic() - t0))
@@ -289,10 +292,15 @@ async def execute_segment(
         await progress.log(f"[6/7] Video downloaded: {video_info['filename']} ({video_mb:.1f} MB)")
         step_times.append(("download", time.monotonic() - t0))
 
-        # Step 7: Extract last frame + extract motion + upload
+        # Step 7: Extract last frame + measure motion + upload
         t0 = time.monotonic()
         await progress.log("[7/7] Extracting last frame and uploading...")
         last_frame_data = await _extract_last_frame(video_data)
+
+        # Measure motion magnitude using optical flow
+        motion_magnitude = await measure_motion_magnitude(video_data)
+        if motion_magnitude:
+            await progress.log(f"[7/7] Motion magnitude: %.2f px/frame" % motion_magnitude)
 
         motion_keywords = await extract_motion_keywords(segment.prompt, video_data)
         if motion_keywords:
@@ -300,6 +308,7 @@ async def execute_segment(
         segment_result = SegmentResult(
             status="completed",
             motion_keywords=motion_keywords if motion_keywords else None,
+            motion_magnitude=motion_magnitude,
         )
         await queue.upload_segment_output(segment.id, video_data, last_frame_data, segment_result)
         step_times.append(("upload", time.monotonic() - t0))

--- a/daemon/motion_analyzer.py
+++ b/daemon/motion_analyzer.py
@@ -1,0 +1,134 @@
+"""Optical flow motion analysis for segment videos.
+
+Measures the average motion magnitude in a video using OpenCV Farneback optical flow.
+This is used to match motion speed across segments.
+"""
+
+import logging
+import os
+import tempfile
+from typing import Optional
+
+import cv2
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def measure_motion_magnitude(video_data: bytes, fps: int = 15) -> Optional[float]:
+    """Measure average optical flow magnitude in a video.
+
+    Uses Farneback algorithm to compute dense optical flow between consecutive frames,
+    then returns the average pixel displacement across all frame pairs.
+
+    Args:
+        video_data: Raw video bytes (mp4)
+        fps: Frame rate to extract frames at (default 15 = native WAN generation rate)
+
+    Returns:
+        Average motion magnitude in pixels per frame, or None if measurement fails
+    """
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp_video:
+        tmp_video.write(video_data)
+        tmp_video_path = tmp_video.name
+
+    try:
+        cap = cv2.VideoCapture(tmp_video_path)
+        if not cap.isOpened():
+            logger.warning("Could not open video for motion analysis")
+            return None
+
+        frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        if frame_count < 2:
+            logger.warning("Video has fewer than 2 frames, cannot measure motion")
+            return None
+
+        magnitudes: list[float] = []
+
+        ret, prev_frame = cap.read()
+        if not ret:
+            logger.warning("Could not read first frame")
+            return None
+
+        prev_gray = cv2.cvtColor(prev_frame, cv2.COLOR_BGR2GRAY)
+
+        while True:
+            ret, curr_frame = cap.read()
+            if not ret:
+                break
+
+            curr_gray = cv2.cvtColor(curr_frame, cv2.COLOR_BGR2GRAY)
+
+            flow = cv2.calcOpticalFlowFarneback(
+                prev_gray,
+                curr_gray,
+                None,
+                pyr_scale=0.5,
+                levels=3,
+                winsize=15,
+                iterations=3,
+                poly_n=5,
+                poly_sigma=1.2,
+                flags=0,
+            )
+
+            magnitude, _ = cv2.cartToPolar(flow[..., 0], flow[..., 1])
+            avg_magnitude = float(np.mean(magnitude))
+            magnitudes.append(avg_magnitude)
+
+            prev_gray = curr_gray
+
+        cap.release()
+
+        if magnitudes:
+            avg_motion = float(np.mean(magnitudes))
+            logger.info(
+                "Motion analysis: %.2f px/frame (avg over %d frame pairs)",
+                avg_motion,
+                len(magnitudes),
+            )
+            return avg_motion
+
+        logger.warning("No motion data extracted from video")
+        return None
+
+    except Exception as e:
+        logger.warning("Motion analysis failed: %s", e)
+        return None
+    finally:
+        try:
+            os.unlink(tmp_video_path)
+        except OSError:
+            pass
+
+
+def estimate_motion_from_flow(
+    previous_motion_magnitude: Optional[float],
+    previous_motion_amplitude: float,
+    target_motion_magnitude: float,
+) -> float:
+    """Estimate motion_amplitude needed to achieve target motion.
+
+    This is a simple linear estimation. The relationship between motion_amplitude
+    and output motion magnitude is not perfectly linear, but this provides a starting
+    point that can be refined empirically.
+
+    Args:
+        previous_motion_magnitude: Measured motion from previous segment (px/frame)
+        previous_motion_amplitude: motion_amplitude used for previous segment
+        target_motion_magnitude: Target motion magnitude to match
+
+    Returns:
+        Estimated motion_amplitude to achieve target motion
+    """
+    if previous_motion_magnitude is None or previous_motion_magnitude <= 0:
+        return 1.0
+
+    baseline_motion = previous_motion_magnitude / previous_motion_amplitude
+
+    if baseline_motion <= 0:
+        return 1.0
+
+    estimated = target_motion_magnitude / baseline_motion
+
+    return max(0.5, min(2.0, estimated))

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -70,7 +70,7 @@ class QueueClient:
             _raise_with_details(resp, f"upload_segment_output {segment_id}")
         logger.info("Uploaded segment output via API for %s", segment_id)
 
-        if result and result.motion_keywords:
+        if result and (result.motion_keywords or result.motion_magnitude):
             await self.update_segment(segment_id, result)
 
     async def download_file(self, s3_path: str) -> bytes:

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -36,6 +36,7 @@ class SegmentClaim(BaseModel):
     initial_reference_image: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
     previous_motion_keywords: Optional[list[str]] = None
+    previous_motion_magnitude: Optional[float] = None
     reference_frames: Optional[list[str]] = None
     lightx2v_strength_high: Optional[float] = None
     lightx2v_strength_low: Optional[float] = None
@@ -57,3 +58,4 @@ class SegmentResult(BaseModel):
     error_message: Optional[str] = None
     progress_log: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
+    motion_magnitude: Optional[float] = None

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from daemon.config import settings
 from daemon.schemas import SegmentClaim
+from daemon.motion_analyzer import estimate_motion_from_flow
 
 logger = logging.getLogger(__name__)
 
@@ -182,6 +183,42 @@ def _calculate_generation_params(target_fps: int, duration_sec: float, speed: fl
     }
 
 
+def _calculate_motion_amplitude(
+    segment_index: int,
+    previous_motion_magnitude: float | None,
+    motion_amplitude_setting: float,
+) -> float:
+    """Calculate motion_amplitude for a segment based on previous motion data.
+    
+    Args:
+        segment_index: Index of the segment being built (0 = first segment)
+        previous_motion_magnitude: Measured motion from previous segment (px/frame)
+        motion_amplitude_setting: Default/configured motion_amplitude value
+        
+    Returns:
+        motion_amplitude to use for this segment
+    """
+    # Segment 0 uses the default/configured value
+    if segment_index == 0:
+        return motion_amplitude_setting
+    
+    # If no previous motion data, use default
+    if previous_motion_magnitude is None:
+        return motion_amplitude_setting
+    
+    # Motion matching enabled: estimate amplitude to match previous motion
+    # Use previous_motion_magnitude as target to achieve consistency
+    estimated = estimate_motion_from_flow(
+        previous_motion_magnitude=previous_motion_magnitude,
+        previous_motion_amplitude=motion_amplitude_setting,
+        target_motion_magnitude=previous_motion_magnitude,
+    )
+    
+    # Clamp to valid range
+    from daemon.config import settings
+    return max(settings.motion_amplitude_min, min(settings.motion_amplitude_max, estimated))
+
+
 def _add_user_loras(workflow: dict, loras: list[dict]) -> None:
     """Add user LoRA nodes and rewire the lightx2v chain."""
     loras = [l for l in loras if l.get("high_file") or l.get("low_file")]
@@ -318,6 +355,7 @@ def build_workflow(
     start_image_filename: str | None = None,
     initial_reference_image_filename: str | None = None,
     reference_frame_filenames: list[str] | None = None,
+    previous_motion_magnitude: float | None = None,
 ) -> dict:
     """Build a complete ComfyUI workflow from segment parameters.
 
@@ -332,8 +370,20 @@ def build_workflow(
             to PainterLongVideo with dual-reference inputs.
             identity for characters. PainterLongVideo only accepts a single
             clip_vision_output, so multi-frame reference frames are not used.
+        previous_motion_magnitude: Measured motion magnitude from previous 
+            segment (px/frame). Used to auto-adjust motion_amplitude for 
+            consistent motion across segments.
     """
     gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
+    
+    # Calculate motion_amplitude based on previous segment's motion
+    motion_amplitude = _calculate_motion_amplitude(
+        segment_index=segment.index,
+        previous_motion_magnitude=previous_motion_magnitude,
+        motion_amplitude_setting=settings.painter_motion_amplitude,
+    )
+    logger.info("Segment %d motion_amplitude: %.2f (previous_magnitude=%s)",
+                segment.index, motion_amplitude, previous_motion_magnitude)
     workflow = copy.deepcopy(WAN_I2V_API_WORKFLOW)
 
     # Inject model filenames from config
@@ -410,7 +460,7 @@ def build_workflow(
                 "batch_size": 1,
                 "previous_video": ["97", 0],
                 "motion_frames": settings.painter_motion_frames,
-                "motion_amplitude": settings.painter_motion_amplitude,
+                "motion_amplitude": motion_amplitude,
                 "initial_reference_image": ["300", 0],
                 "clip_vision_output": ["302", 0],
                 "start_image": ["97", 0],


### PR DESCRIPTION
## Summary
- Add motion_analyzer.py with Farneback optical flow measurement
- Measure motion magnitude (px/frame) after each segment completes
- Pass previous_motion_magnitude to next segment for auto-adjustment
- Calculate motion_amplitude based on previous motion data
- Add motion_magnitude to Segment model and API schemas
- Add config settings for motion matching (enabled, min/max amplitude)

This enables automatic motion speed consistency across video segments by measuring actual motion in completed segments and adjusting the PainterLongVideo motion_amplitude parameter for subsequent segments.