### PR TITLE
feat(vace): daemon VACE continuation path (PR 2, default off)

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -30,6 +30,23 @@ class Settings(BaseSettings):
     flow_shift: float = 5.0  # ModelSamplingSD3 schedule shift; higher = more high-noise steps = more motion
     clip_vision_model: str = "clip_vision_h.safetensors"
 
+    # VACE continuation (Fun-VACE modules on the Wan2.2 T2V-A14B base, via WanVideoWrapper).
+    # Validated defaults from the 3090 bench (Lightning 4-step / cfg 1). The T2V base differs
+    # from the I2V unet_* models above; WanVideoTextEncodeCached needs the bf16 .pth T5.
+    vace_t2v_high_model: str = "wan2.2_t2v_high_noise_14B_fp16.safetensors"
+    vace_t2v_low_model: str = "wan2.2_t2v_low_noise_14B_fp16.safetensors"
+    vace_module_high: str = "Wan2_2_Fun_VACE_module_A14B_HIGH_fp8_e4m3fn_scaled_KJ.safetensors"
+    vace_module_low: str = "Wan2_2_Fun_VACE_module_A14B_LOW_fp8_e4m3fn_scaled_KJ.safetensors"
+    vace_lightning_high: str = "Wan2.2-Lightning_T2V-A14B-4steps-lora_HIGH_fp16.safetensors"
+    vace_lightning_low: str = "Wan2.2-Lightning_T2V-A14B-4steps-lora_LOW_fp16.safetensors"
+    vace_t5_model: str = "models_t5_umt5-xxl-enc-bf16.pth"
+    vace_steps: int = 6
+    vace_cfg: float = 1.0
+    vace_boundary: int = 3  # high expert runs [0, boundary], low runs [boundary, end]
+    vace_shift: float = 8.0
+    vace_blocks_to_swap: int = 25
+    vace_lightning: bool = True  # use the 4-step distill LoRAs (fast path)
+
     # PainterLongVideo motion parameters (identity anchoring)
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion
     painter_motion_frames: int = 5  # Range: 1-20, controls motion cycle length

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -14,9 +14,11 @@ On error → report failure to queue
 """
 
 import asyncio
+import glob
 import io
 import logging
 import os
+import shutil
 import tempfile
 import time
 
@@ -30,7 +32,13 @@ from daemon.motion_analyzer import measure_motion_magnitude
 from daemon.progress import ProgressLog
 from daemon.queue_client import QueueClient
 from daemon.schemas import SegmentClaim, SegmentResult
-from daemon.workflow_builder import build_workflow, build_faceswap_workflow
+from daemon.workflow_builder import (
+    GENERATION_FPS,
+    build_workflow,
+    build_faceswap_workflow,
+    build_vace_workflow,
+    vace_num_frames,
+)
 from daemon.config import settings
 
 logger = logging.getLogger(__name__)
@@ -164,6 +172,186 @@ async def _extract_last_frame(video_data: bytes) -> bytes:
                 pass
 
 
+async def _run_ffmpeg(args: list[str]) -> None:
+    """Run ffmpeg (with -y) and raise RuntimeError on failure."""
+    proc = await asyncio.create_subprocess_exec(
+        "ffmpeg", "-y", *args,
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.PIPE,
+    )
+    _, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg failed: {stderr.decode(errors='replace')[-500:]}")
+
+
+async def _build_vace_control(
+    video_data: bytes, keep_n: int, num_frames: int, width: int, height: int
+) -> tuple[bytes, bytes]:
+    """From a previous segment's video, build the VACE control clip (last keep_n frames at
+    GENERATION_FPS + grey pad to num_frames) and the mask (black=keep tail, white=generate).
+    The wrapper's WanVideoVACEEncode does NOT auto-pad, so both must be full num_frames long.
+    Returns (control_mp4_bytes, mask_mp4_bytes)."""
+    tmpdir = tempfile.mkdtemp(prefix="vace_")
+    try:
+        prev = os.path.join(tmpdir, "prev.mp4")
+        with open(prev, "wb") as f:
+            f.write(video_data)
+        frames_dir = os.path.join(tmpdir, "frames")
+        os.makedirs(frames_dir)
+        await _run_ffmpeg(["-i", prev, "-vf", f"fps={GENERATION_FPS},scale={width}:{height}",
+                           os.path.join(frames_dir, "%05d.png")])
+        allf = sorted(glob.glob(os.path.join(frames_dir, "*.png")))
+        if not allf:
+            raise RuntimeError("no frames extracted from previous segment video")
+        keep_n = max(1, min(keep_n, len(allf)))
+        tail_dir = os.path.join(tmpdir, "tail")
+        os.makedirs(tail_dir)
+        for i, src in enumerate(allf[-keep_n:]):
+            shutil.copy(src, os.path.join(tail_dir, f"{i:05d}.png"))
+        pad = max(num_frames - keep_n, 0)
+
+        tail_clip = os.path.join(tmpdir, "tail.mp4")
+        await _run_ffmpeg(["-framerate", str(GENERATION_FPS), "-i", os.path.join(tail_dir, "%05d.png"),
+                           "-c:v", "libx264", "-pix_fmt", "yuv420p", tail_clip])
+        grey_clip = os.path.join(tmpdir, "grey.mp4")
+        await _run_ffmpeg(["-f", "lavfi", "-i", f"color=c=0x808080:s={width}x{height}:r={GENERATION_FPS}",
+                           "-frames:v", str(pad), "-c:v", "libx264", "-pix_fmt", "yuv420p", grey_clip])
+        control = os.path.join(tmpdir, "control.mp4")
+        cc = os.path.join(tmpdir, "cc.txt")
+        with open(cc, "w") as f:
+            f.write(f"file '{tail_clip}'\nfile '{grey_clip}'\n")
+        await _run_ffmpeg(["-f", "concat", "-safe", "0", "-i", cc, "-c:v", "libx264", "-pix_fmt", "yuv420p", control])
+
+        black_clip = os.path.join(tmpdir, "black.mp4")
+        await _run_ffmpeg(["-f", "lavfi", "-i", f"color=c=black:s={width}x{height}:r={GENERATION_FPS}",
+                           "-frames:v", str(keep_n), "-c:v", "libx264", "-pix_fmt", "yuv420p", black_clip])
+        white_clip = os.path.join(tmpdir, "white.mp4")
+        await _run_ffmpeg(["-f", "lavfi", "-i", f"color=c=white:s={width}x{height}:r={GENERATION_FPS}",
+                           "-frames:v", str(pad), "-c:v", "libx264", "-pix_fmt", "yuv420p", white_clip])
+        mask = os.path.join(tmpdir, "mask.mp4")
+        mm = os.path.join(tmpdir, "mm.txt")
+        with open(mm, "w") as f:
+            f.write(f"file '{black_clip}'\nfile '{white_clip}'\n")
+        await _run_ffmpeg(["-f", "concat", "-safe", "0", "-i", mm, "-c:v", "libx264", "-pix_fmt", "yuv420p", mask])
+
+        with open(control, "rb") as f:
+            control_bytes = f.read()
+        with open(mask, "rb") as f:
+            mask_bytes = f.read()
+        return control_bytes, mask_bytes
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+async def _vace_capable(comfyui: ComfyUIClient) -> bool:
+    """True if this worker's ComfyUI has the WanVideoWrapper VACE node + the Fun-VACE modules."""
+    try:
+        resp = await comfyui.http.get("/object_info/WanVideoVACEModelSelect")
+        if resp.status_code != 200:
+            return False
+        info = resp.json().get("WanVideoVACEModelSelect", {})
+        spec = info.get("input", {}).get("required", {}).get("vace_model", [[]])
+        choices = spec[0] if spec and isinstance(spec[0], list) else []
+        return settings.vace_module_high in choices and settings.vace_module_low in choices
+    except Exception as e:
+        logger.warning("VACE capability check failed (%s) — treating as not capable", e)
+        return False
+
+
+async def _execute_vace_continuation(
+    segment: SegmentClaim,
+    comfyui: ComfyUIClient,
+    queue: QueueClient,
+) -> None:
+    """Generate a segment as a VACE video-conditioned continuation of the previous
+    segment's tail (seamless), instead of the traditional single-frame i2v handoff."""
+    logger.info("=== VACE continuation segment %d (job %s) === overlap=%d",
+                segment.index, str(segment.job_id)[:8], segment.vace_overlap_frames)
+    progress = ProgressLog(segment.id, queue)
+    segment_start = time.monotonic()
+    try:
+        if not segment.previous_output_path:
+            raise RuntimeError("VACE continuation requires previous_output_path")
+        if segment.loras:
+            await ensure_loras_available(segment.loras, queue)
+
+        # 1. Download previous segment video (tail source)
+        await progress.log("[1/7] Downloading previous segment video...")
+        prev_data = await _download_with_retry(
+            lambda: queue.download_file(segment.previous_output_path), "prev_video"
+        )
+        await progress.log(f"[1/7] Downloaded ({len(prev_data) / (1024 * 1024):.1f} MB)")
+
+        # 2. Build control (kept tail + grey pad) + mask (keep + generate)
+        await progress.log("[2/7] Building VACE control from tail...")
+        num_frames = vace_num_frames(segment)
+        keep_n = max(1, min(segment.vace_overlap_frames, num_frames - 4))
+        control_data, mask_data = await _build_vace_control(
+            prev_data, keep_n, num_frames, segment.width, segment.height
+        )
+
+        # 3. Reference image (identity anchor): job start image, else prev last frame
+        ref_source = segment.initial_reference_image
+        if ref_source and ref_source.startswith("s3://"):
+            ref_data = await _download_with_retry(
+                lambda: queue.download_file(ref_source), "vace_reference"
+            )
+        else:
+            ref_data = await _extract_last_frame(prev_data)
+
+        # 4. Upload control assets to ComfyUI
+        await progress.log("[3/7] Uploading control assets to ComfyUI...")
+        control_fn = await comfyui.upload_video(control_data, f"vace_control_{segment.id}.mp4")
+        mask_fn = await comfyui.upload_video(mask_data, f"vace_mask_{segment.id}.mp4")
+        ref_fn = await comfyui.upload_image(ref_data, f"vace_ref_{segment.id}.png")
+
+        # 5. Build + submit
+        await progress.log("[4/7] Building VACE workflow...")
+        workflow = build_vace_workflow(segment, control_fn, mask_fn, ref_fn, num_frames)
+        prompt_id, client_id = await comfyui.submit_workflow(workflow)
+        await progress.log(f"[5/7] Submitted (prompt_id={prompt_id[:8]}, {num_frames} frames)")
+
+        # 6. Monitor
+        await progress.log("[6/7] Waiting for VACE execution...")
+        await comfyui.monitor_execution(prompt_id, client_id, progress=progress)
+
+        # 7. Download output, extract last frame, upload
+        await progress.log("[7/7] Downloading result and uploading...")
+        history = await comfyui.get_history(prompt_id)
+        video_info = comfyui.find_video_output(history)
+        if not video_info:
+            raise RuntimeError("No video output found in ComfyUI history")
+        result_data = await comfyui.download_output(
+            filename=video_info["filename"],
+            subfolder=video_info.get("subfolder", ""),
+            output_type=video_info.get("type", "output"),
+        )
+        last_frame_data = await _extract_last_frame(result_data)
+        await queue.upload_segment_output(
+            segment.id, result_data, last_frame_data, SegmentResult(status="completed")
+        )
+        logger.info("VACE continuation segment %d complete in %.1fs",
+                    segment.index, time.monotonic() - segment_start)
+
+    except ComfyUIExecutionError as e:
+        error_msg = f"ComfyUI error: {e}"
+        if e.node_id:
+            error_msg += f" (node {e.node_id} [{e.node_type}])"
+        logger.error(error_msg)
+        if e.traceback:
+            logger.error("Traceback:\n%s", e.traceback)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        logger.exception("VACE continuation segment %s failed", segment.id)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+
+
 async def _execute_faceswap_reprocess(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -262,6 +450,16 @@ async def execute_segment(
     """Execute a single segment end-to-end."""
     if segment.reprocess_type == "faceswap":
         return await _execute_faceswap_reprocess(segment, comfyui, queue)
+
+    # VACE video-conditioned continuation (resolved API-side). Capability-gated: a worker
+    # without the Fun-VACE models/nodes silently falls through to the traditional i2v path.
+    if segment.continuation_mode == "vace":
+        if await _vace_capable(comfyui):
+            return await _execute_vace_continuation(segment, comfyui, queue)
+        logger.info(
+            "Segment %d requested VACE but worker is not VACE-capable — falling back to traditional i2v",
+            segment.index,
+        )
 
     lora_names = ", ".join(l.high_file or l.low_file or "?" for l in (segment.loras or []))
 

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -183,6 +183,25 @@ async def _run_ffmpeg(args: list[str]) -> None:
         raise RuntimeError(f"ffmpeg failed: {stderr.decode(errors='replace')[-500:]}")
 
 
+async def _trim_video_start(video_data: bytes, seconds: float) -> bytes:
+    """Drop the first `seconds` from a video (frame-accurate, re-encoded). Returns bytes."""
+    if seconds <= 0:
+        return video_data
+    tmpdir = tempfile.mkdtemp(prefix="trim_")
+    try:
+        src = os.path.join(tmpdir, "in.mp4")
+        out = os.path.join(tmpdir, "out.mp4")
+        with open(src, "wb") as f:
+            f.write(video_data)
+        # -ss AFTER -i = frame-accurate output seeking.
+        await _run_ffmpeg(["-i", src, "-ss", f"{seconds:.4f}",
+                           "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "15", out])
+        with open(out, "rb") as f:
+            return f.read()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 async def _build_vace_control(
     video_data: bytes, keep_n: int, num_frames: int, width: int, height: int
 ) -> tuple[bytes, bytes]:
@@ -283,8 +302,11 @@ async def _execute_vace_continuation(
 
         # 2. Build control (kept tail + grey pad) + mask (keep + generate)
         await progress.log("[2/7] Building VACE control from tail...")
-        num_frames = vace_num_frames(segment)
-        keep_n = max(1, min(segment.vace_overlap_frames, num_frames - 4))
+        base_frames = vace_num_frames(segment)
+        keep_n = max(1, min(segment.vace_overlap_frames, base_frames - 4))
+        # Generate keep_n extra (reconstructed lead-in) frames, trimmed after decode, so the
+        # segment keeps its intended duration AND butts seamlessly onto the previous one.
+        num_frames = ((base_frames + keep_n - 1) // 4) * 4 + 1
         control_data, mask_data = await _build_vace_control(
             prev_data, keep_n, num_frames, segment.width, segment.height
         )
@@ -325,6 +347,9 @@ async def _execute_vace_continuation(
             subfolder=video_info.get("subfolder", ""),
             output_type=video_info.get("type", "output"),
         )
+        # Trim the reconstructed lead-in tail (keep_n frames @ GENERATION_FPS) so this segment
+        # butts seamlessly onto the previous one — stitch stays a plain concat, no dup tail.
+        result_data = await _trim_video_start(result_data, keep_n / GENERATION_FPS)
         last_frame_data = await _extract_last_frame(result_data)
         await queue.upload_segment_output(
             segment.id, result_data, last_frame_data, SegmentResult(status="completed")

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -48,6 +48,12 @@ class SegmentClaim(BaseModel):
     negative_prompt: Optional[str] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None
+    # VACE continuation (resolved API-side). "vace" => generate this segment as a
+    # video-conditioned continuation of previous_output_path's tail (vace_overlap_frames
+    # kept frames). Daemon falls back to the traditional i2v path if not VACE-capable.
+    continuation_mode: str = "traditional"
+    previous_output_path: Optional[str] = None
+    vace_overlap_frames: int = 12
     width: int
     height: int
     fps: int

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -414,6 +414,132 @@ def build_faceswap_workflow(segment: SegmentClaim, video_filename: str) -> dict:
     return workflow
 
 
+def vace_num_frames(segment: SegmentClaim) -> int:
+    """WAN generation frame count for a VACE segment, rounded to a valid 4n+1."""
+    gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
+    n = max(gen["wan_frames"], 5)
+    return ((n - 1) // 4) * 4 + 1
+
+
+def _build_vace_lora_chains(workflow: dict, segment: SegmentClaim) -> tuple[list | None, list | None]:
+    """Build per-expert WanVideoLoraSelect chains: Lightning distill (optional) + user
+    character/motion LoRAs, chained via prev_lora. Returns (high_ref, low_ref) node refs."""
+    counter = [700]
+
+    def add(lora_name: str, strength: float, prev: list | None) -> list:
+        nid = str(counter[0]); counter[0] += 1
+        inputs = {"lora": lora_name, "strength": float(strength), "merge_loras": True}
+        if prev is not None:
+            inputs["prev_lora"] = prev
+        workflow[nid] = {"class_type": "WanVideoLoraSelect", "inputs": inputs}
+        return [nid, 0]
+
+    high_ref = low_ref = None
+    if settings.vace_lightning:
+        high_ref = add(settings.vace_lightning_high, 1.0, None)
+        low_ref = add(settings.vace_lightning_low, 1.0, None)
+    for lora in (segment.loras or []):
+        if lora.high_file:
+            high_ref = add(lora.high_file, lora.high_weight, high_ref)
+        if lora.low_file:
+            low_ref = add(lora.low_file, lora.low_weight, low_ref)
+    return high_ref, low_ref
+
+
+def build_vace_workflow(
+    segment: SegmentClaim,
+    control_filename: str,
+    mask_filename: str,
+    reference_filename: str,
+    num_frames: int,
+) -> dict:
+    """Fun-VACE (Wan2.2 T2V-A14B) continuation workflow via WanVideoWrapper.
+
+    control_filename = num_frames-long video (kept tail + grey pad); mask_filename =
+    matching mask (black=keep tail, white=generate); reference = identity anchor image.
+    Dual-expert (high/low) T2V base each fed its Fun-VACE module via extra_model, with
+    Lightning + user LoRAs. Output is RIFE-interpolated to the segment's target fps so
+    it stitches with traditional segments. Validated on the 3090 bench.
+    """
+    gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
+    neg = segment.negative_prompt or ""
+    vhs = {"force_rate": 0, "custom_width": 0, "custom_height": 0,
+           "frame_load_cap": 0, "skip_first_frames": 0, "select_every_nth": 1}
+    wf: dict[str, Any] = {}
+
+    # VACE module selectors -> each loader's extra_model
+    wf["501"] = {"class_type": "WanVideoVACEModelSelect", "inputs": {"vace_model": settings.vace_module_high}}
+    wf["502"] = {"class_type": "WanVideoVACEModelSelect", "inputs": {"vace_model": settings.vace_module_low}}
+    wf["503"] = {"class_type": "WanVideoBlockSwap", "inputs": {
+        "blocks_to_swap": settings.vace_blocks_to_swap, "offload_img_emb": False,
+        "offload_txt_emb": False, "vace_blocks_to_swap": 0}}
+
+    high_lora, low_lora = _build_vace_lora_chains(wf, segment)
+
+    high_in = {"model": settings.vace_t2v_high_model, "base_precision": "fp16",
+               "quantization": "fp8_e4m3fn_scaled", "load_device": "offload_device",
+               "attention_mode": "sdpa", "extra_model": ["501", 0], "block_swap_args": ["503", 0]}
+    if high_lora:
+        high_in["lora"] = high_lora
+    wf["510"] = {"class_type": "WanVideoModelLoader", "inputs": high_in}
+
+    low_in = {"model": settings.vace_t2v_low_model, "base_precision": "fp16",
+              "quantization": "fp8_e4m3fn_scaled", "load_device": "offload_device",
+              "attention_mode": "sdpa", "extra_model": ["502", 0], "block_swap_args": ["503", 0]}
+    if low_lora:
+        low_in["lora"] = low_lora
+    wf["511"] = {"class_type": "WanVideoModelLoader", "inputs": low_in}
+
+    wf["520"] = {"class_type": "WanVideoVAELoader", "inputs": {"model_name": settings.vae_model, "precision": "bf16"}}
+    wf["521"] = {"class_type": "WanVideoTextEncodeCached", "inputs": {
+        "model_name": settings.vace_t5_model, "precision": "bf16",
+        "positive_prompt": segment.prompt, "negative_prompt": neg,
+        "quantization": "disabled", "use_disk_cache": False, "device": "gpu"}}
+
+    wf["530"] = {"class_type": "VHS_LoadVideo", "inputs": {"video": control_filename, **vhs}}
+    wf["531"] = {"class_type": "VHS_LoadVideo", "inputs": {"video": mask_filename, **vhs}}
+    wf["532"] = {"class_type": "ImageToMask", "inputs": {"image": ["531", 0], "channel": "red"}}
+    wf["533"] = {"class_type": "LoadImage", "inputs": {"image": reference_filename}}
+
+    wf["540"] = {"class_type": "WanVideoVACEEncode", "inputs": {
+        "vae": ["520", 0], "width": segment.width, "height": segment.height,
+        "num_frames": num_frames, "strength": 1.0, "vace_start_percent": 0.0,
+        "vace_end_percent": 1.0, "input_frames": ["530", 0], "ref_images": ["533", 0],
+        "input_masks": ["532", 0]}}
+
+    steps, cfg, boundary, shift = settings.vace_steps, settings.vace_cfg, settings.vace_boundary, settings.vace_shift
+    wf["550"] = {"class_type": "WanVideoSampler", "inputs": {
+        "model": ["510", 0], "image_embeds": ["540", 0], "text_embeds": ["521", 0],
+        "steps": steps, "cfg": cfg, "shift": shift, "seed": segment.seed, "force_offload": True,
+        "scheduler": "unipc", "riflex_freq_index": 0, "start_step": 0, "end_step": boundary}}
+    wf["551"] = {"class_type": "WanVideoSampler", "inputs": {
+        "model": ["511", 0], "image_embeds": ["540", 0], "text_embeds": ["521", 0],
+        "samples": ["550", 0], "steps": steps, "cfg": cfg, "shift": shift, "seed": segment.seed,
+        "force_offload": True, "scheduler": "unipc", "riflex_freq_index": 0,
+        "start_step": boundary, "end_step": -1}}
+
+    wf["560"] = {"class_type": "WanVideoDecode", "inputs": {
+        "vae": ["520", 0], "samples": ["551", 0], "enable_vae_tiling": False,
+        "tile_x": 272, "tile_y": 272, "tile_stride_x": 144, "tile_stride_y": 128}}
+
+    rife_mult = gen["rife_multiplier"]
+    final_images = ["560", 0]
+    if rife_mult > 1:
+        wf["570"] = {"class_type": "RIFE VFI", "inputs": {
+            "ckpt_name": "rife49.pth", "clear_cache_after_n_frames": 10, "multiplier": rife_mult,
+            "fast_mode": True, "ensemble": True, "scale_factor": 1.0, "dtype": "float16",
+            "torch_compile": False, "batch_size": 1, "frames": ["560", 0]}}
+        final_images = ["570", 0]
+    wf["580"] = {"class_type": "VHS_VideoCombine", "inputs": {
+        "frame_rate": gen["output_fps"], "loop_count": 0, "filename_prefix": "output",
+        "format": "video/h264-mp4", "pix_fmt": "yuv420p", "crf": 15, "save_metadata": True,
+        "trim_to_audio": False, "pingpong": False, "save_output": True, "images": final_images}}
+
+    logger.info("Built VACE continuation workflow (%d nodes, %d frames, rife %dx)",
+                len(wf), num_frames, rife_mult)
+    return wf
+
+
 def build_workflow(
     segment: SegmentClaim,
     start_image_filename: str | None = None,


### PR DESCRIPTION
**PR 2 of 3.** The production VACE generation path, ported from the validated 3090 bench.

- Claim schema gains `continuation_mode`/`previous_output_path`/`vace_overlap_frames`
- Config: Fun-VACE model set + validated sampler defaults (Lightning 4-step / cfg 1 / boundary 3 / shift 8 / block-swap 25)
- `build_vace_workflow`: dual-expert T2V + Fun-VACE modules (via `extra_model`), VACE-encode from control/mask/ref, Lightning + user LoRA chains, **RIFE to the segment's target fps** so it stitches with traditional segments
- Executor: ffmpeg tail→control/mask builder, `_vace_capable` check, `_execute_vace_continuation` (mirrors faceswap-reprocess error handling), capability-gated branch

**Safe by construction:** dormant until the API flag flips AND the worker has the models; any VACE failure fails the one segment (normal retry), non-capable workers silently do traditional. Build sanity-checked (20 nodes, 0 dangling refs, k3lly on low expert). Next: PR 3 (stitch overlap trim).