### PR TITLE
feat: live stage/step progress in the Job Detail panel

### DIFF
--- a/daemon/comfyui_client.py
+++ b/daemon/comfyui_client.py
@@ -14,6 +14,14 @@ logger = logging.getLogger(__name__)
 EXECUTION_TIMEOUT = 1800  # 30 minutes
 PROGRESS_TIMEOUT = 300  # 5 minutes without any progress = stuck
 
+# Workflow node IDs → human progress stages (for the Job Detail progress panel).
+# 84 = CLIPLoader/text encode, 86 = high-noise KSampler, 85 = low-noise KSampler.
+NODE_STAGES = {
+    "84": "Text encoding",
+    "86": "High-noise pass",
+    "85": "Low-noise pass",
+}
+
 
 class ComfyUIExecutionError(Exception):
     """Raised when ComfyUI reports an execution error."""
@@ -109,15 +117,17 @@ class ComfyUIClient:
         logger.info("Submitted workflow, prompt_id=%s", prompt_id)
         return prompt_id, client_id
 
-    async def monitor_execution(self, prompt_id: str, client_id: str) -> dict[str, Any]:
+    async def monitor_execution(self, prompt_id: str, client_id: str, progress=None) -> dict[str, Any]:
         """Monitor workflow execution via WebSocket with a timeout.
 
         Returns output data from 'executed' messages.
         Raises ComfyUIExecutionError on timeout or execution failure.
+        If a ProgressLog is passed, live stage/step updates are pushed to it
+        (→ the Job Detail progress panel).
         """
         try:
             return await asyncio.wait_for(
-                self._monitor_ws(prompt_id, client_id),
+                self._monitor_ws(prompt_id, client_id, progress),
                 timeout=EXECUTION_TIMEOUT,
             )
         except asyncio.TimeoutError:
@@ -125,7 +135,7 @@ class ComfyUIClient:
                 f"Execution timed out after {EXECUTION_TIMEOUT}s"
             )
 
-    async def _monitor_ws(self, prompt_id: str, client_id: str) -> dict[str, Any]:
+    async def _monitor_ws(self, prompt_id: str, client_id: str, progress=None) -> dict[str, Any]:
         """Inner WebSocket monitoring loop with progress-based timeout."""
         ws_url = f"ws://{self.base_url.replace('http://', '').replace('https://', '')}/ws?clientId={client_id}"
         if self.api_key:
@@ -171,6 +181,8 @@ class ComfyUIClient:
                     else:
                         current_node = node
                         last_progress_pct = -1
+                        if progress is not None and str(node) in NODE_STAGES:
+                            await progress.log(f"{NODE_STAGES[str(node)]}…")
                     last_activity = asyncio.get_event_loop().time()
 
                 elif msg_type == "progress":
@@ -185,6 +197,9 @@ class ComfyUIClient:
                                 node_label = f" (node {current_node})" if current_node else ""
                                 logger.info("       Step %d/%d (%d%%)%s", value, max_val, pct, node_label)
                                 last_progress_pct = threshold
+                                if progress is not None and threshold > 0:
+                                    stage = NODE_STAGES.get(str(current_node), "Sampling")
+                                    await progress.log(f"{stage} · step {value}/{max_val} ({pct}%)")
                                 break
 
                 elif msg_type == "executed":

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -207,7 +207,7 @@ async def _execute_faceswap_reprocess(
 
         # Step 4: Wait for execution
         await progress.log("[4/5] Waiting for faceswap execution...")
-        await comfyui.monitor_execution(prompt_id, client_id)
+        await comfyui.monitor_execution(prompt_id, client_id, progress)
         await progress.log("[4/5] Execution complete")
 
         # Step 5: Download output, extract last frame, upload
@@ -364,7 +364,7 @@ async def execute_segment(
         # Step 5: Wait for ComfyUI execution
         t0 = time.monotonic()
         await progress.log("[5/7] Waiting for ComfyUI execution...")
-        await comfyui.monitor_execution(prompt_id, client_id)
+        await comfyui.monitor_execution(prompt_id, client_id, progress)
         await progress.log("[5/7] Execution complete")
         step_times.append(("execute", time.monotonic() - t0))
 


### PR DESCRIPTION
**Problem:** the Job Detail 'Progress' panel sits at `[5/7] Waiting for ComfyUI execution...` for the whole run. The daemon's WebSocket monitor already receives `execution_start` / `executing`(node) / `progress`(step X/Y) / `executed` — it just logged them and never pushed to `segment.progress_log` (the field the UI renders).

**Fix:** `monitor_execution` now takes the `ProgressLog` and pushes live updates:
- node IDs → human stages (`84`=Text encoding, `86`=High-noise pass, `85`=Low-noise pass)
- appends e.g. `High-noise pass · step 5/12 (42%)` at the 25/50/75/100% thresholds (already throttled)

So the panel now shows Text encoding → High-noise pass stepping → Low-noise pass stepping → complete, live. ~a dozen PATCHes/run. API + Job Detail already store/render `progress_log` → no changes needed there.