### PR TITLE
feat: parameterize sampler schedule, split boundary, shift, and generation fps

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -25,6 +25,23 @@ class Settings(BaseSettings):
     cfg_low: float = 1.0  # CFG for low noise KSampler (node 85)
     clip_vision_model: str = "clip_vision_h.safetensors"
 
+    # Sampler schedule (previously hardcoded in the workflow template)
+    generation_fps: int = 16  # Wan 2.2 14B is trained at 16fps; was hardcoded 15. CORRECTNESS FIX.
+    steps_total: int = 4  # total KSamplerAdvanced schedule length (shared by both passes)
+    high_noise_steps: int = 2  # boundary: high-noise expert runs steps [0, high_noise_steps); low-noise runs [high_noise_steps, steps_total)
+    shift_high: float = 5.0  # ModelSamplingSD3 shift for the high-noise expert (node 104)
+    shift_low: float = 5.0  # ModelSamplingSD3 shift for the low-noise expert (node 103)
+
+    # --- Realism profile (de-distilled high-noise) — flip these to A/B against the distilled baseline ---
+    # Setting lightx2v_strength_high = 0.0 removes the distillation LoRA from the high-noise pass entirely
+    # (the builder rewires the graph), letting the high-noise expert run real steps at real CFG.
+    #   lightx2v_strength_high = 0.0
+    #   cfg_high               = 3.5
+    #   steps_total            = 8
+    #   high_noise_steps       = 4
+    #   shift_high             = 7.0
+    #   (low-noise stays distilled: lightx2v_strength_low = 1.0, cfg_low = 1.0, shift_low = 5.0)
+
     # PainterLongVideo motion parameters (identity anchoring)
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion
     painter_motion_frames: int = 5  # Range: 1-20, controls motion cycle length

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -42,6 +42,10 @@ class SegmentClaim(BaseModel):
     lightx2v_strength_low: Optional[float] = None
     cfg_high: Optional[float] = None
     cfg_low: Optional[float] = None
+    steps_total: Optional[int] = None
+    high_noise_steps: Optional[int] = None
+    shift_high: Optional[float] = None
+    shift_low: Optional[float] = None
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -15,9 +15,6 @@ from daemon.motion_analyzer import estimate_motion_from_flow
 
 logger = logging.getLogger(__name__)
 
-# Generation is always at 15fps; RIFE interpolation brings it to target fps.
-GENERATION_FPS = 15
-
 # Node IDs for dynamically added user LoRA pairs (up to 3).
 LORA_NODE_IDS = {
     "high": ["118", "120", "122"],
@@ -167,12 +164,20 @@ WAN_I2V_API_WORKFLOW: dict[str, Any] = {
 }
 
 
+def _snap_to_4n_plus_1(frames: int) -> int:
+    """Snap a frame count to the nearest 4n+1 value (Wan VAE temporal stride = 4), min 5."""
+    return max(4 * math.floor((frames - 1) / 4 + 0.5) + 1, 5)
+
+
 def _calculate_generation_params(target_fps: int, duration_sec: float, speed: float = 1.0) -> dict[str, Any]:
+    gen_fps = settings.generation_fps
     speed = max(speed, 0.25)
     # More speed = more WAN frames = more motion packed into the same duration.
-    wan_frames = max(math.ceil(duration_sec * GENERATION_FPS * speed), 5)
+    wan_frames = max(math.ceil(duration_sec * gen_fps * speed), 5)
+    # Wan VAE is 4x temporal; off-grid lengths cause end-of-clip artifacts.
+    wan_frames = _snap_to_4n_plus_1(wan_frames)
     # RIFE smoothing based on target fps (2x for 30fps, 4x for 60fps).
-    rife_multiplier = max(target_fps // GENERATION_FPS, 1)
+    rife_multiplier = max(round(target_fps / gen_fps), 1)
     total_frames = wan_frames * rife_multiplier
     # Output fps adjusts so all frames fit into the requested duration.
     output_fps = round(total_frames / duration_sec)
@@ -349,7 +354,7 @@ def _add_faceswap(workflow: dict, segment: SegmentClaim, input_node: str = "87")
 
 
 def build_faceswap_workflow(segment: SegmentClaim, video_filename: str) -> dict:
-    """Build a faceswap-only workflow: load video at 15fps → faceswap → RIFE → encode.
+    """Build a faceswap-only workflow: load video at generation fps → faceswap → RIFE → encode.
 
     Matches the normal generation pipeline: faceswap on native-rate frames,
     then RIFE interpolates back to target fps.
@@ -361,14 +366,14 @@ def build_faceswap_workflow(segment: SegmentClaim, video_filename: str) -> dict:
         "class_type": "VHS_LoadVideo",
         "inputs": {
             "video": video_filename,
-            "force_rate": float(GENERATION_FPS),
+            "force_rate": float(settings.generation_fps),
             "custom_width": 0,
             "custom_height": 0,
             "frame_load_cap": 0,
             "skip_first_frames": 0,
             "select_every_nth": 1,
         },
-        "_meta": {"title": "Load Existing Video @ 15fps"},
+        "_meta": {"title": f"Load Existing Video @ {settings.generation_fps}fps"},
     }
 
     _add_faceswap(workflow, segment, input_node="400")
@@ -434,9 +439,17 @@ def build_workflow(
             to PainterLongVideo with dual-reference inputs.
             identity for characters. PainterLongVideo only accepts a single
             clip_vision_output, so multi-frame reference frames are not used.
-        previous_motion_magnitude: Measured motion magnitude from previous 
-            segment (px/frame). Used to auto-adjust motion_amplitude for 
+        previous_motion_magnitude: Measured motion magnitude from previous
+            segment (px/frame). Used to auto-adjust motion_amplitude for
             consistent motion across segments.
+
+    Sampler knobs (lightx2v strengths, cfg, steps_total, high_noise_steps,
+    shift_high, shift_low) resolve as: per-segment override (if not None) →
+    `settings.<field>` default. When a resolved lightx2v strength is <= 0,
+    the corresponding distillation LoRA node (101 high / 102 low) is removed
+    and its upstream model (bare UNET or end of the user-LoRA chain) is
+    spliced directly into the ModelSamplingSD3 node (104 / 103), letting that
+    expert run de-distilled at real steps and real CFG.
     """
     gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
     
@@ -455,14 +468,32 @@ def build_workflow(
     workflow["90"]["inputs"]["vae_name"] = settings.vae_model
     workflow["95"]["inputs"]["unet_name"] = settings.unet_high_model
     workflow["96"]["inputs"]["unet_name"] = settings.unet_low_model
+    strength_high = segment.lightx2v_strength_high if segment.lightx2v_strength_high is not None else settings.lightx2v_strength_high
+    strength_low = segment.lightx2v_strength_low if segment.lightx2v_strength_low is not None else settings.lightx2v_strength_low
     workflow["101"]["inputs"]["lora_name"] = settings.lightx2v_lora_high
-    workflow["101"]["inputs"]["strength_model"] = segment.lightx2v_strength_high if segment.lightx2v_strength_high is not None else settings.lightx2v_strength_high
+    workflow["101"]["inputs"]["strength_model"] = strength_high
     workflow["102"]["inputs"]["lora_name"] = settings.lightx2v_lora_low
-    workflow["102"]["inputs"]["strength_model"] = segment.lightx2v_strength_low if segment.lightx2v_strength_low is not None else settings.lightx2v_strength_low
+    workflow["102"]["inputs"]["strength_model"] = strength_low
 
     # CFG values for KSampler nodes
     workflow["86"]["inputs"]["cfg"] = segment.cfg_high if segment.cfg_high is not None else settings.cfg_high
     workflow["85"]["inputs"]["cfg"] = segment.cfg_low if segment.cfg_low is not None else settings.cfg_low
+
+    # Sampler schedule and shift (segment override → settings default)
+    steps_total = segment.steps_total if segment.steps_total is not None else settings.steps_total
+    high_noise_steps = segment.high_noise_steps if segment.high_noise_steps is not None else settings.high_noise_steps
+    high_noise_steps = max(1, min(high_noise_steps, steps_total - 1))  # clamp to a valid split
+    shift_high = segment.shift_high if segment.shift_high is not None else settings.shift_high
+    shift_low = segment.shift_low if segment.shift_low is not None else settings.shift_low
+
+    workflow["86"]["inputs"]["steps"] = steps_total
+    workflow["86"]["inputs"]["start_at_step"] = 0
+    workflow["86"]["inputs"]["end_at_step"] = high_noise_steps
+    workflow["85"]["inputs"]["steps"] = steps_total
+    workflow["85"]["inputs"]["start_at_step"] = high_noise_steps
+    workflow["85"]["inputs"]["end_at_step"] = steps_total
+    workflow["104"]["inputs"]["shift"] = shift_high
+    workflow["103"]["inputs"]["shift"] = shift_low
 
     # Negative prompt
     if segment.negative_prompt is not None:
@@ -542,6 +573,17 @@ def build_workflow(
     if segment.loras:
         _add_user_loras(workflow, [l.model_dump() for l in segment.loras])
 
+    # De-distilled rewire: strength <= 0 removes the lightx2v LoRA node and
+    # splices its upstream model (bare UNET or end of user-LoRA chain) into
+    # ModelSamplingSD3. Must run after _add_user_loras, which rewires
+    # 101/102 .inputs.model to the end of the user-LoRA chain.
+    if strength_high <= 0:
+        workflow["104"]["inputs"]["model"] = workflow["101"]["inputs"]["model"]
+        del workflow["101"]
+    if strength_low <= 0:
+        workflow["103"]["inputs"]["model"] = workflow["102"]["inputs"]["model"]
+        del workflow["102"]
+
     # Face swap (before RIFE so it processes only native WAN frames, not
     # interpolated ones — cuts faceswap frame count by 50-75%)
     faceswap = segment.faceswap_enabled and segment.faceswap_image
@@ -590,14 +632,22 @@ def build_workflow(
     }
 
     logger.info(
-        "Built workflow: %dx%d, %d frames @ %dfps, RIFE %dx, speed=%.1fx, seed=%d, faceswap=%s",
+        "Built workflow: %dx%d, %d frames @ %dfps, RIFE %dx, speed=%.1fx, seed=%d, faceswap=%s, "
+        "steps_total=%d, high_noise_steps=%d, shift_high=%.1f, shift_low=%.1f, "
+        "strength_high=%.2f, strength_low=%.2f",
         segment.width,
         segment.height,
         gen["wan_frames"],
-        GENERATION_FPS,
+        settings.generation_fps,
         rife_multiplier,
         segment.speed,
         segment.seed,
         faceswap,
+        steps_total,
+        high_noise_steps,
+        shift_high,
+        shift_low,
+        strength_high,
+        strength_low,
     )
     return workflow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures for workflow_builder tests."""
+
+from uuid import uuid4
+
+import pytest
+
+from daemon.schemas import SegmentClaim
+
+
+@pytest.fixture
+def make_segment():
+    """Factory for SegmentClaim with sensible defaults; override via kwargs."""
+
+    def _make(**overrides) -> SegmentClaim:
+        defaults = {
+            "id": uuid4(),
+            "job_id": uuid4(),
+            "index": 0,
+            "prompt": "a calm lake at sunrise",
+            "duration_seconds": 5.0,
+            "faceswap_enabled": False,
+            "width": 640,
+            "height": 640,
+            "fps": 30,
+            "seed": 42,
+        }
+        defaults.update(overrides)
+        return SegmentClaim(**defaults)
+
+    return _make

--- a/tests/test_workflow_builder.py
+++ b/tests/test_workflow_builder.py
@@ -1,0 +1,183 @@
+"""Tests for daemon.workflow_builder: frame/fps math, sampler schedule
+injection, shift injection, and the de-distilled lightx2v rewire."""
+
+import pytest
+
+from daemon.config import settings
+from daemon.schemas import LoraItem
+from daemon.workflow_builder import (
+    _calculate_generation_params,
+    _snap_to_4n_plus_1,
+    build_faceswap_workflow,
+    build_workflow,
+)
+
+
+@pytest.mark.parametrize(
+    ("frames", "expected"),
+    [
+        (75, 77),
+        (80, 81),
+        (81, 81),
+        (3, 5),
+        (5, 5),
+        (78, 77),
+    ],
+)
+def test_snap_to_4n_plus_1(frames, expected):
+    assert _snap_to_4n_plus_1(frames) == expected
+
+
+class TestCalculateGenerationParams:
+    @pytest.fixture(autouse=True)
+    def _gen_fps_16(self, monkeypatch):
+        monkeypatch.setattr(settings, "generation_fps", 16)
+
+    @pytest.mark.parametrize("duration", [1.0, 2.5, 3.3, 5.0, 8.0, 10.7])
+    @pytest.mark.parametrize("speed", [0.25, 0.5, 1.0, 1.5, 2.0])
+    def test_wan_frames_always_on_4n_plus_1_grid(self, duration, speed):
+        gen = _calculate_generation_params(30, duration, speed)
+        assert (gen["wan_frames"] - 1) % 4 == 0
+        assert gen["wan_frames"] >= 5
+
+    @pytest.mark.parametrize(
+        ("target_fps", "expected_multiplier"),
+        [
+            (30, 2),
+            (60, 4),
+            (16, 1),
+        ],
+    )
+    def test_rife_multiplier(self, target_fps, expected_multiplier):
+        gen = _calculate_generation_params(target_fps, 5.0)
+        assert gen["rife_multiplier"] == expected_multiplier
+
+    def test_output_fps_fits_duration(self):
+        gen = _calculate_generation_params(30, 5.0)
+        expected_total = gen["wan_frames"] * gen["rife_multiplier"]
+        assert gen["output_fps"] == round(expected_total / 5.0)
+
+
+class TestScheduleInjection:
+    def test_custom_schedule_split(self, make_segment):
+        segment = make_segment(steps_total=8, high_noise_steps=4)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert workflow["86"]["inputs"]["steps"] == 8
+        assert workflow["86"]["inputs"]["start_at_step"] == 0
+        assert workflow["86"]["inputs"]["end_at_step"] == 4
+        assert workflow["85"]["inputs"]["steps"] == 8
+        assert workflow["85"]["inputs"]["start_at_step"] == 4
+        assert workflow["85"]["inputs"]["end_at_step"] == 8
+
+    def test_high_noise_steps_clamped_below_steps_total(self, make_segment):
+        segment = make_segment(steps_total=4, high_noise_steps=10)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert workflow["86"]["inputs"]["end_at_step"] == 3
+        assert workflow["85"]["inputs"]["start_at_step"] == 3
+
+    def test_high_noise_steps_clamped_above_zero(self, make_segment):
+        segment = make_segment(steps_total=4, high_noise_steps=0)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert workflow["86"]["inputs"]["end_at_step"] == 1
+        assert workflow["85"]["inputs"]["start_at_step"] == 1
+
+
+class TestShiftInjection:
+    def test_shift_values_reach_model_sampling_nodes(self, make_segment):
+        segment = make_segment(shift_high=7.0, shift_low=4.5)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert workflow["104"]["inputs"]["shift"] == 7.0
+        assert workflow["103"]["inputs"]["shift"] == 4.5
+
+
+class TestOverridePrecedence:
+    def test_segment_overrides_win_over_settings(self, make_segment, monkeypatch):
+        monkeypatch.setattr(settings, "steps_total", 6)
+        monkeypatch.setattr(settings, "shift_high", 5.0)
+        segment = make_segment(steps_total=8, high_noise_steps=4, shift_high=7.0)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert workflow["86"]["inputs"]["steps"] == 8
+        assert workflow["104"]["inputs"]["shift"] == 7.0
+
+    def test_none_falls_back_to_settings(self, make_segment, monkeypatch):
+        monkeypatch.setattr(settings, "steps_total", 6)
+        monkeypatch.setattr(settings, "high_noise_steps", 3)
+        monkeypatch.setattr(settings, "shift_high", 6.5)
+        monkeypatch.setattr(settings, "shift_low", 4.0)
+        segment = make_segment()  # all sampler overrides default to None
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert workflow["86"]["inputs"]["steps"] == 6
+        assert workflow["86"]["inputs"]["end_at_step"] == 3
+        assert workflow["85"]["inputs"]["start_at_step"] == 3
+        assert workflow["85"]["inputs"]["end_at_step"] == 6
+        assert workflow["104"]["inputs"]["shift"] == 6.5
+        assert workflow["103"]["inputs"]["shift"] == 4.0
+
+
+class TestDeDistillRewire:
+    def test_high_strength_zero_removes_node_101(self, make_segment):
+        segment = make_segment(lightx2v_strength_high=0.0)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert "101" not in workflow
+        # 104 is spliced onto 101's upstream model: the high-noise UNET (95)
+        assert workflow["104"]["inputs"]["model"] == ["95", 0]
+        # Low side untouched
+        assert "102" in workflow
+        assert workflow["103"]["inputs"]["model"] == ["102", 0]
+
+    def test_high_strength_positive_keeps_node_101(self, make_segment):
+        segment = make_segment(lightx2v_strength_high=2.0)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert "101" in workflow
+        assert workflow["101"]["inputs"]["strength_model"] == 2.0
+        assert workflow["104"]["inputs"]["model"] == ["101", 0]
+
+    def test_low_strength_zero_removes_node_102(self, make_segment):
+        segment = make_segment(lightx2v_strength_low=0.0)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert "102" not in workflow
+        assert workflow["103"]["inputs"]["model"] == ["96", 0]
+        # High side untouched
+        assert "101" in workflow
+        assert workflow["104"]["inputs"]["model"] == ["101", 0]
+
+    def test_low_strength_positive_keeps_node_102(self, make_segment):
+        segment = make_segment(lightx2v_strength_low=1.0)
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert "102" in workflow
+        assert workflow["102"]["inputs"]["strength_model"] == 1.0
+        assert workflow["103"]["inputs"]["model"] == ["102", 0]
+
+    def test_rewire_composes_with_user_lora(self, make_segment):
+        segment = make_segment(
+            lightx2v_strength_high=0.0,
+            loras=[LoraItem(high_file="user_high.safetensors", high_weight=0.8)],
+        )
+        workflow = build_workflow(segment, start_image_filename="start.png")
+
+        assert "101" not in workflow
+        # 104 must point at the user-LoRA node (118), not the bare UNET (95)
+        assert workflow["104"]["inputs"]["model"] == ["118", 0]
+        assert workflow["118"]["inputs"]["model"] == ["95", 0]
+
+
+class TestFaceswapWorkflowFps:
+    def test_force_rate_follows_generation_fps(self, make_segment, monkeypatch):
+        monkeypatch.setattr(settings, "generation_fps", 16)
+        segment = make_segment(faceswap_enabled=True, faceswap_image="face.png")
+        workflow = build_faceswap_workflow(segment, "existing.mp4")
+
+        assert workflow["400"]["inputs"]["force_rate"] == 16.0
+        assert "16fps" in workflow["400"]["_meta"]["title"]
+        # target fps 30 at gen fps 16 → RIFE 2x (round, not floor)
+        assert workflow["200"]["inputs"]["multiplier"] == 2


### PR DESCRIPTION
## Summary
Exposes the Wan 2.2 sampler knobs that were hardcoded in the workflow template so the distilled "fast" profile and a de-distilled "realism" profile can be A/B tested without code edits, plus three correctness fixes in frame/fps math.

Resolution precedence for every new knob: **per-segment override (if not None) → `settings.<field>` default** — same pattern as the existing `cfg_high` / `lightx2v_strength_high` handling.

## Changes
- **`daemon/config.py`** — new `Settings` fields: `generation_fps` (16), `steps_total` (4), `high_noise_steps` (2), `shift_high` (5.0), `shift_low` (5.0). Existing defaults unchanged, so current output remains the A/B baseline. The de-distilled realism profile is documented as a commented block.
- **`daemon/schemas.py`** — `SegmentClaim` gains optional `steps_total`, `high_noise_steps`, `shift_high`, `shift_low` (default `None`; API can send them later — wanly-api untouched).
- **`daemon/workflow_builder.py`**
  - Schedule/shift injection into KSamplerAdvanced 85/86 and ModelSamplingSD3 103/104, with `high_noise_steps` clamped to `[1, steps_total - 1]`.
  - De-distill rewire: a resolved lightx2v strength `<= 0` removes node 101/102 and splices its upstream model (bare UNET or end of user-LoRA chain) into ModelSamplingSD3. Runs after `_add_user_loras` so user-LoRA chains are preserved.
  - Extended build-summary log with all resolved sampler knobs.

## Correctness fixes
1. `generation_fps` 15 → 16 (Wan 2.2 14B is trained at 16fps); the `GENERATION_FPS` constant is removed and every reference — including `build_faceswap_workflow`'s `VHS_LoadVideo` `force_rate` — now reads `settings.generation_fps`, keeping faceswap-reprocess and generation in lockstep.
2. `wan_frames` snapped to the nearest `4n+1` (Wan VAE temporal stride = 4); off-grid lengths cause end-of-clip artifacts, and that exact frame chains into the next segment.
3. RIFE multiplier uses `max(round(target/gen), 1)` instead of integer `//` — with `gen_fps=16`, `30 // 16 == 1` silently killed interpolation.

> Note: the snap helper uses round-half-up (`floor(x + 0.5)`) rather than Python's banker's `round()`, so the midpoint case snaps up (75 → 77, matching the spec's test vector).

## Testing
- New `tests/` suite (none existed before): 52 tests covering the snap helper, fps/RIFE math at `generation_fps=16`, schedule/shift injection, boundary clamping, de-distill rewire (both experts, with and without user LoRAs), override precedence, and faceswap `force_rate`.
- All 52 pass; 100% coverage on every touched line (remaining uncovered lines are pre-existing untouched paths: motion matching, ReActor branch, PainterLongVideo block).