### PR TITLE
feat: per-job steps + Lightning bypass (CFG playground)

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -23,6 +23,10 @@ class Settings(BaseSettings):
     lightx2v_strength_low: float = 1.0  # Strength for low noise lightx2v LoRA (community range: 1.0–2.0)
     cfg_high: float = 1.0  # CFG for high noise KSampler (node 86)
     cfg_low: float = 1.0  # CFG for low noise KSampler (node 85)
+    # Sampler schedule (distilled default = 4/2). Per-job override lets you de-distill:
+    # pass lightx2v strength 0 (builder drops the Lightning LoRA) + raise cfg + raise steps.
+    steps_total: int = 4  # total KSamplerAdvanced schedule length (both passes share it)
+    high_noise_steps: int = 2  # boundary: high runs [0, high_noise_steps], low runs [high_noise_steps, steps_total]
     clip_vision_model: str = "clip_vision_h.safetensors"
 
     # PainterLongVideo motion parameters (identity anchoring)

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -42,6 +42,8 @@ class SegmentClaim(BaseModel):
     lightx2v_strength_low: Optional[float] = None
     cfg_high: Optional[float] = None
     cfg_low: Optional[float] = None
+    steps_total: Optional[int] = None       # per-job sampler schedule length (None -> daemon default)
+    high_noise_steps: Optional[int] = None   # high/low split boundary (None -> daemon default)
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -464,6 +464,24 @@ def build_workflow(
     workflow["86"]["inputs"]["cfg"] = segment.cfg_high if segment.cfg_high is not None else settings.cfg_high
     workflow["85"]["inputs"]["cfg"] = segment.cfg_low if segment.cfg_low is not None else settings.cfg_low
 
+    # Sampler step schedule (per-job override). Both KSamplers share the total length; the
+    # boundary splits it: high (86) runs [0, high_noise_steps], low (85) runs [high_noise_steps, total].
+    steps_total = segment.steps_total if segment.steps_total is not None else settings.steps_total
+    high_noise_steps = segment.high_noise_steps if segment.high_noise_steps is not None else settings.high_noise_steps
+    workflow["86"]["inputs"]["steps"] = steps_total
+    workflow["86"]["inputs"]["start_at_step"] = 0
+    workflow["86"]["inputs"]["end_at_step"] = high_noise_steps
+    workflow["85"]["inputs"]["steps"] = steps_total
+    workflow["85"]["inputs"]["start_at_step"] = high_noise_steps
+    workflow["85"]["inputs"]["end_at_step"] = steps_total
+
+    # De-distill bypass: when a lightx2v strength is 0, drop that Lightning LoRA from the graph
+    # (repoint its consumer past it) so the expert runs raw and CFG > 1 does real work.
+    if workflow["101"]["inputs"]["strength_model"] == 0:
+        workflow["104"]["inputs"]["model"] = workflow["101"]["inputs"]["model"]  # high chain skips node 101
+    if workflow["102"]["inputs"]["strength_model"] == 0:
+        workflow["103"]["inputs"]["model"] = workflow["102"]["inputs"]["model"]  # low chain skips node 102
+
     # Negative prompt
     if segment.negative_prompt is not None:
         workflow["89"]["inputs"]["text"] = segment.negative_prompt


### PR DESCRIPTION
Daemon half. When lightx2v strength=0, drop that Lightning LoRA from the graph (rewire consumer past it) so the expert runs raw and CFG>1 works. Wire per-job steps_total + high_noise_steps to KSamplers 86/85. Pairs with api + console PRs (same branch).