### PR TITLE
feat: expose flow_shift (motion lever)

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -27,6 +27,7 @@ class Settings(BaseSettings):
     # pass lightx2v strength 0 (builder drops the Lightning LoRA) + raise cfg + raise steps.
     steps_total: int = 4  # total KSamplerAdvanced schedule length (both passes share it)
     high_noise_steps: int = 2  # boundary: high runs [0, high_noise_steps], low runs [high_noise_steps, steps_total]
+    flow_shift: float = 5.0  # ModelSamplingSD3 schedule shift; higher = more high-noise steps = more motion
     clip_vision_model: str = "clip_vision_h.safetensors"
 
     # PainterLongVideo motion parameters (identity anchoring)

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -44,6 +44,7 @@ class SegmentClaim(BaseModel):
     cfg_low: Optional[float] = None
     steps_total: Optional[int] = None       # per-job sampler schedule length (None -> daemon default)
     high_noise_steps: Optional[int] = None   # high/low split boundary (None -> daemon default)
+    flow_shift: Optional[float] = None       # ModelSamplingSD3 shift (None -> daemon default)
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -475,6 +475,13 @@ def build_workflow(
     workflow["85"]["inputs"]["start_at_step"] = high_noise_steps
     workflow["85"]["inputs"]["end_at_step"] = steps_total
 
+    # Flow-matching schedule shift (per-job). One value on BOTH experts (they share the noise
+    # trajectory; mismatched shifts break the high->low handoff sigma). Higher = more high-noise
+    # steps = more motion; raise when de-distilling to cure the "frozen" look.
+    flow_shift = segment.flow_shift if segment.flow_shift is not None else settings.flow_shift
+    workflow["104"]["inputs"]["shift"] = flow_shift  # high expert ModelSamplingSD3
+    workflow["103"]["inputs"]["shift"] = flow_shift  # low expert ModelSamplingSD3
+
     # De-distill bypass: when a lightx2v strength is 0, drop that Lightning LoRA from the graph
     # (repoint its consumer past it) so the expert runs raw and CFG > 1 does real work.
     if workflow["101"]["inputs"]["strength_model"] == 0:


### PR DESCRIPTION
Per-job flow_shift wired to both ModelSamplingSD3 nodes (single value; shared trajectory). Higher = more high-noise steps = more motion — fixes the de-distilled 'frozen' look. Default 5.0. Pairs with api+console.