### PR TITLE
feat: Faceswap-only reprocessing pipeline (#85)

### DIFF
--- a/daemon/comfyui_client.py
+++ b/daemon/comfyui_client.py
@@ -84,6 +84,18 @@ class ComfyUIClient:
         result = resp.json()
         return result.get("name", filename)
 
+    async def upload_video(self, data: bytes, filename: str) -> str:
+        """Upload a video to ComfyUI's input folder. Returns the stored filename."""
+        resp = await self.http.post(
+            "/upload/image",
+            files={"image": (filename, data, "video/mp4")},
+            data={"overwrite": "true", "type": "input"},
+            timeout=120,
+        )
+        resp.raise_for_status()
+        result = resp.json()
+        return result.get("name", filename)
+
     async def submit_workflow(self, workflow: dict) -> tuple[str, str]:
         """Submit a workflow to ComfyUI. Returns (prompt_id, client_id)."""
         client_id = str(uuid.uuid4())

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -30,7 +30,7 @@ from daemon.motion_analyzer import measure_motion_magnitude
 from daemon.progress import ProgressLog
 from daemon.queue_client import QueueClient
 from daemon.schemas import SegmentClaim, SegmentResult
-from daemon.workflow_builder import build_workflow
+from daemon.workflow_builder import build_workflow, build_faceswap_workflow
 
 logger = logging.getLogger(__name__)
 
@@ -163,12 +163,104 @@ async def _extract_last_frame(video_data: bytes) -> bytes:
                 pass
 
 
+async def _execute_faceswap_reprocess(
+    segment: SegmentClaim,
+    comfyui: ComfyUIClient,
+    queue: QueueClient,
+) -> None:
+    """Apply faceswap to an existing completed video without regenerating it."""
+    logger.info(
+        "=== Faceswap reprocess segment %d (job %s) === method: %s",
+        segment.index, str(segment.job_id)[:8], segment.faceswap_method or "facefusion",
+    )
+
+    if not segment.output_path:
+        raise RuntimeError("No output_path on segment — cannot reprocess without existing video")
+
+    progress = ProgressLog(segment.id, queue)
+    segment_start = time.monotonic()
+
+    try:
+        # Step 1: Download existing video from S3
+        await progress.log("[1/5] Downloading existing video...")
+        video_data = await _download_with_retry(
+            lambda: queue.download_file(segment.output_path), "existing_video"
+        )
+        video_mb = len(video_data) / (1024 * 1024)
+        await progress.log(f"[1/5] Video downloaded ({video_mb:.1f} MB)")
+
+        # Step 2: Upload video + faceswap image to ComfyUI
+        await progress.log("[2/5] Uploading to ComfyUI...")
+        video_filename = f"reprocess_{segment.id}.mp4"
+        comfyui_video = await comfyui.upload_video(video_data, video_filename)
+        logger.info("Uploaded existing video to ComfyUI as: %s", comfyui_video)
+
+        faceswap_comfyui_filename = await _resolve_faceswap_image(segment, comfyui, queue)
+        if faceswap_comfyui_filename:
+            segment = segment.model_copy(update={"faceswap_image": faceswap_comfyui_filename})
+        await progress.log("[2/5] Files ready in ComfyUI")
+
+        # Step 3: Build and submit faceswap-only workflow
+        await progress.log("[3/5] Building faceswap workflow...")
+        workflow = build_faceswap_workflow(segment, comfyui_video)
+        prompt_id, client_id = await comfyui.submit_workflow(workflow)
+        await progress.log(f"[3/5] Submitted (prompt_id={prompt_id[:8]})")
+
+        # Step 4: Wait for execution
+        await progress.log("[4/5] Waiting for faceswap execution...")
+        await comfyui.monitor_execution(prompt_id, client_id)
+        await progress.log("[4/5] Execution complete")
+
+        # Step 5: Download output, extract last frame, upload
+        await progress.log("[5/5] Downloading result and uploading...")
+        history = await comfyui.get_history(prompt_id)
+        video_info = comfyui.find_video_output(history)
+        if not video_info:
+            raise RuntimeError("No video output found in ComfyUI history")
+
+        result_data = await comfyui.download_output(
+            filename=video_info["filename"],
+            subfolder=video_info.get("subfolder", ""),
+            output_type=video_info.get("type", "output"),
+        )
+        last_frame_data = await _extract_last_frame(result_data)
+
+        segment_result = SegmentResult(status="completed")
+        await queue.upload_segment_output(segment.id, result_data, last_frame_data, segment_result)
+
+        total = time.monotonic() - segment_start
+        logger.info("Faceswap reprocess segment %d complete in %.1fs", segment.index, total)
+
+    except ComfyUIExecutionError as e:
+        error_msg = f"ComfyUI error: {e}"
+        if e.node_id:
+            error_msg += f" (node {e.node_id} [{e.node_type}])"
+        logger.error(error_msg)
+        if e.traceback:
+            logger.error("Traceback:\n%s", e.traceback)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        logger.exception("Faceswap reprocess segment %s failed", segment.id)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+
+
 async def execute_segment(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
     queue: QueueClient,
 ) -> None:
     """Execute a single segment end-to-end."""
+    if segment.reprocess_type == "faceswap":
+        return await _execute_faceswap_reprocess(segment, comfyui, queue)
+
     lora_names = ", ".join(l.high_file or l.low_file or "?" for l in (segment.loras or []))
 
     augmented_prompt = segment.prompt

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -43,6 +43,8 @@ class SegmentClaim(BaseModel):
     cfg_high: Optional[float] = None
     cfg_low: Optional[float] = None
     negative_prompt: Optional[str] = None
+    reprocess_type: Optional[str] = None
+    output_path: Optional[str] = None
     width: int
     height: int
     fps: int

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -268,14 +268,12 @@ def _add_user_loras(workflow: dict, loras: list[dict]) -> None:
     workflow["102"]["inputs"]["model"] = [last_low_node, 0]
 
 
-def _add_faceswap(workflow: dict, segment: SegmentClaim) -> None:
+def _add_faceswap(workflow: dict, segment: SegmentClaim, input_node: str = "87") -> None:
     """Add face swap nodes (188 LoadImage + 183 FaceSwap).
 
-    Faceswap runs BEFORE RIFE interpolation on the native WAN frames
-    (node 87 VAEDecode output). RIFE then smoothly interpolates between
-    already-swapped frames.
+    input_node controls where frames come from: "87" (VAEDecode) for generation
+    workflows, or "400" (VHS_LoadVideo) for faceswap-only reprocessing.
     """
-    # Node 188: load face source image
     workflow["188"] = {
         "class_type": "LoadImage",
         "inputs": {"image": segment.faceswap_image},
@@ -309,7 +307,7 @@ def _add_faceswap(workflow: dict, segment: SegmentClaim) -> None:
                 "face_restore_model": "codeformer-v0.1.0.pth",
                 "face_restore_visibility": 1.0,
                 "codeformer_weight": 0.8,
-                "input_image": ["87", 0],
+                "input_image": [input_node, 0],
                 "source_image": ["188", 0],
                 "options": ["189", 0],
             },
@@ -320,7 +318,7 @@ def _add_faceswap(workflow: dict, segment: SegmentClaim) -> None:
         # FaceFusion (default)
         facefusion_inputs: dict[str, Any] = {
             "source_images": ["188", 0],
-            "target_image": ["87", 0],
+            "target_image": [input_node, 0],
             "api_token": "-1",
             "face_swapper_model": "inswapper_128",
             "face_detector_model": "retinaface",
@@ -348,6 +346,47 @@ def _add_faceswap(workflow: dict, segment: SegmentClaim) -> None:
             "_meta": {"title": "FaceFusion Face Swap"},
         }
         logger.info("Added FaceFusion face swap nodes")
+
+
+def build_faceswap_workflow(segment: SegmentClaim, video_filename: str) -> dict:
+    """Build a faceswap-only workflow: load existing video → faceswap → re-encode."""
+    workflow: dict[str, Any] = {}
+
+    workflow["400"] = {
+        "class_type": "VHS_LoadVideo",
+        "inputs": {
+            "video": video_filename,
+            "force_rate": 0,
+            "force_size": "Disabled",
+            "frame_load_cap": 0,
+            "skip_first_frames": 0,
+            "select_every_nth": 1,
+        },
+        "_meta": {"title": "Load Existing Video"},
+    }
+
+    _add_faceswap(workflow, segment, input_node="400")
+
+    workflow["186"] = {
+        "class_type": "VHS_VideoCombine",
+        "inputs": {
+            "frame_rate": segment.fps,
+            "loop_count": 0,
+            "filename_prefix": "output",
+            "format": "video/h264-mp4",
+            "pix_fmt": "yuv420p",
+            "crf": 15,
+            "save_metadata": True,
+            "trim_to_audio": False,
+            "pingpong": False,
+            "save_output": True,
+            "images": ["183", 0],
+        },
+        "_meta": {"title": "Video Combine"},
+    }
+
+    logger.info("Built faceswap-only workflow (%d nodes) for video: %s", len(workflow), video_filename)
+    return workflow
 
 
 def build_workflow(


### PR DESCRIPTION
## Summary
- Add `build_faceswap_workflow()`: minimal ComfyUI workflow that loads existing video via `VHS_LoadVideo`, applies faceswap, and re-encodes via `VHS_VideoCombine`
- Add `_execute_faceswap_reprocess()`: 5-step pipeline — download video from S3, upload to ComfyUI, submit faceswap workflow, download result, upload back
- Parameterize `_add_faceswap()` with `input_node` so it works with both generation (node 87) and video-load (node 400) workflows
- Add `ComfyUIClient.upload_video()` for uploading video files to ComfyUI input
- Route via `reprocess_type` field in `execute_segment()`

## Context
Companion to DavidJBarnes/wanly-api#87. When a segment has `reprocess_type="faceswap"`, the daemon skips the full WAN video generation pipeline and instead applies faceswap directly to the existing completed video.

## Test plan
- [ ] Claim a segment with `reprocess_type=faceswap` and verify faceswap-only workflow is used
- [ ] Verify existing video is downloaded, faceswapped, and re-uploaded
- [ ] Verify normal segments (no `reprocess_type`) still use the full generation pipeline
- [ ] Test both ReActor and FaceFusion methods