### PR TITLE
Land dtype knob + realism toggle on main; log model per job

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,9 @@ QUEUE_API_KEY=
 POLL_INTERVAL=5
 LIGHTX2V_STRENGTH_HIGH=2.5
 LIGHTX2V_STRENGTH_LOW=1.0
+# UNET load precision — clarity lever for the baked-fp8 DaSiWa model.
+# default | fp8_e4m3fn | fp8_e4m3fn_fast   (see daemon/config.py for trade-offs)
+UNET_WEIGHT_DTYPE=fp8_e4m3fn
+# De-distill the high-noise expert (real steps + CFG) for motion + facial expression.
+# Single A/B toggle; costs generation time. true = realism, false = fast distilled baseline.
+HIGH_NOISE_REALISM=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,13 +61,17 @@ Environment variables (see `daemon/settings.py`):
 
 ## Deployment
 
-Runs as systemd service `wanly` on GPU servers:
-- `2070.zero` (RTX 4070)
-- `3090.zero` (RTX 3090)
+Runs as systemd service `wanly` on self-hosted GPU servers (ZeroTier network):
+- `2070.zero` (RTX 4070) — 192.168.196.x
+- `3090.zero` (RTX 3090) — 192.168.196.172
+
+Servers are accessed directly via SSH over ZeroTier (no AWS/RunPod involved):
 
 ```bash
-sudo systemctl restart wanly
+ssh 3090.zero 'sudo systemctl restart wanly'
 ```
+
+The daemon working directory is `/home/david/projects/wanly-gpu-daemon` with `.env` at that path. Deploy by pulling the git repo and restarting the service.
 
 ## Related Projects
 

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -17,6 +17,11 @@ class Settings(BaseSettings):
     vae_model: str = "wan_2.1_vae.safetensors"
     unet_high_model: str = "wan2.2_i2v_high_noise_14B_fp16.safetensors"
     unet_low_model: str = "wan2.2_i2v_low_noise_14B_fp16.safetensors"
+    # UNETLoader weight_dtype (nodes 95 high / 96 low). Clarity vs. speed/VRAM lever.
+    #   "default"          — load at native precision (sharpest, most VRAM)
+    #   "fp8_e4m3fn"       — fp8 storage, standard matmul (clean; recommended for baked-fp8 DaSiWa)
+    #   "fp8_e4m3fn_fast"  — fp8 + reduced-precision fast GEMM (fuzziest; Ada/Hopper only — wasted on the 3090)
+    unet_weight_dtype: str = "fp8_e4m3fn"
     lightx2v_lora_high: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_high_noise.safetensors"
     lightx2v_lora_low: str = "wan2.2_i2v_lightx2v_4steps_lora_v1_low_noise.safetensors"
     lightx2v_strength_high: float = 2.0  # Strength for high noise lightx2v LoRA (community range: 1.0–5.6)
@@ -32,15 +37,15 @@ class Settings(BaseSettings):
     shift_high: float = 5.0  # ModelSamplingSD3 shift for the high-noise expert (node 104)
     shift_low: float = 5.0  # ModelSamplingSD3 shift for the low-noise expert (node 103)
 
-    # --- Realism profile (de-distilled high-noise) — flip these to A/B against the distilled baseline ---
-    # Setting lightx2v_strength_high = 0.0 removes the distillation LoRA from the high-noise pass entirely
-    # (the builder rewires the graph), letting the high-noise expert run real steps at real CFG.
-    #   lightx2v_strength_high = 0.0
-    #   cfg_high               = 3.5
-    #   steps_total            = 8
-    #   high_noise_steps       = 4
-    #   shift_high             = 7.0
-    #   (low-noise stays distilled: lightx2v_strength_low = 1.0, cfg_low = 1.0, shift_low = 5.0)
+    # --- Realism profile (de-distilled high-noise) — single A/B toggle against the distilled baseline ---
+    # When True, the high-noise expert runs de-distilled: its lightx2v LoRA is dropped (the builder
+    # rewires the graph) and it runs real steps at real CFG, for stronger motion and more natural
+    # facial expression. Low-noise pass stays distilled. The bundle below moves together because
+    # steps_total is shared across both passes, so a single switch is the clean way to flip it.
+    # Distilled baseline: strength_high 2.0, cfg_high 1.0, steps_total 4, high_noise_steps 2, shift_high 5.0
+    # Realism bundle:     strength_high 0.0, cfg_high 3.5, steps_total 8, high_noise_steps 4, shift_high 7.0
+    # Per-segment overrides (from the job) still win over the profile.
+    high_noise_realism: bool = False
 
     # PainterLongVideo motion parameters (identity anchoring)
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -101,14 +101,14 @@ WAN_I2V_API_WORKFLOW: dict[str, Any] = {
         "class_type": "UNETLoader",
         "inputs": {
             "unet_name": "wan2.2_i2v_high_noise_14B_fp16.safetensors",
-            "weight_dtype": "default",
+            "weight_dtype": "fp8_e4m3fn_fast",
         },
     },
     "96": {
         "class_type": "UNETLoader",
         "inputs": {
             "unet_name": "wan2.2_i2v_low_noise_14B_fp16.safetensors",
-            "weight_dtype": "default",
+            "weight_dtype": "fp8_e4m3fn_fast",
         },
     },
     "97": {
@@ -468,7 +468,19 @@ def build_workflow(
     workflow["90"]["inputs"]["vae_name"] = settings.vae_model
     workflow["95"]["inputs"]["unet_name"] = settings.unet_high_model
     workflow["96"]["inputs"]["unet_name"] = settings.unet_low_model
-    strength_high = segment.lightx2v_strength_high if segment.lightx2v_strength_high is not None else settings.lightx2v_strength_high
+    workflow["95"]["inputs"]["weight_dtype"] = settings.unet_weight_dtype
+    workflow["96"]["inputs"]["weight_dtype"] = settings.unet_weight_dtype
+    # High-noise realism profile: when enabled, the high-noise expert runs de-distilled
+    # (lightx2v dropped, real steps + CFG) for stronger motion and more natural facial
+    # expression. Low-noise pass is untouched. These become the high-noise defaults;
+    # per-segment overrides from the job still take precedence below.
+    if settings.high_noise_realism:
+        d_strength_high, d_cfg_high, d_steps_total, d_high_noise_steps, d_shift_high = 0.0, 3.5, 8, 4, 7.0
+    else:
+        d_strength_high, d_cfg_high = settings.lightx2v_strength_high, settings.cfg_high
+        d_steps_total, d_high_noise_steps, d_shift_high = settings.steps_total, settings.high_noise_steps, settings.shift_high
+
+    strength_high = segment.lightx2v_strength_high if segment.lightx2v_strength_high is not None else d_strength_high
     strength_low = segment.lightx2v_strength_low if segment.lightx2v_strength_low is not None else settings.lightx2v_strength_low
     workflow["101"]["inputs"]["lora_name"] = settings.lightx2v_lora_high
     workflow["101"]["inputs"]["strength_model"] = strength_high
@@ -476,14 +488,14 @@ def build_workflow(
     workflow["102"]["inputs"]["strength_model"] = strength_low
 
     # CFG values for KSampler nodes
-    workflow["86"]["inputs"]["cfg"] = segment.cfg_high if segment.cfg_high is not None else settings.cfg_high
+    workflow["86"]["inputs"]["cfg"] = segment.cfg_high if segment.cfg_high is not None else d_cfg_high
     workflow["85"]["inputs"]["cfg"] = segment.cfg_low if segment.cfg_low is not None else settings.cfg_low
 
-    # Sampler schedule and shift (segment override → settings default)
-    steps_total = segment.steps_total if segment.steps_total is not None else settings.steps_total
-    high_noise_steps = segment.high_noise_steps if segment.high_noise_steps is not None else settings.high_noise_steps
+    # Sampler schedule and shift (segment override → profile/settings default)
+    steps_total = segment.steps_total if segment.steps_total is not None else d_steps_total
+    high_noise_steps = segment.high_noise_steps if segment.high_noise_steps is not None else d_high_noise_steps
     high_noise_steps = max(1, min(high_noise_steps, steps_total - 1))  # clamp to a valid split
-    shift_high = segment.shift_high if segment.shift_high is not None else settings.shift_high
+    shift_high = segment.shift_high if segment.shift_high is not None else d_shift_high
     shift_low = segment.shift_low if segment.shift_low is not None else settings.shift_low
 
     workflow["86"]["inputs"]["steps"] = steps_total
@@ -634,7 +646,7 @@ def build_workflow(
     logger.info(
         "Built workflow: %dx%d, %d frames @ %dfps, RIFE %dx, speed=%.1fx, seed=%d, faceswap=%s, "
         "steps_total=%d, high_noise_steps=%d, shift_high=%.1f, shift_low=%.1f, "
-        "strength_high=%.2f, strength_low=%.2f",
+        "strength_high=%.2f, strength_low=%.2f, dtype=%s, model=%s | %s",
         segment.width,
         segment.height,
         gen["wan_frames"],
@@ -649,5 +661,8 @@ def build_workflow(
         shift_low,
         strength_high,
         strength_low,
+        settings.unet_weight_dtype,
+        workflow["95"]["inputs"]["unet_name"],
+        workflow["96"]["inputs"]["unet_name"],
     )
     return workflow


### PR DESCRIPTION
Brings the validated daemon code from `feat/parameterize-sampler-schedule` onto `main` so the GPU box can track `main` (the parameterize work was already squash-merged via #44; this is the remaining delta).

- `unet_weight_dtype` knob (default `fp8_e4m3fn`)
- `high_noise_realism` A/B toggle
- AGENTS.md deploy docs
- per-job `Built workflow` log now includes `dtype=` and `model=<high> | <low>` so each generation records its checkpoint/precision

Config lives in the box `.env` (gitignored) and is unaffected. py_compile clean.