### PR TITLE
fix(daemon): raise ComfyUI EXECUTION_TIMEOUT to 3600s (720p)

### DIFF
--- a/daemon/comfyui_client.py
+++ b/daemon/comfyui_client.py
@@ -11,7 +11,7 @@ from daemon.config import settings
 
 logger = logging.getLogger(__name__)
 
-EXECUTION_TIMEOUT = 1800  # 30 minutes
+EXECUTION_TIMEOUT = 3600  # 60 minutes (720p is ~4x the pixels of 480p and can exceed 30m)
 PROGRESS_TIMEOUT = 300  # 5 minutes without any progress = stuck
 
 # i2v workflow node id -> human phase name, surfaced to the Job Detail progress log.


### PR DESCRIPTION
720p is ~4x the pixels of 480p and can exceed the old 30-min hard cap — you hit `Execution timed out after 1800s` live. Raises `EXECUTION_TIMEOUT` 1800→3600s (60 min). Separate from the VACE work.