### PR TITLE
Final Cut: fix OOM cascade (offload memory for mix + free VRAM around animate)

### DIFF
--- a/daemon/comfyui_client.py
+++ b/daemon/comfyui_client.py
@@ -50,6 +50,13 @@ class ComfyUIClient:
         except Exception:
             return False
 
+    async def free_memory(self, unload_models: bool = True) -> None:
+        """Free ComfyUI VRAM (unload models + clear cache). Best-effort — avoids OOM cascades."""
+        try:
+            await self.http.post("/free", json={"unload_models": unload_models, "free_memory": True})
+        except Exception as e:
+            logger.warning("ComfyUI /free failed (non-fatal): %s", e)
+
     async def check_health(self) -> bool:
         """Check if ComfyUI is running via GET /system_stats."""
         try:

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -290,7 +290,8 @@ async def _execute_animate(
             await ensure_loras_available(segment.loras, queue)
         await progress.log("[2/5] Files ready in ComfyUI")
 
-        # Step 3: memory estimate for the 3090 model_base patch, then build + submit
+        # Step 3: clear VRAM (avoid OOM from a prior job's residue), set memory estimate, build + submit
+        await comfyui.free_memory()
         try:
             with open("/tmp/wanly_estimate", "w") as f:
                 f.write(animate_memory_estimate(segment))
@@ -322,6 +323,7 @@ async def _execute_animate(
         logger.info("Final Cut segment %d complete in %.1fs", segment.index, time.monotonic() - segment_start)
 
     except ComfyUIExecutionError as e:
+        await comfyui.free_memory()   # release VRAM so an OOM'd animate job can't poison the next job
         error_msg = f"ComfyUI error: {e}"
         if e.node_id:
             error_msg += f" (node {e.node_id} [{e.node_type}])"
@@ -334,6 +336,7 @@ async def _execute_animate(
         )
 
     except Exception as e:
+        await comfyui.free_memory()   # release VRAM on any animate failure
         error_msg = f"{type(e).__name__}: {e}"
         logger.exception("Final Cut segment %s failed", segment.id)
         await queue.update_segment(

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -689,10 +689,14 @@ _ANIMATE_NEG = "blurry, distorted, deformed, plastic skin, low quality, watermar
 
 
 def animate_memory_estimate(segment: SegmentClaim) -> str:
-    """Per-run memory-estimate constant for the 3090 model_base patch (/tmp/wanly_estimate)."""
+    """Per-run memory-estimate constant for the 3090 model_base patch (/tmp/wanly_estimate).
+
+    Mix mode (14B Animate + SAM2 + relight LoRA) and high-res are memory-heavy, so use the
+    offload estimate (0.015) to avoid OOM; plain move/fast fits resident (0.003).
+    """
+    mode = (segment.animate_mode or "mix").lower()
     preset = (segment.animate_preset or "fast").lower()
-    W, H = _ANIMATE_PRESET_RES.get(preset, _ANIMATE_PRESET_RES["fast"])["portrait"]
-    return "0.015" if (W * H > 480 * 832) else "0.003"
+    return "0.015" if (mode == "mix" or preset == "highres") else "0.003"
 
 
 def build_animate_workflow(segment: SegmentClaim, driving_filename: str, reference_filename: str) -> dict:


### PR DESCRIPTION
Diagnosed from 2026-07-05 failures: a mix-mode Final Cut OOM'd on the resident (0.003) memory estimate and poisoned ComfyUI VRAM, cascading OOM into the following jobs (including 2 regular i2v jobs). Fix: mix/highres Final Cut uses offload (0.015); daemon frees ComfyUI VRAM before the animate load and on any animate failure so a heavy/failed Final Cut can't poison the next job.