### PR TITLE
feat: per-job memory estimate hint (cfg-aware resident vs offload)

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -467,6 +467,15 @@ def build_workflow(
     # The mode is set once per job and locked for all its segments.
     p = get_mode_preset(getattr(segment, "mode", None))
 
+    # Per-job memory hint for the 3090's cfg-aware model_base patch (harmless where that
+    # patch isn't applied, e.g. RunPod): cfg>1 (expression) → 0.015 so the model offloads
+    # to fit the CFG-doubled activation; cfg<=1 (identity/dasiwa) → 0.003 = resident.
+    try:
+        with open("/tmp/wanly_estimate", "w") as _ef:
+            _ef.write("0.015" if p["cfg_high"] > 1 else "0.003")
+    except Exception:
+        pass
+
     # Inject models from the preset. Text encoder on CPU frees ~6.4 GB so the 14B loads
     # resident on the 3090 (harmless elsewhere).
     workflow["84"]["inputs"]["clip_name"] = settings.clip_model


### PR DESCRIPTION
The two base modes need **opposite** memory strategies: **identity** (cfg 1) stays resident for speed; **expression** (cfg 3.5, de-distilled high) must **offload** to fit the CFG-doubled activation (else OOM). ComfyUI's global memory estimate can't see cfg — and keying off `input_shape[0]` doesn't work because `sampler_helpers.py:133` hardcodes `noise_shape[0]*2`.

**Fix:** the daemon writes `/tmp/wanly_estimate` (`0.015` if the mode's `cfg_high>1` else `0.003`) when building each workflow; a small **3090-local** `comfy/model_base.py` patch reads it. Sequential single-GPU → no race. **Harmless on RunPod** (pristine model_base ignores the file; native fp8 doesn't need the hack).

Verified by load-test: **0.015 → 5563 MB usable (offloads), 0.003 → 19567 MB usable (resident).** Completes the mode-selector memory story (api #92 / console #194 / daemon #47).