### PR TITLE
fix: raise EXECUTION_TIMEOUT 1800→3600 (de-distill expression jobs)

### DIFF
--- a/daemon/comfyui_client.py
+++ b/daemon/comfyui_client.py
@@ -11,7 +11,7 @@ from daemon.config import settings
 
 logger = logging.getLogger(__name__)
 
-EXECUTION_TIMEOUT = 1800  # 30 minutes
+EXECUTION_TIMEOUT = 3600  # 60 minutes (de-distill expression jobs run 28-34m)
 PROGRESS_TIMEOUT = 300  # 5 minutes without any progress = stuck
 
 

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -105,7 +105,7 @@ MODE_PRESETS: dict[str, dict] = {
         "shift_high": 5.0, "shift_low": 5.0,
     },
     # DaSiWa (Fast) — baked-distilled remix, ~13m, natural motion / weaker identity.
-    # TODO: confirm values with one test run before treating as final.
+    # Confirmed 2026-07-01 (first preset guess ran clean + looked great).
     "dasiwa": {
         "unet_high_model": "DasiwaWAN22I2V14BLightspeed_snatchkissHighV11.safetensors",
         "unet_low_model": "DasiwaWAN22I2V14BLightspeed_snatchkissLowV11.safetensors",


### PR DESCRIPTION
Expression mode de-distills the high expert → jobs run **28-34 min**, tripping the 30-min ComfyUI execution timeout. Raise to 60 min. (Was applied live on the 3090 but lost from the #47 merge — this makes it stick in main + the RunPod image.)