### PR TITLE
Final Cut: daemon Animate pipeline (workflow, executor, capability gate)

### DIFF
--- a/daemon/comfyui_client.py
+++ b/daemon/comfyui_client.py
@@ -42,6 +42,14 @@ class ComfyUIClient:
             headers["Authorization"] = f"Bearer {self.api_key}"
         self.http = httpx.AsyncClient(base_url=self.base_url, timeout=30, headers=headers)
 
+    async def has_node(self, node_type: str) -> bool:
+        """True if ComfyUI has the given node type registered (capability check)."""
+        try:
+            r = await self.http.get(f"/object_info/{node_type}")
+            return r.status_code == 200
+        except Exception:
+            return False
+
     async def check_health(self) -> bool:
         """Check if ComfyUI is running via GET /system_stats."""
         try:

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -30,7 +30,7 @@ from daemon.motion_analyzer import measure_motion_magnitude
 from daemon.progress import ProgressLog
 from daemon.queue_client import QueueClient
 from daemon.schemas import SegmentClaim, SegmentResult
-from daemon.workflow_builder import build_workflow, build_faceswap_workflow
+from daemon.workflow_builder import build_workflow, build_faceswap_workflow, build_animate_workflow, animate_memory_estimate
 
 logger = logging.getLogger(__name__)
 
@@ -253,6 +253,95 @@ async def _execute_faceswap_reprocess(
         )
 
 
+async def _execute_animate(
+    segment: SegmentClaim,
+    comfyui: ComfyUIClient,
+    queue: QueueClient,
+) -> None:
+    """Final Cut: re-render an existing (finalized) video through Wan 2.2 Animate.
+
+    Driving video = segment.output_path (source's finalized video); character reference =
+    segment.start_image. Mirrors the faceswap-reprocess flow but runs the Animate graph.
+    """
+    logger.info(
+        "=== Final Cut (animate) segment %d (job %s) === mode=%s preset=%s",
+        segment.index, str(segment.job_id)[:8],
+        segment.animate_mode or "mix", segment.animate_preset or "fast",
+    )
+    progress = ProgressLog(segment.id, queue)
+    segment_start = time.monotonic()
+
+    try:
+        if not segment.output_path:
+            raise RuntimeError("No output_path on segment — Final Cut needs the source's finalized video")
+
+        # Step 1: download the driving (source finalized) video + upload to ComfyUI
+        await progress.log("[1/5] Downloading source video...")
+        video_data = await _download_with_retry(
+            lambda: queue.download_file(segment.output_path), "driving_video"
+        )
+        driving_filename = await comfyui.upload_video(video_data, f"finalcut_driving_{segment.id}.mp4")
+
+        # Step 2: resolve the character reference image + ensure LoRA available
+        reference_filename = await _resolve_start_image(segment, comfyui, queue)
+        if not reference_filename:
+            raise RuntimeError("No reference image resolved for Final Cut")
+        if segment.loras:
+            await ensure_loras_available(segment.loras, queue)
+        await progress.log("[2/5] Files ready in ComfyUI")
+
+        # Step 3: memory estimate for the 3090 model_base patch, then build + submit
+        try:
+            with open("/tmp/wanly_estimate", "w") as f:
+                f.write(animate_memory_estimate(segment))
+        except Exception:
+            logger.warning("Could not write /tmp/wanly_estimate (non-fatal)")
+        workflow = build_animate_workflow(segment, driving_filename, reference_filename)
+        prompt_id, client_id = await comfyui.submit_workflow(workflow)
+        await progress.log(f"[3/5] Submitted (prompt_id={prompt_id[:8]})")
+
+        # Step 4: wait (chunked Animate — can be several minutes)
+        await progress.log("[4/5] Waiting for Animate execution...")
+        await comfyui.monitor_execution(prompt_id, client_id, progress)
+
+        # Step 5: download output, extract last frame, upload
+        await progress.log("[5/5] Downloading result and uploading...")
+        history = await comfyui.get_history(prompt_id)
+        video_info = comfyui.find_video_output(history)
+        if not video_info:
+            raise RuntimeError("No video output found in ComfyUI history")
+        result_data = await comfyui.download_output(
+            filename=video_info["filename"],
+            subfolder=video_info.get("subfolder", ""),
+            output_type=video_info.get("type", "output"),
+        )
+        last_frame_data = await _extract_last_frame(result_data)
+        await queue.upload_segment_output(
+            segment.id, result_data, last_frame_data, SegmentResult(status="completed")
+        )
+        logger.info("Final Cut segment %d complete in %.1fs", segment.index, time.monotonic() - segment_start)
+
+    except ComfyUIExecutionError as e:
+        error_msg = f"ComfyUI error: {e}"
+        if e.node_id:
+            error_msg += f" (node {e.node_id} [{e.node_type}])"
+        logger.error(error_msg)
+        if e.traceback:
+            logger.error("Traceback:\n%s", e.traceback)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        logger.exception("Final Cut segment %s failed", segment.id)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+
+
 async def execute_segment(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -261,6 +350,8 @@ async def execute_segment(
     """Execute a single segment end-to-end."""
     if segment.reprocess_type == "faceswap":
         return await _execute_faceswap_reprocess(segment, comfyui, queue)
+    if segment.reprocess_type == "animate":
+        return await _execute_animate(segment, comfyui, queue)
 
     lora_names = ", ".join(l.high_file or l.low_file or "?" for l in (segment.loras or []))
 

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -158,6 +158,7 @@ async def heartbeat_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_
 async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_event, executing_event, drain_event):
     """Poll the queue for segments and execute them one at a time."""
     poll_count = 0
+    animate_cap: list = [None]   # Final Cut (WanAnimateToVideo) capability — checked once when ComfyUI is up
     while not shutdown_event.is_set():
         try:
             await asyncio.wait_for(
@@ -189,8 +190,12 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
             poll_count += 1
             continue
 
+        if animate_cap[0] is None:
+            animate_cap[0] = await comfyui.has_node("WanAnimateToVideo")
+            logger.info("Final Cut (Animate) capability: %s", animate_cap[0])
+
         try:
-            segment = await queue.claim_next(worker_id, friendly_name_ref[0])
+            segment = await queue.claim_next(worker_id, friendly_name_ref[0], supports_animate=bool(animate_cap[0]))
         except Exception as e:
             logger.error("Poll failed: %s", e)
             continue

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -30,11 +30,12 @@ class QueueClient:
             headers["X-API-Key"] = settings.queue_api_key
         self.client = httpx.AsyncClient(base_url=self.base_url, timeout=10, headers=headers)
 
-    async def claim_next(self, worker_id: uuid.UUID, worker_name: str | None = None) -> Optional[SegmentClaim]:
+    async def claim_next(self, worker_id: uuid.UUID, worker_name: str | None = None, supports_animate: bool = False) -> Optional[SegmentClaim]:
         """Claim the next available segment. Returns None if no work available."""
         resp = await self.client.get(
             "/segments/next",
-            params={"worker_id": str(worker_id), "worker_name": worker_name or settings.friendly_name},
+            params={"worker_id": str(worker_id), "worker_name": worker_name or settings.friendly_name,
+                    "supports_animate": str(supports_animate).lower()},
         )
         if not resp.is_success:
             _raise_with_details(resp, "claim_next")

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -42,6 +42,8 @@ class SegmentClaim(BaseModel):
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None
+    animate_mode: Optional[str] = None      # Final Cut: Wan Animate mode (move/mix)
+    animate_preset: Optional[str] = None    # Final Cut: preset (fast/highres)
     width: int
     height: int
     fps: int

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -673,3 +673,129 @@ def build_workflow(
         workflow["96"]["inputs"]["unet_name"],
     )
     return workflow
+
+
+# --- Final Cut / Wan 2.2 Animate -----------------------------------------------
+# Ported from the validated animate.py CLI graph (move/mix + chunk-chaining).
+_ANIMATE_MODEL = "Wan2_2-Animate-14B_fp8_e4m3fn_scaled_KJ.safetensors"
+_ANIMATE_LIGHTX2V = "lightx2v_I2V_14B_480p_cfg_step_distill_rank64_bf16.safetensors"
+_ANIMATE_RELIGHT = "WanAnimate_relight_lora_fp16.safetensors"
+_ANIMATE_PRESET_RES = {
+    "fast":    {"portrait": (480, 832),  "landscape": (832, 480)},
+    "highres": {"portrait": (720, 1280), "landscape": (1280, 720)},
+}
+_ANIMATE_PRESET_STEPS = {"fast": 6, "highres": 8}
+_ANIMATE_NEG = "blurry, distorted, deformed, plastic skin, low quality, watermark, text, extra limbs"
+
+
+def animate_memory_estimate(segment: SegmentClaim) -> str:
+    """Per-run memory-estimate constant for the 3090 model_base patch (/tmp/wanly_estimate)."""
+    preset = (segment.animate_preset or "fast").lower()
+    W, H = _ANIMATE_PRESET_RES.get(preset, _ANIMATE_PRESET_RES["fast"])["portrait"]
+    return "0.015" if (W * H > 480 * 832) else "0.003"
+
+
+def build_animate_workflow(segment: SegmentClaim, driving_filename: str, reference_filename: str) -> dict:
+    """Final Cut: Wan 2.2 Animate re-render of a driving video with a character reference.
+
+    driving_filename / reference_filename are ComfyUI-local (already uploaded). Output dims come
+    from the preset + the driving orientation (source job w/h); chunk count covers the full clip.
+    """
+    mode = (segment.animate_mode or "mix").lower()
+    preset = (segment.animate_preset or "fast").lower()
+    orient = "landscape" if segment.width > segment.height else "portrait"
+    W, H = _ANIMATE_PRESET_RES.get(preset, _ANIMATE_PRESET_RES["fast"])[orient]
+    steps = _ANIMATE_PRESET_STEPS.get(preset, 6)
+    L, OVERLAP = 77, 5
+    target = max(L, int((segment.duration_seconds or 5.0) * 16))
+    stride = L - OVERLAP
+    N = max(1, 1 + -(-max(0, target - L) // stride))   # ceil: chunks to cover the driving clip
+    frame_cap = L + (N - 1) * stride + 4
+
+    char_lora = None
+    for l in (segment.loras or []):
+        f = l.low_file or l.high_file
+        if f:
+            char_lora = (f, l.low_weight or 0.7)
+            break
+
+    wf: dict[str, Any] = {}
+    def n(i, ct, **inp):
+        wf[str(i)] = {"class_type": ct, "inputs": inp}
+
+    n(1, "VHS_LoadVideo", video=driving_filename, force_rate=16.0, custom_width=0, custom_height=0,
+      frame_load_cap=frame_cap, skip_first_frames=0, select_every_nth=1)
+    n(2, "ImageScale", image=["1", 0], upscale_method="bilinear", width=W, height=H, crop="center")
+    n(4, "OnnxDetectionModelLoader", vitpose_model="vitpose-l-wholebody.onnx",
+      yolo_model="yolov10m.onnx", onnx_device="CUDAExecutionProvider")
+    n(5, "PoseAndFaceDetection", model=["4", 0], images=["2", 0], width=W, height=H, face_padding=0)
+    n(6, "DrawViTPose", pose_data=["5", 0], width=W, height=H, retarget_padding=16,
+      body_stick_width=-1, hand_stick_width=-1, draw_head=True)
+    n(7, "LoadImage", image=reference_filename)
+    n(8, "ImageScale", image=["7", 0], upscale_method="bilinear", width=W, height=H, crop="center")
+    n(9, "CLIPVisionLoader", clip_name="clip_vision_h.safetensors")
+    n(10, "CLIPVisionEncode", clip_vision=["9", 0], image=["8", 0], crop="center")
+    n(11, "CLIPLoader", clip_name="umt5_xxl_fp8_e4m3fn_scaled.safetensors", type="wan")
+    n(12, "CLIPTextEncode", clip=["11", 0], text=segment.prompt)
+    n(13, "CLIPTextEncode", clip=["11", 0], text=(segment.negative_prompt or _ANIMATE_NEG))
+    n(14, "VAELoader", vae_name="wan_2.1_vae.safetensors")
+    n(15, "UNETLoader", unet_name=_ANIMATE_MODEL, weight_dtype="default")
+    model = ["15", 0]
+    n(16, "LoraLoaderModelOnly", model=model, lora_name=_ANIMATE_LIGHTX2V, strength_model=1.0)
+    model = ["16", 0]
+    if mode == "mix":
+        n(24, "LoraLoaderModelOnly", model=model, lora_name=_ANIMATE_RELIGHT, strength_model=1.0)
+        model = ["24", 0]
+    if char_lora:
+        n(23, "LoraLoaderModelOnly", model=model, lora_name=char_lora[0], strength_model=char_lora[1])
+        model = ["23", 0]
+    n(17, "ModelSamplingSD3", model=model, shift=8.0)
+
+    mix_bg = mix_mask = None
+    if mode == "mix":
+        n(30, "DownloadAndLoadSAM2Model", model="sam2.1_hiera_base_plus.safetensors",
+          segmentor="video", device="cuda", precision="fp16")
+        n(31, "Sam2Segmentation", sam2_model=["30", 0], image=["2", 0], keep_model_loaded=False, bboxes=["5", 3])
+        n(32, "GrowMaskWithBlur", mask=["31", 0], expand=6, incremental_expandrate=0.0,
+          tapered_corners=True, flip_input=False, blur_radius=3.0, lerp_alpha=1.0, decay_factor=1.0, fill_holes=True)
+        n(35, "BlockifyMask", masks=["32", 0], block_size=32, device="gpu")
+        n(36, "DrawMaskOnImage", image=["2", 0], mask=["35", 0], color="0, 0, 0", device="gpu")
+        mix_bg, mix_mask = ["36", 0], ["35", 0]
+
+    chunk_imgs, prev_decode, prev_offset = [], None, None
+    for ci in range(N):
+        w = 100 + ci * 10
+        anim = dict(positive=["12", 0], negative=["13", 0], vae=["14", 0], width=W, height=H, length=L,
+                    batch_size=1, continue_motion_max_frames=OVERLAP,
+                    clip_vision_output=["10", 0], reference_image=["8", 0],
+                    face_video=["5", 1], pose_video=["6", 0])
+        if mix_bg is not None:
+            anim["background_video"] = mix_bg
+            anim["character_mask"] = mix_mask
+        if ci == 0:
+            anim["video_frame_offset"] = 0
+        else:
+            anim["video_frame_offset"] = prev_offset
+            anim["continue_motion"] = prev_decode
+        n(w, "WanAnimateToVideo", **anim)
+        n(w + 1, "KSampler", model=["17", 0], positive=[str(w), 0], negative=[str(w), 1], latent_image=[str(w), 2],
+          seed=segment.seed, steps=steps, cfg=1.0, sampler_name="euler", scheduler="simple", denoise=1.0)
+        n(w + 2, "TrimVideoLatent", samples=[str(w + 1), 0], trim_amount=[str(w), 3])
+        n(w + 3, "VAEDecode", samples=[str(w + 2), 0], vae=["14", 0])
+        n(w + 4, "ImageFromBatch", image=[str(w + 3), 0], batch_index=[str(w), 4], length=4096)
+        chunk_imgs.append([str(w + 4), 0])
+        prev_decode, prev_offset = [str(w + 3), 0], [str(w), 5]
+
+    if len(chunk_imgs) == 1:
+        final_imgs = chunk_imgs[0]
+    else:
+        acc, cid = chunk_imgs[0], 900
+        for img in chunk_imgs[1:]:
+            n(cid, "ImageBatch", image1=acc, image2=img)
+            acc = [str(cid), 0]
+            cid += 1
+        final_imgs = acc
+
+    n(22, "VHS_VideoCombine", images=final_imgs, frame_rate=16, loop_count=0,
+      filename_prefix=f"finalcut_{segment.id}", format="video/h264-mp4", pingpong=False, save_output=True)
+    return wf


### PR DESCRIPTION
Part of the Final Cut feature. build_animate_workflow ports the validated animate.py graph (move/mix, chunk-chained, preset+orientation sizing, char LoRA). executor _execute_animate branch (reprocess_type=animate; driving=output_path, ref=start_image, /tmp/wanly_estimate). ComfyUIClient.has_node capability check -> claim_next sends supports_animate so only the 3090 claims Final Cut work.