### PR TITLE
Final Cut: Wan Animate → FaceFusion (daemon)

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -67,6 +67,13 @@ class Settings(BaseSettings):
     # sd-scripts LoRA training monitor
     sd_scripts_path: str = "~/projects/sd-scripts"
 
+    # FaceFusion — Final Cut stage-2 face-swap. Runs as a subprocess in its own conda env
+    # (not ComfyUI). Validated recipe is locked in executor._execute_facefusion. Paths are
+    # 3090-specific; override per worker in .env. A worker advertises the `facefusion`
+    # capability only if both of these exist.
+    facefusion_path: str = "/home/david/projects/facefusion"
+    facefusion_python: str = "/home/david/miniconda3/envs/facefusion/bin/python"
+
     # RunPod auto-stop (set by RunPod environment + user config)
     runpod_pod_id: str | None = None
     runpod_api_key: str | None = None

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -17,6 +17,7 @@ import asyncio
 import io
 import logging
 import os
+import shutil
 import tempfile
 import time
 
@@ -24,6 +25,7 @@ import httpx
 from PIL import Image
 
 from daemon.comfyui_client import ComfyUIClient, ComfyUIExecutionError
+from daemon.config import settings
 from daemon.lora_sync import ensure_loras_available
 from daemon.motion_extractor import _augment_prompt_with_motion, extract_motion_keywords
 from daemon.motion_analyzer import measure_motion_magnitude
@@ -345,6 +347,124 @@ async def _execute_animate(
         )
 
 
+def _build_facefusion_command(
+    segment: SegmentClaim, face_path: str, video_path: str, out_path: str
+) -> list[str]:
+    """The validated FaceFusion recipe: identity + expression, holds through head-turns via a
+    loose reference-face-distance, occlusion mask on. face-index picks which face in a
+    multi-person clip; when a face is targeted the distance auto-tightens to isolate it."""
+    face_index = segment.facefusion_face_index or 0
+    distance = segment.facefusion_distance
+    if distance is None:
+        distance = 0.6 if face_index else 1.0
+    return [
+        settings.facefusion_python, "facefusion.py", "headless-run",
+        "-s", face_path, "-t", video_path, "-o", out_path,
+        "--processors", "face_swapper", "face_enhancer",
+        "--face-swapper-model", "inswapper_128", "--face-swapper-pixel-boost", "512x512",
+        "--face-enhancer-model", "gfpgan_1.4",
+        "--face-mask-types", "box", "occlusion",
+        "--face-selector-mode", "reference", "--reference-face-distance", str(distance),
+        "--face-selector-order", "left-right", "--reference-face-position", str(face_index),
+        "--execution-providers", "cuda",
+    ]
+
+
+async def _run_facefusion(cmd: list[str]) -> tuple[int, str]:
+    """Run FaceFusion in its own conda env as a subprocess (cwd = the facefusion install)."""
+    proc = await asyncio.create_subprocess_exec(
+        *cmd, cwd=os.path.expanduser(settings.facefusion_path),
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+    )
+    stdout, _ = await proc.communicate()
+    return proc.returncode, (stdout or b"").decode(errors="replace")
+
+
+async def _execute_facefusion(
+    segment: SegmentClaim,
+    comfyui: ComfyUIClient,
+    queue: QueueClient,
+) -> None:
+    """Final Cut: face-swap a character onto an existing (finalized) video via FaceFusion.
+
+    Driving video = segment.output_path (source's finalized video); reference face =
+    segment.start_image. Runs the validated FaceFusion recipe as a subprocess in its own conda
+    env. GPU serialization is inherent — the segment queue hands the worker one claimed segment
+    at a time, so this blocks like any generation segment; free_memory() first so FaceFusion
+    has the card (ComfyUI reloads lazily afterward).
+    """
+    logger.info(
+        "=== Final Cut (facefusion) segment %d (job %s) === face_index=%d",
+        segment.index, str(segment.job_id)[:8], segment.facefusion_face_index or 0,
+    )
+    progress = ProgressLog(segment.id, queue)
+    segment_start = time.monotonic()
+    tmpdir = tempfile.mkdtemp(prefix=f"finalcut_ff_{segment.id}_")
+
+    try:
+        if not segment.output_path:
+            raise RuntimeError("No output_path — Final Cut needs the source's finalized video")
+        if not segment.start_image:
+            raise RuntimeError("No reference face resolved for Final Cut")
+
+        # Step 1: download the driving (source finalized) video -> local temp
+        await progress.log("[1/5] Downloading source video...")
+        video_data = await _download_with_retry(
+            lambda: queue.download_file(segment.output_path), "driving_video"
+        )
+        video_path = os.path.join(tmpdir, "driving.mp4")
+        with open(video_path, "wb") as f:
+            f.write(video_data)
+
+        # Step 2: download the reference face -> local temp
+        face_data = await _download_with_retry(
+            lambda: queue.download_file(segment.start_image), "reference_face"
+        )
+        _validate_image_data(face_data, "reference_face")
+        face_ext = os.path.splitext(segment.start_image)[1] or ".png"
+        face_path = os.path.join(tmpdir, f"face{face_ext}")
+        with open(face_path, "wb") as f:
+            f.write(face_data)
+        out_path = os.path.join(tmpdir, f"swapped_{segment.id}.mp4")
+        await progress.log("[2/5] Files ready")
+
+        # Step 3: release ComfyUI VRAM so FaceFusion gets the GPU (queue already serializes work)
+        await comfyui.free_memory()
+
+        # Step 4: run FaceFusion (blocking subprocess — holds the worker until done)
+        await progress.log("[3/5] Running FaceFusion swap...")
+        rc, output = await _run_facefusion(
+            _build_facefusion_command(segment, face_path, video_path, out_path)
+        )
+        if rc != 0 or not os.path.exists(out_path):
+            raise RuntimeError(f"FaceFusion failed (rc={rc}): ...{output[-800:]}")
+        await progress.log("[4/5] Swap complete")
+
+        # Step 5: read result -> last frame -> upload
+        await progress.log("[5/5] Uploading result...")
+        with open(out_path, "rb") as f:
+            result_data = f.read()
+        last_frame_data = await _extract_last_frame(result_data)
+        await queue.upload_segment_output(
+            segment.id, result_data, last_frame_data, SegmentResult(status="completed")
+        )
+        logger.info(
+            "Final Cut (facefusion) segment %d complete in %.1fs",
+            segment.index, time.monotonic() - segment_start,
+        )
+
+    except Exception as e:
+        await comfyui.free_memory()   # keep the box clean for the next segment
+        error_msg = f"{type(e).__name__}: {e}"
+        logger.exception("Final Cut (facefusion) segment %s failed", segment.id)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 async def execute_segment(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -353,6 +473,8 @@ async def execute_segment(
     """Execute a single segment end-to-end."""
     if segment.reprocess_type == "faceswap":
         return await _execute_faceswap_reprocess(segment, comfyui, queue)
+    if segment.reprocess_type == "facefusion":
+        return await _execute_facefusion(segment, comfyui, queue)
     if segment.reprocess_type == "animate":
         return await _execute_animate(segment, comfyui, queue)
 

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -159,6 +159,10 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
     """Poll the queue for segments and execute them one at a time."""
     poll_count = 0
     animate_cap: list = [None]   # Final Cut (WanAnimateToVideo) capability — checked once when ComfyUI is up
+    facefusion_cap = os.path.exists(os.path.expanduser(settings.facefusion_python)) and os.path.exists(
+        os.path.join(os.path.expanduser(settings.facefusion_path), "facefusion.py")
+    )   # Final Cut (FaceFusion) capability — the env + entrypoint exist on this worker
+    logger.info("Final Cut (FaceFusion) capability: %s", facefusion_cap)
     while not shutdown_event.is_set():
         try:
             await asyncio.wait_for(
@@ -195,7 +199,10 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
             logger.info("Final Cut (Animate) capability: %s", animate_cap[0])
 
         try:
-            segment = await queue.claim_next(worker_id, friendly_name_ref[0], supports_animate=bool(animate_cap[0]))
+            segment = await queue.claim_next(
+                worker_id, friendly_name_ref[0],
+                supports_animate=bool(animate_cap[0]), supports_facefusion=facefusion_cap,
+            )
         except Exception as e:
             logger.error("Poll failed: %s", e)
             continue

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -30,12 +30,13 @@ class QueueClient:
             headers["X-API-Key"] = settings.queue_api_key
         self.client = httpx.AsyncClient(base_url=self.base_url, timeout=10, headers=headers)
 
-    async def claim_next(self, worker_id: uuid.UUID, worker_name: str | None = None, supports_animate: bool = False) -> Optional[SegmentClaim]:
+    async def claim_next(self, worker_id: uuid.UUID, worker_name: str | None = None, supports_animate: bool = False, supports_facefusion: bool = False) -> Optional[SegmentClaim]:
         """Claim the next available segment. Returns None if no work available."""
         resp = await self.client.get(
             "/segments/next",
             params={"worker_id": str(worker_id), "worker_name": worker_name or settings.friendly_name,
-                    "supports_animate": str(supports_animate).lower()},
+                    "supports_animate": str(supports_animate).lower(),
+                    "supports_facefusion": str(supports_facefusion).lower()},
         )
         if not resp.is_success:
             _raise_with_details(resp, "claim_next")

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -42,8 +42,10 @@ class SegmentClaim(BaseModel):
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None
-    animate_mode: Optional[str] = None      # Final Cut: Wan Animate mode (move/mix)
-    animate_preset: Optional[str] = None    # Final Cut: preset (fast/highres)
+    animate_mode: Optional[str] = None      # Final Cut (legacy Animate): mode (move/mix)
+    animate_preset: Optional[str] = None    # Final Cut (legacy Animate): preset (fast/highres)
+    facefusion_face_index: int = 0          # Final Cut (FaceFusion): which face to swap, left-to-right
+    facefusion_distance: Optional[float] = None  # FaceFusion reference-face-distance; None → auto
     width: int
     height: int
     fps: int


### PR DESCRIPTION
Refactor Final Cut's stage-2 engine from Wan Animate to FaceFusion (daemon half).

**Part of a 3-PR feature** (api + console are the companions) — merge/deploy together.

- `_execute_facefusion`: download driving video + reference face → local temps → `free_memory()` (release ComfyUI VRAM) → run the validated FaceFusion recipe as a subprocess in its own conda env → upload result.
- **Queue-block (the key requirement): inherent.** `execute_segment` runs one claimed segment to completion before the worker claims the next, so a FaceFusion Final Cut serializes on the GPU exactly like a generation segment — no collision.
- `_build_facefusion_command`: locked recipe (inswapper_128 + 512 boost + gfpgan_1.4, reference selector w/ auto distance, box+occlusion mask, left-right face-index).
- `facefusion` capability = env python + `facefusion.py` exist; sent on `claim_next`.
- `SegmentClaim`: `facefusion_face_index`, `facefusion_distance`. reprocess_type `facefusion`.
- Legacy `_execute_animate` left intact alongside.

Config (`facefusion_path`, `facefusion_python`) is 3090-specific; override per worker in `.env`. Not yet deployed.
