### PR TITLE
fix: Report segment failure on unhandled exceptions

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -174,13 +174,12 @@ async def _execute_faceswap_reprocess(
         segment.index, str(segment.job_id)[:8], segment.faceswap_method or "facefusion",
     )
 
-    if not segment.output_path:
-        raise RuntimeError("No output_path on segment — cannot reprocess without existing video")
-
     progress = ProgressLog(segment.id, queue)
     segment_start = time.monotonic()
 
     try:
+        if not segment.output_path:
+            raise RuntimeError("No output_path on segment — cannot reprocess without existing video")
         # Step 1: Download existing video from S3
         await progress.log("[1/5] Downloading existing video...")
         video_data = await _download_with_retry(

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -213,6 +213,14 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
             await execute_segment(segment, comfyui, queue)
         except Exception as e:
             logger.exception("Unexpected error executing segment %s", segment.id)
+            try:
+                from daemon.schemas import SegmentResult
+                await queue.update_segment(
+                    segment.id,
+                    SegmentResult(status="failed", error_message=f"{type(e).__name__}: {e}"[:2000]),
+                )
+            except Exception as report_err:
+                logger.error("Failed to report segment failure: %s", report_err)
         finally:
             # Log VRAM usage after each segment to spot memory leaks
             try:


### PR DESCRIPTION
## Summary
- Move RuntimeError check inside try/except in `_execute_faceswap_reprocess` so failures are reported to the API
- Add failure reporting in `job_poll_loop` when `execute_segment` throws — previously only logged the error, leaving the segment stuck in CLAIMED status

## Root cause
When `execute_segment` threw an unhandled exception, the segment stayed in CLAIMED status forever (until 30-minute stale timeout). The daemon then claimed the next segment, causing two segments to appear as "processing" simultaneously.

## Test plan
- [ ] Verify segments are marked as failed when unexpected errors occur
- [ ] Verify only one segment shows as processing at a time