### PR TITLE
feat: AR hologram daemon stage (Tier-0) — chroma matte + packed alpha

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -16,6 +16,7 @@ On error → report failure to queue
 import asyncio
 import glob
 import io
+import json
 import logging
 import os
 import shutil
@@ -23,6 +24,7 @@ import tempfile
 import time
 
 import httpx
+import numpy as np
 from PIL import Image
 
 from daemon.comfyui_client import ComfyUIClient, ComfyUIExecutionError
@@ -40,6 +42,14 @@ from daemon.workflow_builder import (
     vace_num_frames,
 )
 from daemon.config import settings
+from daemon.hologram import (
+    GUARD_PX,
+    build_manifest,
+    chroma_key_despill,
+    edge_extend_color,
+    pack_sbs,
+    union_alpha_bbox,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -471,6 +481,103 @@ async def _execute_faceswap_reprocess(
         )
 
 
+async def _execute_ar_hologram(
+    segment: SegmentClaim,
+    comfyui: ComfyUIClient,
+    queue: QueueClient,
+) -> None:
+    """Matte a finalized clip into a packed color+alpha 'hologram' + manifest + poster.
+
+    Tier-0 (flat/mono), chroma-key only in v1. Pure ffmpeg/numpy/cv2 — no ComfyUI. The
+    source is the job's finalized stitched video (hologram_source_path), NOT this carrier
+    segment's own output.
+    """
+    key_color = segment.hologram_key_color or "0x00b140"
+    subject_height_m = segment.hologram_subject_height_m or 1.70
+    logger.info(
+        "=== AR hologram segment %d (job %s) === key=%s height=%.2fm",
+        segment.index, str(segment.job_id)[:8], key_color, subject_height_m,
+    )
+    progress = ProgressLog(segment.id, queue)
+    t0 = time.monotonic()
+    tmpdir = tempfile.mkdtemp(prefix="holo_")
+    try:
+        if not segment.hologram_source_path:
+            raise RuntimeError("No hologram_source_path — job has no finalized video to source from")
+        fps = float(segment.fps) or 30.0
+
+        await progress.log("[1/6] Downloading source video...")
+        video_data = await _download_with_retry(
+            lambda: queue.download_file(segment.hologram_source_path), "hologram_source"
+        )
+        src = os.path.join(tmpdir, "src.mp4")
+        with open(src, "wb") as f:
+            f.write(video_data)
+
+        await progress.log("[2/6] Extracting frames...")
+        frames_dir = os.path.join(tmpdir, "frames")
+        os.makedirs(frames_dir)
+        await _run_ffmpeg(["-i", src, "-vsync", "0", os.path.join(frames_dir, "%05d.png")])
+        frame_files = sorted(glob.glob(os.path.join(frames_dir, "*.png")))
+        if not frame_files:
+            raise RuntimeError("No frames extracted from source video")
+
+        await progress.log(f"[3/6] Matting {len(frame_files)} frames (chroma-key + despill)...")
+        rgbs: list[np.ndarray] = []
+        alphas: list[np.ndarray] = []
+        for ff in frame_files:
+            arr = np.asarray(Image.open(ff).convert("RGB"))
+            rgb, alpha = chroma_key_despill(arr, key_color)
+            rgbs.append(rgb)
+            alphas.append(alpha)
+
+        await progress.log("[4/6] Cropping + packing color+alpha...")
+        x, y, cw, ch = union_alpha_bbox(alphas)
+        packed_dir = os.path.join(tmpdir, "packed")
+        os.makedirs(packed_dir)
+        packed_w = packed_h = 0
+        for i, (rgb, alpha) in enumerate(zip(rgbs, alphas)):
+            crgb = edge_extend_color(rgb[y:y + ch, x:x + cw], alpha[y:y + ch, x:x + cw])
+            packed = pack_sbs(crgb, alpha[y:y + ch, x:x + cw])
+            if packed_w == 0:
+                packed_h, packed_w = packed.shape[0], packed.shape[1]
+            Image.fromarray(packed).save(os.path.join(packed_dir, f"{i:05d}.png"))
+
+        await progress.log("[5/6] Encoding packed mp4 + manifest + poster...")
+        packed_mp4 = os.path.join(tmpdir, "hologram.mp4")
+        await _run_ffmpeg([
+            "-framerate", f"{fps}", "-i", os.path.join(packed_dir, "%05d.png"),
+            "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "12",
+            "-movflags", "+faststart", packed_mp4,
+        ])
+        with open(packed_mp4, "rb") as f:
+            packed_bytes = f.read()
+
+        # Poster: first frame's cropped subject on straight alpha (transparent PNG).
+        pal = (np.clip(alphas[0][y:y + ch, x:x + cw], 0.0, 1.0) * 255).astype(np.uint8)
+        poster_rgba = np.dstack([rgbs[0][y:y + ch, x:x + cw], pal])
+        poster_buf = io.BytesIO()
+        Image.fromarray(poster_rgba, "RGBA").save(poster_buf, format="PNG")
+        poster_bytes = poster_buf.getvalue()
+
+        manifest = build_manifest(packed_w, packed_h, cw, GUARD_PX, fps, (x, y, cw, ch), subject_height_m)
+        manifest_bytes = json.dumps(manifest).encode("utf-8")
+
+        await progress.log("[6/6] Uploading hologram...")
+        await queue.upload_hologram_output(segment.id, packed_bytes, manifest_bytes, poster_bytes)
+        logger.info("AR hologram segment %d complete in %.1fs", segment.index, time.monotonic() - t0)
+
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        logger.exception("AR hologram segment %s failed", segment.id)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
 async def execute_segment(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -479,6 +586,9 @@ async def execute_segment(
     """Execute a single segment end-to-end."""
     if segment.reprocess_type == "faceswap":
         return await _execute_faceswap_reprocess(segment, comfyui, queue)
+
+    if segment.reprocess_type == "ar_hologram":
+        return await _execute_ar_hologram(segment, comfyui, queue)
 
     # VACE video-conditioned continuation (resolved API-side). Capability-gated: a worker
     # without the Fun-VACE models/nodes silently falls through to the traditional i2v path.

--- a/daemon/hologram.py
+++ b/daemon/hologram.py
@@ -1,0 +1,156 @@
+"""AR hologram (Tier-0) matte + pack helpers.
+
+Pure functions (numpy / cv2 / PIL), no ComfyUI. The daemon's `_execute_ar_hologram`
+orchestrates these over the frames of a finalized clip to produce a packed color+alpha
+mp4 + manifest + transparent poster.
+
+v1 is chroma-key only (green screen). RVM matting for arbitrary backgrounds is a deferred
+drop-in: implement `rvm_matte(frames) -> alphas` and branch in the executor.
+"""
+from __future__ import annotations
+
+import cv2
+import numpy as np
+
+# Green-excess soft-key thresholds (on the 0..1 green-excess scale). Tunable.
+KEY_T_LOW = 0.04   # excess <= this -> fully subject (alpha 1)
+KEY_T_HIGH = 0.24  # excess >= this -> fully background (alpha 0)
+GUARD_PX = 8       # black gutter between color and alpha regions in the packed frame
+
+
+def parse_key_color(key_color: str | None) -> tuple[int, int, int]:
+    """'0x00b140' / '#00b140' / 'green' / 'magenta' -> (r, g, b) 0..255."""
+    if not key_color:
+        return (0, 177, 64)
+    s = key_color.strip().lower()
+    if s == "green":
+        return (0, 177, 64)
+    if s in ("magenta", "pink"):
+        return (177, 0, 177)
+    s = s.replace("0x", "").replace("#", "")
+    try:
+        return (int(s[0:2], 16), int(s[2:4], 16), int(s[4:6], 16))
+    except Exception:
+        return (0, 177, 64)
+
+
+def _excess(f: np.ndarray, key_rgb: tuple[int, int, int]) -> np.ndarray:
+    """Key-channel excess (high on the key background, ~0 on the subject). f is float RGB 0..1."""
+    r, g, b = f[..., 0], f[..., 1], f[..., 2]
+    kr, kg, kb = key_rgb
+    if kg >= kr and kg >= kb:            # green key
+        return g - np.maximum(r, b)
+    return np.minimum(r, b) - g          # magenta / other (key is r+b high, g low)
+
+
+def detect_greenscreen(frame_rgb: np.ndarray, key_color: str = "green", frac: float = 0.6) -> bool:
+    """True if the outer border ring is dominantly the key color (a clean chroma plate)."""
+    h, w = frame_rgb.shape[:2]
+    b = max(2, int(min(h, w) * 0.04))
+    ring = np.concatenate([
+        frame_rgb[:b, :, :].reshape(-1, 3),
+        frame_rgb[-b:, :, :].reshape(-1, 3),
+        frame_rgb[:, :b, :].reshape(-1, 3),
+        frame_rgb[:, -b:, :].reshape(-1, 3),
+    ]).astype(np.float32) / 255.0
+    excess = _excess(ring.reshape(1, -1, 3), parse_key_color(key_color)).reshape(-1)
+    return float((excess > 0.15).mean()) >= frac
+
+
+def chroma_key_despill(frame_rgb: np.ndarray, key_color: str) -> tuple[np.ndarray, np.ndarray]:
+    """Green-excess soft key + despill.
+
+    Returns (despilled RGB uint8, straight alpha float32 0..1). Soft edges (not a hard
+    threshold) are where matte quality is won; despill clamps the key channel toward the
+    other two to kill colored fringing on hair/edges.
+    """
+    key_rgb = parse_key_color(key_color)
+    f = frame_rgb.astype(np.float32) / 255.0
+    r, g, b = f[..., 0], f[..., 1], f[..., 2]
+    excess = _excess(f, key_rgb)
+    alpha = np.clip((KEY_T_HIGH - excess) / (KEY_T_HIGH - KEY_T_LOW), 0.0, 1.0).astype(np.float32)
+
+    kr, kg, kb = key_rgb
+    if kg >= kr and kg >= kb:            # despill green fringe
+        f[..., 1] = np.minimum(g, np.maximum(r, b))
+    else:                               # despill magenta fringe
+        m = g
+        f[..., 0] = np.minimum(r, np.maximum(g, b)) if kr >= kg else r
+        f[..., 2] = np.minimum(b, np.maximum(g, r)) if kb >= kg else b
+        _ = m
+    rgb = (np.clip(f, 0.0, 1.0) * 255).astype(np.uint8)
+    return rgb, alpha
+
+
+def union_alpha_bbox(alphas: list[np.ndarray], thresh: float = 0.5, pad_frac: float = 0.04) -> tuple[int, int, int, int]:
+    """One static crop rect (x, y, w, h) covering the subject across ALL frames.
+
+    A single static crop keeps the textured quad stable in 3D; per-frame crops would make
+    it swim. Padded and snapped to even dimensions for h264.
+    """
+    h, w = alphas[0].shape[:2]
+    x0, y0, x1, y1 = w, h, 0, 0
+    for a in alphas:
+        ys, xs = np.where(a > thresh)
+        if xs.size == 0:
+            continue
+        x0, x1 = min(x0, int(xs.min())), max(x1, int(xs.max()))
+        y0, y1 = min(y0, int(ys.min())), max(y1, int(ys.max()))
+    if x1 <= x0 or y1 <= y0:            # nothing matted — fall back to full even frame
+        return (0, 0, w - (w % 2), h - (h % 2))
+    pad = int(max(h, w) * pad_frac)
+    x0, y0 = max(0, x0 - pad), max(0, y0 - pad)
+    x1, y1 = min(w - 1, x1 + pad), min(h - 1, y1 + pad)
+    cw, ch = (x1 - x0 + 1), (y1 - y0 + 1)
+    cw -= cw % 2
+    ch -= ch % 2
+    return (x0, y0, cw, ch)
+
+
+def edge_extend_color(rgb: np.ndarray, alpha: np.ndarray, radius: int = 6) -> np.ndarray:
+    """Fill the background (alpha<0.5) with edge-extended subject color.
+
+    Straight alpha means the color under alpha=0 is otherwise garbage; extending the
+    subject's edge color outward stops 4:2:0 chroma subsampling from bleeding a hard
+    background color across the matte edge (dark/colored halos). Shader premultiplies later.
+    """
+    bg_mask = (alpha < 0.5).astype(np.uint8) * 255
+    if int(bg_mask.max()) == 0:
+        return rgb
+    bgr = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+    filled = cv2.inpaint(bgr, bg_mask, radius, cv2.INPAINT_TELEA)
+    return cv2.cvtColor(filled, cv2.COLOR_BGR2RGB)
+
+
+def pack_sbs(rgb: np.ndarray, alpha: np.ndarray, guard_px: int = GUARD_PX) -> np.ndarray:
+    """Pack one frame side-by-side: [ color | black guard | alpha-in-luma ]. Even width."""
+    h = rgb.shape[0]
+    a8 = (np.clip(alpha, 0.0, 1.0) * 255).astype(np.uint8)
+    a3 = np.repeat(a8[:, :, None], 3, axis=2)
+    guard = np.zeros((h, guard_px, 3), dtype=np.uint8)
+    packed = np.concatenate([rgb, guard, a3], axis=1)
+    if packed.shape[1] % 2:
+        packed = np.concatenate([packed, np.zeros((h, 1, 3), dtype=np.uint8)], axis=1)
+    return packed
+
+
+def build_manifest(packed_w: int, packed_h: int, color_w: int, guard_px: int, fps: float,
+                   crop_rect: tuple[int, int, int, int], subject_height_m: float) -> dict:
+    """Player manifest. UV rects (top-left origin, normalized) so the shader is resolution-agnostic."""
+    total = float(packed_w)
+    return {
+        "tier": 0,
+        "layout": "sbs_color_alpha",
+        "codec": "h264",
+        "fps": round(float(fps), 3),
+        "video_width": int(packed_w),
+        "video_height": int(packed_h),
+        "region_color_uv": {"x": 0.0, "y": 0.0, "w": color_w / total, "h": 1.0},
+        "region_alpha_uv": {"x": (color_w + guard_px) / total, "y": 0.0, "w": color_w / total, "h": 1.0},
+        "guard_px": int(guard_px),
+        "crop_rect": {"x": int(crop_rect[0]), "y": int(crop_rect[1]), "w": int(crop_rect[2]), "h": int(crop_rect[3])},
+        "subject_px_height": int(crop_rect[3]),
+        "subject_height_m": float(subject_height_m),
+        "premultiplied": False,
+        "alpha_encoding": "luma",
+    }

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -77,6 +77,23 @@ class QueueClient:
         ):
             await self.update_segment(segment_id, result)
 
+    async def upload_hologram_output(
+        self, segment_id: uuid.UUID, video_data: bytes, manifest_data: bytes, poster_data: bytes
+    ) -> None:
+        """Upload AR hologram artifacts (packed color+alpha mp4 + manifest + poster) to the API."""
+        resp = await self.client.post(
+            f"/segments/{segment_id}/hologram_upload",
+            files={
+                "video": ("hologram.mp4", video_data, "video/mp4"),
+                "manifest": ("hologram.json", manifest_data, "application/json"),
+                "poster": ("poster.png", poster_data, "image/png"),
+            },
+            timeout=300,
+        )
+        if not resp.is_success:
+            _raise_with_details(resp, f"upload_hologram_output {segment_id}")
+        logger.info("Uploaded hologram output via API for %s", segment_id)
+
     async def download_file(self, s3_path: str) -> bytes:
         """Download a file from S3 via a presigned URL redirect.
 

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -54,6 +54,10 @@ class SegmentClaim(BaseModel):
     continuation_mode: str = "traditional"
     previous_output_path: Optional[str] = None
     vace_overlap_frames: int = 12
+    # AR hologram (reprocess_type="ar_hologram"): source = the job's finalized stitched video.
+    hologram_source_path: Optional[str] = None
+    hologram_key_color: Optional[str] = None
+    hologram_subject_height_m: Optional[float] = None
     width: int
     height: int
     fps: int


### PR DESCRIPTION
Pairs with wanly-api #109. The daemon half of the personal AR-hologram feature.

New `daemon/hologram.py` (pure numpy/cv2/PIL): green-excess **soft chroma-key + despill**, **static union-bbox crop**, **edge-extended color fill** (cv2 inpaint — stops 4:2:0 bleeding background across the matte edge), **side-by-side pack** `[color | guard | alpha-in-luma]`, and a resolution-agnostic `hologram.json` manifest.

`executor._execute_ar_hologram` (dispatched off `reprocess_type=="ar_hologram"`): downloads the job's finalized stitched video → ffmpeg-extract → matte → crop → pack → h264 yuv420p encode → transparent poster → manifest → `upload_hologram_output`. Straight alpha (shader premultiplies) for fidelity.

RVM matting for arbitrary backgrounds is a stubbed backend seam (deferred). Sanity-tested the matte/pack on a synthetic green frame (alpha bg→0/subject→1, bbox correct, even-width pack, sane manifest UVs).