### PR TITLE
feat: add 'remix' mode — Wan22 Remix (Enhanced Motions), V2.1

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -115,6 +115,19 @@ MODE_PRESETS: dict[str, dict] = {
         "steps_total": 8, "high_noise_steps": 4,
         "shift_high": 5.0, "shift_low": 5.0,
     },
+    # Wan22 Remix (Enhanced Motions) — remix V2.1: motion/pose baked into the weights, so
+    # NO high-expert motion LoRAs are stacked (→ less identity drag on the character LoRA).
+    # Baked-distilled (lightning) like dasiwa → cfg 1, low steps, external lightx2v off.
+    # TODO: confirm values with one test run. V3.0 is a heavier-distilled 27GB upgrade (deferred).
+    "remix": {
+        "unet_high_model": "wan22RemixT2VI2V_i2vHighV21.safetensors",
+        "unet_low_model": "wan22RemixT2VI2V_i2vLowV21.safetensors",
+        "unet_weight_dtype": "fp8_e4m3fn",
+        "lightx2v_strength_high": 0.0, "lightx2v_strength_low": 0.0,
+        "cfg_high": 1.0, "cfg_low": 1.0,
+        "steps_total": 8, "high_noise_steps": 4,
+        "shift_high": 5.0, "shift_low": 5.0,
+    },
 }
 
 


### PR DESCRIPTION
New `remix` generation mode using the **V2.1 remix models** (already on the 3090). Rationale: the remix bakes motion/pose into the weights, so you run it with **no high-expert motion LoRAs stacked** on k3lly2026 → **less identity drag**. Baked-distilled (lightning) so cfg 1 / 8 steps / external lightx2v off (de-distill rewire), mirroring dasiwa. Values want one confirming test. Pairs with the API enum + console dropdown PRs. (V3.0 is a heavier-distilled 27GB upgrade — deferred; V2.1 may retain identity better.)