### PR TITLE
feat: MODE_PRESETS + mode-driven resolution (+ TE-cpu, LoRA-skip)

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -75,3 +75,50 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
+
+
+# Generation mode presets — each is a FULL profile (model + sampler knobs) selected
+# per job via GenerationMode (wanly-api) and resolved in workflow_builder by segment.mode.
+# identity/expression are the proven walking-5/walking-7 recipes. dasiwa values are
+# best-known and want one confirming test before they're locked.
+_BASE_HIGH = "wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors"
+_BASE_LOW = "wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors"
+
+MODE_PRESETS: dict[str, dict] = {
+    # Wan22 Base (Character Identity) — fully resident, ~16m, 10/10 identity
+    "identity": {
+        "unet_high_model": _BASE_HIGH, "unet_low_model": _BASE_LOW,
+        "unet_weight_dtype": "fp8_e4m3fn",
+        "lightx2v_strength_high": 0.5, "lightx2v_strength_low": 0.5,
+        "cfg_high": 1.0, "cfg_low": 1.0,
+        "steps_total": 10, "high_noise_steps": 5,
+        "shift_high": 5.0, "shift_low": 5.0,
+    },
+    # Wan22 Base (Identity + Expression) — de-distilled high (lightx2v 0 + real CFG),
+    # model offloads, ~21m, natural motion + expression. Needs the cfg-aware estimate.
+    "expression": {
+        "unet_high_model": _BASE_HIGH, "unet_low_model": _BASE_LOW,
+        "unet_weight_dtype": "fp8_e4m3fn",
+        "lightx2v_strength_high": 0.0, "lightx2v_strength_low": 0.5,
+        "cfg_high": 3.5, "cfg_low": 1.0,
+        "steps_total": 20, "high_noise_steps": 12,
+        "shift_high": 5.0, "shift_low": 5.0,
+    },
+    # DaSiWa (Fast) — baked-distilled remix, ~13m, natural motion / weaker identity.
+    # TODO: confirm values with one test run before treating as final.
+    "dasiwa": {
+        "unet_high_model": "DasiwaWAN22I2V14BLightspeed_snatchkissHighV11.safetensors",
+        "unet_low_model": "DasiwaWAN22I2V14BLightspeed_snatchkissLowV11.safetensors",
+        "unet_weight_dtype": "fp8_e4m3fn",
+        "lightx2v_strength_high": 0.0, "lightx2v_strength_low": 0.0,
+        "cfg_high": 1.0, "cfg_low": 1.0,
+        "steps_total": 8, "high_noise_steps": 4,
+        "shift_high": 5.0, "shift_low": 5.0,
+    },
+}
+
+
+def get_mode_preset(mode: str | None) -> dict:
+    """Resolve a job's generation mode to its full model+sampler preset.
+    Unknown/legacy modes fall back to the safe resident 'identity' profile."""
+    return MODE_PRESETS.get(mode or "identity", MODE_PRESETS["identity"])

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -38,14 +38,7 @@ class SegmentClaim(BaseModel):
     previous_motion_keywords: Optional[list[str]] = None
     previous_motion_magnitude: Optional[float] = None
     reference_frames: Optional[list[str]] = None
-    lightx2v_strength_high: Optional[float] = None
-    lightx2v_strength_low: Optional[float] = None
-    cfg_high: Optional[float] = None
-    cfg_low: Optional[float] = None
-    steps_total: Optional[int] = None
-    high_noise_steps: Optional[int] = None
-    shift_high: Optional[float] = None
-    shift_low: Optional[float] = None
+    mode: str = "identity"  # GenerationMode from the job → daemon resolves model + sampler preset
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -9,7 +9,7 @@ import logging
 import math
 from typing import Any
 
-from daemon.config import settings
+from daemon.config import settings, get_mode_preset
 from daemon.schemas import SegmentClaim
 from daemon.motion_analyzer import estimate_motion_from_flow
 
@@ -220,7 +220,7 @@ def _calculate_motion_amplitude(
     )
     
     # Clamp to valid range
-    from daemon.config import settings
+    from daemon.config import settings, get_mode_preset
     return max(settings.motion_amplitude_min, min(settings.motion_amplitude_max, estimated))
 
 
@@ -242,7 +242,7 @@ def _add_user_loras(workflow: dict, loras: list[dict]) -> None:
         high_node_id = LORA_NODE_IDS["high"][i]
         low_node_id = LORA_NODE_IDS["low"][i]
 
-        if high_file:
+        if high_file and high_weight != 0:
             workflow[high_node_id] = {
                 "class_type": "LoraLoaderModelOnly",
                 "inputs": {
@@ -255,7 +255,7 @@ def _add_user_loras(workflow: dict, loras: list[dict]) -> None:
             last_high_node = high_node_id
             logger.info("Added LoRA %d high: %s (weight=%.2f)", i + 1, high_file, high_weight)
 
-        if low_file:
+        if low_file and low_weight != 0:
             workflow[low_node_id] = {
                 "class_type": "LoraLoaderModelOnly",
                 "inputs": {
@@ -463,40 +463,38 @@ def build_workflow(
                 segment.index, motion_amplitude, previous_motion_magnitude)
     workflow = copy.deepcopy(WAN_I2V_API_WORKFLOW)
 
-    # Inject model filenames from config
-    workflow["84"]["inputs"]["clip_name"] = settings.clip_model
-    workflow["90"]["inputs"]["vae_name"] = settings.vae_model
-    workflow["95"]["inputs"]["unet_name"] = settings.unet_high_model
-    workflow["96"]["inputs"]["unet_name"] = settings.unet_low_model
-    workflow["95"]["inputs"]["weight_dtype"] = settings.unet_weight_dtype
-    workflow["96"]["inputs"]["weight_dtype"] = settings.unet_weight_dtype
-    # High-noise realism profile: when enabled, the high-noise expert runs de-distilled
-    # (lightx2v dropped, real steps + CFG) for stronger motion and more natural facial
-    # expression. Low-noise pass is untouched. These become the high-noise defaults;
-    # per-segment overrides from the job still take precedence below.
-    if settings.high_noise_realism:
-        d_strength_high, d_cfg_high, d_steps_total, d_high_noise_steps, d_shift_high = 0.0, 3.5, 8, 4, 7.0
-    else:
-        d_strength_high, d_cfg_high = settings.lightx2v_strength_high, settings.cfg_high
-        d_steps_total, d_high_noise_steps, d_shift_high = settings.steps_total, settings.high_noise_steps, settings.shift_high
+    # Resolve the job's generation mode → a full model + sampler preset (MODE_PRESETS).
+    # The mode is set once per job and locked for all its segments.
+    p = get_mode_preset(getattr(segment, "mode", None))
 
-    strength_high = segment.lightx2v_strength_high if segment.lightx2v_strength_high is not None else d_strength_high
-    strength_low = segment.lightx2v_strength_low if segment.lightx2v_strength_low is not None else settings.lightx2v_strength_low
+    # Inject models from the preset. Text encoder on CPU frees ~6.4 GB so the 14B loads
+    # resident on the 3090 (harmless elsewhere).
+    workflow["84"]["inputs"]["clip_name"] = settings.clip_model
+    workflow["84"]["inputs"]["device"] = "cpu"
+    workflow["90"]["inputs"]["vae_name"] = settings.vae_model
+    workflow["95"]["inputs"]["unet_name"] = p["unet_high_model"]
+    workflow["96"]["inputs"]["unet_name"] = p["unet_low_model"]
+    workflow["95"]["inputs"]["weight_dtype"] = p["unet_weight_dtype"]
+    workflow["96"]["inputs"]["weight_dtype"] = p["unet_weight_dtype"]
+
+    # lightx2v strength <= 0 triggers the de-distill rewire below (removes the distillation
+    # LoRA so that expert runs at real steps/CFG — the expression preset relies on this).
+    strength_high = p["lightx2v_strength_high"]
+    strength_low = p["lightx2v_strength_low"]
     workflow["101"]["inputs"]["lora_name"] = settings.lightx2v_lora_high
     workflow["101"]["inputs"]["strength_model"] = strength_high
     workflow["102"]["inputs"]["lora_name"] = settings.lightx2v_lora_low
     workflow["102"]["inputs"]["strength_model"] = strength_low
 
     # CFG values for KSampler nodes
-    workflow["86"]["inputs"]["cfg"] = segment.cfg_high if segment.cfg_high is not None else d_cfg_high
-    workflow["85"]["inputs"]["cfg"] = segment.cfg_low if segment.cfg_low is not None else settings.cfg_low
+    workflow["86"]["inputs"]["cfg"] = p["cfg_high"]
+    workflow["85"]["inputs"]["cfg"] = p["cfg_low"]
 
-    # Sampler schedule and shift (segment override → profile/settings default)
-    steps_total = segment.steps_total if segment.steps_total is not None else d_steps_total
-    high_noise_steps = segment.high_noise_steps if segment.high_noise_steps is not None else d_high_noise_steps
-    high_noise_steps = max(1, min(high_noise_steps, steps_total - 1))  # clamp to a valid split
-    shift_high = segment.shift_high if segment.shift_high is not None else d_shift_high
-    shift_low = segment.shift_low if segment.shift_low is not None else settings.shift_low
+    # Sampler schedule and shift from the preset
+    steps_total = p["steps_total"]
+    high_noise_steps = max(1, min(p["high_noise_steps"], steps_total - 1))  # clamp to a valid split
+    shift_high = p["shift_high"]
+    shift_low = p["shift_low"]
 
     workflow["86"]["inputs"]["steps"] = steps_total
     workflow["86"]["inputs"]["start_at_step"] = 0


### PR DESCRIPTION
Resolves a job's generation **mode** → a full **model + sampler preset** (`MODE_PRESETS`), replacing the global `high_noise_realism` toggle and the per-segment override plumbing.

### Presets
- **identity** — base fp8, lx2v 0.5/cfg 1/10-5 steps (resident, ~16m) — *proven (walking-5)*
- **expression** — base fp8, de-distill high (lx2v 0/cfg 3.5/20-12 steps, offload, ~21m) — *proven (walking-7)*
- **dasiwa** — DaSiWa models, cfg 1/8-4 steps (~13m) — *best-known, wants one confirming test*
- unknown/None → falls back to `identity`

### Also (reconcile of this session's live keeper edits — closes the reconcile task)
- **TE-on-CPU** (`CLIPLoader device=cpu`) — frees ~6.4 GB so the 14B loads resident on the 3090
- **Skip zero-weight LoRAs** in `_add_user_loras` — was loading + patching 0-weight LoRAs (~300 MB + an OOM-causing transient)

`SegmentClaim` gains `mode`; dead lightx2v/cfg/steps/shift override fields removed. Preset resolution unit-tested. Pairs with wanly-api #92 + wanly-console #194.

⚠️ Note: the 3090's local daemon checkout needs a `git pull` + restart post-merge (it's not CI/CD-deployed); RunPod image rebuilds automatically. The cfg-aware ComfyUI estimate (3090-only) is applied separately.