### PR TITLE
DaSiWa mode: 4 steps

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -112,7 +112,7 @@ MODE_PRESETS: dict[str, dict] = {
         "unet_weight_dtype": "fp8_e4m3fn",
         "lightx2v_strength_high": 0.0, "lightx2v_strength_low": 0.0,
         "cfg_high": 1.0, "cfg_low": 1.0,
-        "steps_total": 8, "high_noise_steps": 4,
+        "steps_total": 4, "high_noise_steps": 2,
         "shift_high": 5.0, "shift_low": 5.0,
     },
     # Wan22 Remix (Enhanced Motions) — remix V2.1: motion/pose baked into the weights, so


### PR DESCRIPTION
DaSiWa is a lightspeed-distilled model; drop steps_total 8 -> 4 (high_noise 4 -> 2) for a faster fast pass.