### PR TITLE
fix: Correct VHS_LoadVideo inputs per VideoHelperSuite source

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -356,10 +356,9 @@ def build_faceswap_workflow(segment: SegmentClaim, video_filename: str) -> dict:
         "class_type": "VHS_LoadVideo",
         "inputs": {
             "video": video_filename,
-            "force_rate": 0,
-            "force_size": "Disabled",
-            "custom_width": segment.width,
-            "custom_height": segment.height,
+            "force_rate": 0.0,
+            "custom_width": 0,
+            "custom_height": 0,
             "frame_load_cap": 0,
             "skip_first_frames": 0,
             "select_every_nth": 1,


### PR DESCRIPTION
## Summary
Verified against [LoadVideoUpload.INPUT_TYPES](https://github.com/Kosinkadink/ComfyUI-VideoHelperSuite/blob/main/videohelpersuite/load_video_nodes.py):
- Remove `force_size` — it's a hidden input, not a workflow parameter. Passing it caused ComfyUI 400 rejection.
- Use `force_rate` as float (`0.0`) per the `floatOrInt` type spec
- Set `custom_width`/`custom_height` to `0` (disabled state) instead of segment dimensions

## Test plan
- [ ] Faceswap reprocess workflow accepted by ComfyUI (no more 400)
- [ ] Video loads and faceswap applies correctly