### PR TITLE
fix: Add missing VHS_LoadVideo inputs for faceswap workflow

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -174,13 +174,12 @@ async def _execute_faceswap_reprocess(
         segment.index, str(segment.job_id)[:8], segment.faceswap_method or "facefusion",
     )
 
-    if not segment.output_path:
-        raise RuntimeError("No output_path on segment — cannot reprocess without existing video")
-
     progress = ProgressLog(segment.id, queue)
     segment_start = time.monotonic()
 
     try:
+        if not segment.output_path:
+            raise RuntimeError("No output_path on segment — cannot reprocess without existing video")
         # Step 1: Download existing video from S3
         await progress.log("[1/5] Downloading existing video...")
         video_data = await _download_with_retry(

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -244,6 +244,8 @@ async def _execute_faceswap_reprocess(
 
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
+        if hasattr(e, "response") and hasattr(e.response, "text"):
+            error_msg += f"\nResponse: {e.response.text[:500]}"
         logger.exception("Faceswap reprocess segment %s failed", segment.id)
         await queue.update_segment(
             segment.id,

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -213,6 +213,14 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
             await execute_segment(segment, comfyui, queue)
         except Exception as e:
             logger.exception("Unexpected error executing segment %s", segment.id)
+            try:
+                from daemon.schemas import SegmentResult
+                await queue.update_segment(
+                    segment.id,
+                    SegmentResult(status="failed", error_message=f"{type(e).__name__}: {e}"[:2000]),
+                )
+            except Exception as report_err:
+                logger.error("Failed to report segment failure: %s", report_err)
         finally:
             # Log VRAM usage after each segment to spot memory leaks
             try:

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -358,6 +358,8 @@ def build_faceswap_workflow(segment: SegmentClaim, video_filename: str) -> dict:
             "video": video_filename,
             "force_rate": 0,
             "force_size": "Disabled",
+            "custom_width": segment.width,
+            "custom_height": segment.height,
             "frame_load_cap": 0,
             "skip_first_frames": 0,
             "select_every_nth": 1,


### PR DESCRIPTION
## Summary
- Add required `custom_width` and `custom_height` inputs to `VHS_LoadVideo` node — these are required by VideoHelperSuite even when `force_size` is Disabled
- Include HTTP response body in faceswap error messages for better debugging

## Root cause
ComfyUI returned 400 Bad Request because VHS_LoadVideo was missing required inputs.

## Test plan
- [ ] Faceswap reprocess workflow submits successfully to ComfyUI
- [ ] If workflow still fails, error message now includes the ComfyUI response body