### PR TITLE
feat: concurrent CPU hologram loop (parallel to GPU generation)

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -484,6 +484,47 @@ async def _execute_faceswap_reprocess(
         )
 
 
+def _holo_process_frames_sync(
+    frame_files: list[str], packed_dir: str, key_color: str,
+    subject_height_m: float, rvm_model_path: str, fps: float,
+) -> tuple[str, int, int, bytes, dict]:
+    """CPU-heavy hologram work: load -> matte (chroma/RVM) -> crop -> pack -> poster + manifest.
+
+    Runs in a worker thread (asyncio.to_thread) so the daemon event loop stays free for the GPU
+    loop + heartbeat while a hologram builds. Writes packed frames to packed_dir; returns
+    (matte_mode, packed_w, packed_h, poster_png_bytes, manifest_dict).
+    """
+    arrs = [np.asarray(Image.open(ff).convert("RGB")) for ff in frame_files]
+    if detect_greenscreen(arrs[0], key_color):
+        mode = "chroma"
+        rgbs: list[np.ndarray] = []
+        alphas: list[np.ndarray] = []
+        for arr in arrs:
+            rgb, alpha = chroma_key_despill(arr, key_color)
+            rgbs.append(rgb)
+            alphas.append(alpha)
+    else:
+        mode = "rvm"
+        rgbs, alphas = rvm_matte(arrs, ensure_rvm_model(rvm_model_path))
+
+    x, y, cw, ch = union_alpha_bbox(alphas)
+    packed_w = packed_h = 0
+    for i, (rgb, alpha) in enumerate(zip(rgbs, alphas)):
+        crgb = edge_extend_color(rgb[y:y + ch, x:x + cw], alpha[y:y + ch, x:x + cw])
+        packed = pack_sbs(crgb, alpha[y:y + ch, x:x + cw])
+        if packed_w == 0:
+            packed_h, packed_w = packed.shape[0], packed.shape[1]
+        Image.fromarray(packed).save(os.path.join(packed_dir, f"{i:05d}.png"))
+
+    pal = (np.clip(alphas[0][y:y + ch, x:x + cw], 0.0, 1.0) * 255).astype(np.uint8)
+    poster_rgba = np.dstack([rgbs[0][y:y + ch, x:x + cw], pal])
+    poster_buf = io.BytesIO()
+    Image.fromarray(poster_rgba, "RGBA").save(poster_buf, format="PNG")
+
+    manifest = build_manifest(packed_w, packed_h, cw, GUARD_PX, fps, (x, y, cw, ch), subject_height_m)
+    return mode, packed_w, packed_h, poster_buf.getvalue(), manifest
+
+
 async def _execute_ar_hologram(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -525,37 +566,18 @@ async def _execute_ar_hologram(
         if not frame_files:
             raise RuntimeError("No frames extracted from source video")
 
-        # Auto-select the matte backend: chroma-key if the clip is on a green screen (cleanest
-        # edges), else Robust Video Matting for an arbitrary background (no green needed).
-        arrs = [np.asarray(Image.open(ff).convert("RGB")) for ff in frame_files]
-        rgbs: list[np.ndarray]
-        alphas: list[np.ndarray]
-        if detect_greenscreen(arrs[0], key_color):
-            await progress.log(f"[3/6] Green screen detected — chroma-key matting {len(arrs)} frames...")
-            rgbs, alphas = [], []
-            for arr in arrs:
-                rgb, alpha = chroma_key_despill(arr, key_color)
-                rgbs.append(rgb)
-                alphas.append(alpha)
-        else:
-            await progress.log(f"[3/6] No green screen — RVM matting {len(arrs)} frames...")
-            rgbs, alphas = rvm_matte(arrs, ensure_rvm_model(settings.rvm_model_path))
-
-        await progress.log("[4/6] Cropping + packing color+alpha...")
-        x, y, cw, ch = union_alpha_bbox(alphas)
+        # Heavy CPU work (load -> matte -> crop -> pack -> poster + manifest) runs in a thread so
+        # this hologram track runs concurrently with GPU generation without stalling the event loop.
+        await progress.log(f"[3/6] Matting + cropping + packing {len(frame_files)} frames...")
         packed_dir = os.path.join(tmpdir, "packed")
         os.makedirs(packed_dir)
-        packed_w = packed_h = 0
-        for i, (rgb, alpha) in enumerate(zip(rgbs, alphas)):
-            crgb = edge_extend_color(rgb[y:y + ch, x:x + cw], alpha[y:y + ch, x:x + cw])
-            packed = pack_sbs(crgb, alpha[y:y + ch, x:x + cw])
-            if packed_w == 0:
-                packed_h, packed_w = packed.shape[0], packed.shape[1]
-            Image.fromarray(packed).save(os.path.join(packed_dir, f"{i:05d}.png"))
-            if i and i % 100 == 0:
-                await progress.log(f"[4/6] Packed {i}/{len(rgbs)} frames...")
+        mode, packed_w, packed_h, poster_bytes, manifest = await asyncio.to_thread(
+            _holo_process_frames_sync, frame_files, packed_dir, key_color,
+            subject_height_m, settings.rvm_model_path, fps,
+        )
+        await progress.log(f"[4/6] Matted ({mode}) + packed {len(frame_files)} frames")
 
-        await progress.log("[5/6] Encoding packed mp4 + manifest + poster...")
+        await progress.log("[5/6] Encoding packed mp4...")
         packed_mp4 = os.path.join(tmpdir, "hologram.mp4")
         await _run_ffmpeg([
             "-framerate", f"{fps}", "-i", os.path.join(packed_dir, "%05d.png"),
@@ -564,15 +586,6 @@ async def _execute_ar_hologram(
         ])
         with open(packed_mp4, "rb") as f:
             packed_bytes = f.read()
-
-        # Poster: first frame's cropped subject on straight alpha (transparent PNG).
-        pal = (np.clip(alphas[0][y:y + ch, x:x + cw], 0.0, 1.0) * 255).astype(np.uint8)
-        poster_rgba = np.dstack([rgbs[0][y:y + ch, x:x + cw], pal])
-        poster_buf = io.BytesIO()
-        Image.fromarray(poster_rgba, "RGBA").save(poster_buf, format="PNG")
-        poster_bytes = poster_buf.getvalue()
-
-        manifest = build_manifest(packed_w, packed_h, cw, GUARD_PX, fps, (x, y, cw, ch), subject_height_m)
         manifest_bytes = json.dumps(manifest).encode("utf-8")
 
         await progress.log("[6/6] Uploading hologram...")

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -190,7 +190,7 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
             continue
 
         try:
-            segment = await queue.claim_next(worker_id, friendly_name_ref[0])
+            segment = await queue.claim_next(worker_id, friendly_name_ref[0], kind="gpu")
         except Exception as e:
             logger.error("Poll failed: %s", e)
             continue
@@ -250,6 +250,41 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
                         await queue.update_status(worker_id, "online-idle")
                     except Exception as e:
                         logger.error("Failed to update status to idle: %s", e)
+
+
+async def hologram_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_event):
+    """Poll for CPU-only AR hologram work and run it CONCURRENTLY with GPU generation.
+
+    Holograms never touch ComfyUI/the GPU, so this loop skips the ComfyUI-busy gate and runs
+    alongside job_poll_loop. _execute_ar_hologram offloads its heavy numpy/RVM/ffmpeg work to a
+    thread, keeping the event loop free for the GPU loop + heartbeat.
+    """
+    while not shutdown_event.is_set():
+        try:
+            await asyncio.wait_for(shutdown_event.wait(), timeout=settings.poll_interval)
+        except asyncio.TimeoutError:
+            pass
+        if shutdown_event.is_set():
+            break
+        try:
+            segment = await queue.claim_next(worker_id, friendly_name_ref[0], kind="hologram")
+        except Exception as e:
+            logger.error("Hologram poll failed: %s", e)
+            continue
+        if segment is None:
+            continue
+        try:
+            await execute_segment(segment, comfyui, queue)
+        except Exception as e:
+            logger.exception("Unexpected error executing hologram segment %s", segment.id)
+            try:
+                from daemon.schemas import SegmentResult
+                await queue.update_segment(
+                    segment.id,
+                    SegmentResult(status="failed", error_message=f"{type(e).__name__}: {e}"[:2000]),
+                )
+            except Exception as report_err:
+                logger.error("Failed to report hologram failure: %s", report_err)
 
 
 async def _stop_runpod_pod():
@@ -406,8 +441,11 @@ async def run():
         job_task = asyncio.create_task(
             job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_event, executing_event, drain_event)
         )
+        holo_task = asyncio.create_task(
+            hologram_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_event)
+        )
 
-        await asyncio.gather(heartbeat_task, job_task)
+        await asyncio.gather(heartbeat_task, job_task, holo_task)
     finally:
         # Graceful shutdown: wait for current segment if executing
         if executing_event.is_set():

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -31,12 +31,18 @@ class QueueClient:
             headers["X-API-Key"] = settings.queue_api_key
         self.client = httpx.AsyncClient(base_url=self.base_url, timeout=10, headers=headers)
 
-    async def claim_next(self, worker_id: uuid.UUID, worker_name: str | None = None) -> Optional[SegmentClaim]:
-        """Claim the next available segment. Returns None if no work available."""
-        resp = await self.client.get(
-            "/segments/next",
-            params={"worker_id": str(worker_id), "worker_name": worker_name or settings.friendly_name},
-        )
+    async def claim_next(
+        self, worker_id: uuid.UUID, worker_name: str | None = None, kind: str | None = None
+    ) -> Optional[SegmentClaim]:
+        """Claim the next available segment. Returns None if no work available.
+
+        kind="gpu" claims generations only, kind="hologram" claims CPU-only hologram carriers
+        only (so the two can run concurrently); None claims either.
+        """
+        params = {"worker_id": str(worker_id), "worker_name": worker_name or settings.friendly_name}
+        if kind:
+            params["kind"] = kind
+        resp = await self.client.get("/segments/next", params=params)
         if not resp.is_success:
             _raise_with_details(resp, "claim_next")
         data = resp.json()


### PR DESCRIPTION
The hologram pipeline is CPU-only (RVM `CPUExecutionProvider`, ffmpeg libx264, numpy/cv2) but was blocking the single serial work-slot — waiting behind and blocking GPU generations.

Now two concurrent claim loops:
- `job_poll_loop` claims `kind="gpu"` (generations, gated on ComfyUI-idle)
- new `hologram_poll_loop` claims `kind="hologram"` (no ComfyUI gate)

`_execute_ar_hologram`'s heavy CPU work is refactored into `_holo_process_frames_sync` run via `asyncio.to_thread`, so it can't stall the event loop / GPU loop / heartbeat. A hologram builds **alongside** a running generation. Pairs with wanly-api #114.