### PR TITLE
Draft mode safety: offload for high-res draft (prevent OOM cascade)

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -470,9 +470,12 @@ def build_workflow(
     # Per-job memory hint for the 3090's cfg-aware model_base patch (harmless where that
     # patch isn't applied, e.g. RunPod): cfg>1 (expression) → 0.015 so the model offloads
     # to fit the CFG-doubled activation; cfg<=1 (identity/dasiwa) → 0.003 = resident.
+    # Safety: a high-res draft (meant to be a small driver) → offload so it can't OOM/cascade.
     try:
+        _big = segment.width * segment.height > 480 * 832
+        _offload = p["cfg_high"] > 1 or (getattr(segment, "mode", None) == "draft" and _big)
         with open("/tmp/wanly_estimate", "w") as _ef:
-            _ef.write("0.015" if p["cfg_high"] > 1 else "0.003")
+            _ef.write("0.015" if _offload else "0.003")
     except Exception:
         pass
 


### PR DESCRIPTION
Defense-in-depth for the Draft OOM: if a draft job runs at high res (a stale queued job, or a direct API call bypassing the console cap), use the offload memory estimate (0.015) instead of resident (0.003) so it can't OOM and cascade into other jobs. A normal console-capped draft stays resident (fast).