### PR TITLE
fix: move VACE overlap trim from daemon to stitch (removes seam hitch)

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -347,12 +347,16 @@ async def _execute_vace_continuation(
             subfolder=video_info.get("subfolder", ""),
             output_type=video_info.get("type", "output"),
         )
-        # Trim the reconstructed lead-in tail (keep_n frames @ GENERATION_FPS) so this segment
-        # butts seamlessly onto the previous one — stitch stays a plain concat, no dup tail.
-        result_data = await _trim_video_start(result_data, keep_n / GENERATION_FPS)
+        # Do NOT trim the reconstructed lead-in here: those keep_n frames are the smooth
+        # bridge to the previous segment (the generation follows the reconstruction, which
+        # drifts slightly from the previous segment's actual tail — dropping the bridge and
+        # jumping to the first generated frame left a boundary hitch). Instead report the
+        # overlap so stitch trims the *previous* segment's tail, letting this reconstruction
+        # replace it (consecutive frames = seamless).
         last_frame_data = await _extract_last_frame(result_data)
         await queue.upload_segment_output(
-            segment.id, result_data, last_frame_data, SegmentResult(status="completed")
+            segment.id, result_data, last_frame_data,
+            SegmentResult(status="completed", vace_overlap_seconds=keep_n / GENERATION_FPS),
         )
         logger.info("VACE continuation segment %d complete in %.1fs",
                     segment.index, time.monotonic() - segment_start)

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -71,7 +71,10 @@ class QueueClient:
             _raise_with_details(resp, f"upload_segment_output {segment_id}")
         logger.info("Uploaded segment output via API for %s", segment_id)
 
-        if result and (result.motion_keywords or result.motion_magnitude):
+        if result and (
+            result.motion_keywords or result.motion_magnitude
+            or result.vace_overlap_seconds is not None
+        ):
             await self.update_segment(segment_id, result)
 
     async def download_file(self, s3_path: str) -> bytes:

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -70,3 +70,7 @@ class SegmentResult(BaseModel):
     progress_log: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
+    # Set by the VACE continuation path: length (seconds) of the reconstructed lead-in this
+    # segment carries. Stitch trims this much off the *previous* segment's tail so the
+    # reconstruction replaces it seamlessly.
+    vace_overlap_seconds: Optional[float] = None


### PR DESCRIPTION
The daemon trimmed VACE's reconstructed lead-in so the segment would plain-concat onto the previous one. But VACE's generation follows the *reconstruction* (which drifts from the previous segment's actual tail), so jumping to the first generated frame left a boundary hitch — measured as a ~5x frame-diff spike at the seam (11-18 vs ~2-3 within-segment), masked by big motion but obvious in low-motion scenes.

This stops trimming in the daemon and reports `vace_overlap_seconds`; the API stitch trims that off the previous segment's tail instead, letting the reconstruction replace it (consecutive frames = seamless). Paired with wanly-api PR (stitch trim + `segments.vace_overlap_seconds` column + migration 039).