### PR TITLE
feat: RVM matte backend — auto-fallback for non-green hologram clips

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -47,6 +47,10 @@ class Settings(BaseSettings):
     vace_blocks_to_swap: int = 25
     vace_lightning: bool = True  # use the 4-step distill LoRAs (fast path)
 
+    # AR hologram: Robust Video Matting ONNX model (auto-used when a clip is NOT green-screen).
+    # ~15MB; auto-downloaded on first use if missing. Path is relative to the daemon workdir.
+    rvm_model_path: str = "models/rvm_mobilenetv3_fp32.onnx"
+
     # PainterLongVideo motion parameters (identity anchoring)
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion
     painter_motion_frames: int = 5  # Range: 1-20, controls motion cycle length

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -46,8 +46,11 @@ from daemon.hologram import (
     GUARD_PX,
     build_manifest,
     chroma_key_despill,
+    detect_greenscreen,
     edge_extend_color,
+    ensure_rvm_model,
     pack_sbs,
+    rvm_matte,
     union_alpha_bbox,
 )
 
@@ -522,14 +525,21 @@ async def _execute_ar_hologram(
         if not frame_files:
             raise RuntimeError("No frames extracted from source video")
 
-        await progress.log(f"[3/6] Matting {len(frame_files)} frames (chroma-key + despill)...")
-        rgbs: list[np.ndarray] = []
-        alphas: list[np.ndarray] = []
-        for ff in frame_files:
-            arr = np.asarray(Image.open(ff).convert("RGB"))
-            rgb, alpha = chroma_key_despill(arr, key_color)
-            rgbs.append(rgb)
-            alphas.append(alpha)
+        # Auto-select the matte backend: chroma-key if the clip is on a green screen (cleanest
+        # edges), else Robust Video Matting for an arbitrary background (no green needed).
+        arrs = [np.asarray(Image.open(ff).convert("RGB")) for ff in frame_files]
+        rgbs: list[np.ndarray]
+        alphas: list[np.ndarray]
+        if detect_greenscreen(arrs[0], key_color):
+            await progress.log(f"[3/6] Green screen detected — chroma-key matting {len(arrs)} frames...")
+            rgbs, alphas = [], []
+            for arr in arrs:
+                rgb, alpha = chroma_key_despill(arr, key_color)
+                rgbs.append(rgb)
+                alphas.append(alpha)
+        else:
+            await progress.log(f"[3/6] No green screen — RVM matting {len(arrs)} frames...")
+            rgbs, alphas = rvm_matte(arrs, ensure_rvm_model(settings.rvm_model_path))
 
         await progress.log("[4/6] Cropping + packing color+alpha...")
         x, y, cw, ch = union_alpha_bbox(alphas)

--- a/daemon/hologram.py
+++ b/daemon/hologram.py
@@ -9,6 +9,8 @@ drop-in: implement `rvm_matte(frames) -> alphas` and branch in the executor.
 """
 from __future__ import annotations
 
+import os
+
 import cv2
 import numpy as np
 
@@ -132,6 +134,64 @@ def pack_sbs(rgb: np.ndarray, alpha: np.ndarray, guard_px: int = GUARD_PX) -> np
     if packed.shape[1] % 2:
         packed = np.concatenate([packed, np.zeros((h, 1, 3), dtype=np.uint8)], axis=1)
     return packed
+
+
+RVM_MODEL_URL = (
+    "https://github.com/PeterL1n/RobustVideoMatting/releases/download/v1.0.0/"
+    "rvm_mobilenetv3_fp32.onnx"
+)
+_RVM_SESSION = None
+
+
+def ensure_rvm_model(path: str) -> str:
+    """Return the RVM ONNX model path, downloading it (~15MB) on first use if missing."""
+    if not os.path.exists(path):
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        import urllib.request
+
+        urllib.request.urlretrieve(RVM_MODEL_URL, path)
+    return path
+
+
+def _rvm_session(model_path: str):
+    global _RVM_SESSION
+    if _RVM_SESSION is None:
+        import onnxruntime as ort
+
+        _RVM_SESSION = ort.InferenceSession(model_path, providers=["CPUExecutionProvider"])
+    return _RVM_SESSION
+
+
+def rvm_matte(
+    frames_rgb: list[np.ndarray], model_path: str
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Robust Video Matting (ONNX) — mattes arbitrary backgrounds, no green screen needed.
+
+    Sequential with carried recurrent state (r1..r4) for temporal stability; resetting the
+    state mid-clip causes visible alpha pops. Returns (decontaminated foreground RGB uint8,
+    straight alpha float32 0..1) per frame — same shape as chroma_key_despill so the crop +
+    pack stages are identical.
+    """
+    sess = _rvm_session(model_path)
+    rec: list[np.ndarray] = [np.zeros([1, 1, 1, 1], dtype=np.float32) for _ in range(4)]
+    h, w = frames_rgb[0].shape[:2]
+    ratio = float(np.clip(512.0 / max(h, w), 0.1, 1.0))  # RVM: downsample longer side to ~512px
+    downsample = np.array([ratio], dtype=np.float32)
+    rgbs: list[np.ndarray] = []
+    alphas: list[np.ndarray] = []
+    for frame in frames_rgb:
+        src = (frame.astype(np.float32) / 255.0).transpose(2, 0, 1)[None]  # [1,3,H,W]
+        fgr, pha, *rec = sess.run(
+            ["fgr", "pha", "r1o", "r2o", "r3o", "r4o"],
+            {
+                "src": src,
+                "r1i": rec[0], "r2i": rec[1], "r3i": rec[2], "r4i": rec[3],
+                "downsample_ratio": downsample,
+            },
+        )
+        rgbs.append((np.clip(fgr[0].transpose(1, 2, 0), 0.0, 1.0) * 255).astype(np.uint8))
+        alphas.append(pha[0, 0].astype(np.float32))
+    return rgbs, alphas
 
 
 def build_manifest(packed_w: int, packed_h: int, color_w: int, guard_px: int, fps: float,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 httpx
+numpy
+onnxruntime
 opencv-python-headless
 Pillow
 pydantic-settings


### PR DESCRIPTION
Un-defers the RVM matte backend so holograms work on **any-background clips**, not just green screen (SDXL green turned out to be a fight).

The matte stage auto-selects per clip: `detect_greenscreen(first frame)` → **chroma-key** (cleanest edges) when green, else **Robust Video Matting** (ONNX mobilenetv3, ~15MB) for an arbitrary background. No API/console/schema changes — the daemon decides.

- `rvm_matte()`: onnxruntime, **sequential with carried recurrent state** (r1..r4) for temporal stability; returns decontaminated foreground + straight alpha in the same shape as the chroma path, so crop/pack are unchanged.
- `ensure_rvm_model()` auto-downloads the ONNX on first use.
- 3090 already has onnxruntime 1.27 + the model; **verified the ONNX I/O contract against the real model**.

Deploy: git pull + `pip install -r requirements.txt` (onnxruntime already installed) + restart.