### PR TITLE
feat(ar): 2.5d_depth flavor — depth stage + depth-packed frames

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -51,6 +51,16 @@ class Settings(BaseSettings):
     # ~15MB; auto-downloaded on first use if missing. Path is relative to the daemon workdir.
     rvm_model_path: str = "models/rvm_mobilenetv3_fp32.onnx"
 
+    # AR hologram "2.5d_depth" flavor: monocular depth model (Depth Anything V2 small, ONNX).
+    # ~100MB; auto-downloaded on first use. Runs on GPU when onnxruntime-gpu is present, else CPU.
+    depth_model_path: str = "models/depth_anything_v2_vits.onnx"
+    depth_model_url: str = (
+        "https://huggingface.co/onnx-community/depth-anything-v2-small/resolve/main/onnx/model.onnx"
+    )
+    # Relief depth in meters: how far the nearest subject pixels are pushed toward the viewer
+    # in the displaced mesh. Aesthetic knob — tune by eye on the Quest 3.
+    depth_scale_m: float = 0.12
+
     # PainterLongVideo motion parameters (identity anchoring)
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion
     painter_motion_frames: int = 5  # Range: 1-20, controls motion cycle length

--- a/daemon/depth.py
+++ b/daemon/depth.py
@@ -1,0 +1,107 @@
+"""AR hologram Tier-1 (2.5D depth): monocular depth estimation + per-clip normalization.
+
+Pure functions (numpy / cv2 / onnxruntime), no ComfyUI. Used by `_execute_ar_hologram` when
+the carrier's flavor is "2.5d_depth": estimate a relative depth map per frame, then normalize
+the whole clip into a stable 0..255 luma map (bright = near) packed as a third region.
+
+Model: Depth Anything V2 (small), ONNX. Tensor names + input size are read from the loaded
+session so we're robust to export differences. Output is relative inverse-depth where LARGER
+values are NEARER — we keep that convention (bright = near) and let the shader push bright
+vertices toward the viewer.
+"""
+from __future__ import annotations
+
+import os
+
+import cv2
+import numpy as np
+
+# ImageNet normalization (Depth Anything preprocessing).
+_MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
+_STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
+_DEFAULT_INPUT = 518  # Depth Anything V2 default square input
+
+_SESSION = None
+
+
+def ensure_depth_model(path: str, url: str) -> str:
+    """Return the depth ONNX path, downloading it (~100MB) on first use if missing."""
+    if not os.path.exists(path):
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        import urllib.request
+
+        urllib.request.urlretrieve(url, path)
+    return path
+
+
+def _session(model_path: str):
+    global _SESSION
+    if _SESSION is None:
+        import onnxruntime as ort
+
+        # Prefer GPU; onnxruntime silently falls back to CPU when CUDA isn't available.
+        _SESSION = ort.InferenceSession(
+            model_path, providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+        )
+    return _SESSION
+
+
+def _input_size(sess) -> tuple[int, int]:
+    shape = sess.get_inputs()[0].shape  # [N, 3, H, W] — dims may be strings if dynamic
+    h = shape[2] if isinstance(shape[2], int) else _DEFAULT_INPUT
+    w = shape[3] if isinstance(shape[3], int) else _DEFAULT_INPUT
+    return int(h), int(w)
+
+
+def estimate_depth(frame_rgb: np.ndarray, model_path: str) -> np.ndarray:
+    """Relative depth (float32 HxW, larger = nearer) at the frame's native resolution.
+
+    Run on the full frame (scene context) — the caller crops the result to the subject bbox.
+    """
+    sess = _session(model_path)
+    inp = sess.get_inputs()[0]
+    ih, iw = _input_size(sess)
+    H, W = frame_rgb.shape[:2]
+
+    img = cv2.resize(frame_rgb, (iw, ih), interpolation=cv2.INTER_CUBIC).astype(np.float32) / 255.0
+    img = (img - _MEAN) / _STD
+    x = img.transpose(2, 0, 1)[None].astype(np.float32)  # [1,3,ih,iw]
+
+    out = np.asarray(sess.run(None, {inp.name: x})[0]).squeeze()  # -> HxW (model resolution)
+    return cv2.resize(out.astype(np.float32), (W, H), interpolation=cv2.INTER_CUBIC)
+
+
+def normalize_depth_clip(
+    depths: list[np.ndarray],
+    alphas: list[np.ndarray],
+    crop_rect: tuple[int, int, int, int],
+    ema: float = 0.7,
+) -> list[np.ndarray]:
+    """Crop each depth to the subject bbox and normalize the whole clip to uint8 (bright = near).
+
+    Uses one robust per-clip range (2nd/98th percentile over subject pixels, alpha>0.5) so the
+    surface doesn't breathe frame-to-frame, pins background to far (0), and applies a light
+    temporal EMA to damp residual flicker.
+    """
+    x, y, cw, ch = crop_rect
+    cd = [d[y:y + ch, x:x + cw] for d in depths]
+    ca = [a[y:y + ch, x:x + cw] for a in alphas]
+
+    subj = [c[m > 0.5] for c, m in zip(cd, ca) if (m > 0.5).any()]
+    if subj:
+        allv = np.concatenate([s.ravel() for s in subj])
+        lo, hi = float(np.percentile(allv, 2)), float(np.percentile(allv, 98))
+    else:
+        lo, hi = 0.0, 1.0
+    rng = max(hi - lo, 1e-6)
+
+    out: list[np.ndarray] = []
+    prev: np.ndarray | None = None
+    for c, m in zip(cd, ca):
+        n = np.clip((c - lo) / rng, 0.0, 1.0)  # larger raw depth -> brighter -> nearer
+        n = np.where(m > 0.5, n, 0.0)  # background pinned to far/black
+        if prev is not None:
+            n = ema * n + (1.0 - ema) * prev
+        prev = n
+        out.append((n * 255.0).astype(np.uint8))
+    return out

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -50,9 +50,11 @@ from daemon.hologram import (
     edge_extend_color,
     ensure_rvm_model,
     pack_sbs,
+    pack_sbs_depth,
     rvm_matte,
     union_alpha_bbox,
 )
+from daemon.depth import ensure_depth_model, estimate_depth, normalize_depth_clip
 
 logger = logging.getLogger(__name__)
 
@@ -487,12 +489,15 @@ async def _execute_faceswap_reprocess(
 def _holo_process_frames_sync(
     frame_files: list[str], packed_dir: str, key_color: str,
     subject_height_m: float, rvm_model_path: str, fps: float,
+    flavor: str = "2d_matte", depth_model_path: str = "", depth_model_url: str = "",
+    depth_scale_m: float = 0.12,
 ) -> tuple[str, int, int, bytes, dict]:
-    """CPU-heavy hologram work: load -> matte (chroma/RVM) -> crop -> pack -> poster + manifest.
+    """CPU-heavy hologram work: load -> matte (chroma/RVM) -> [depth] -> crop -> pack -> poster + manifest.
 
     Runs in a worker thread (asyncio.to_thread) so the daemon event loop stays free for the GPU
     loop + heartbeat while a hologram builds. Writes packed frames to packed_dir; returns
-    (matte_mode, packed_w, packed_h, poster_png_bytes, manifest_dict).
+    (matte_mode, packed_w, packed_h, poster_png_bytes, manifest_dict). For "2.5d_depth" each frame
+    additionally carries a depth region (bright = near) for the player's displaced mesh.
     """
     arrs = [np.asarray(Image.open(ff).convert("RGB")) for ff in frame_files]
     if detect_greenscreen(arrs[0], key_color):
@@ -508,10 +513,23 @@ def _holo_process_frames_sync(
         rgbs, alphas = rvm_matte(arrs, ensure_rvm_model(rvm_model_path))
 
     x, y, cw, ch = union_alpha_bbox(alphas)
+
+    depth_u8: list[np.ndarray] = []
+    if flavor == "2.5d_depth":
+        mode += "+depth"
+        dpath = ensure_depth_model(depth_model_path, depth_model_url)
+        # Depth on the full frame (scene context); normalize_depth_clip crops to the subject bbox.
+        raw_depths = [estimate_depth(arr, dpath) for arr in arrs]
+        depth_u8 = normalize_depth_clip(raw_depths, alphas, (x, y, cw, ch))
+
     packed_w = packed_h = 0
     for i, (rgb, alpha) in enumerate(zip(rgbs, alphas)):
         crgb = edge_extend_color(rgb[y:y + ch, x:x + cw], alpha[y:y + ch, x:x + cw])
-        packed = pack_sbs(crgb, alpha[y:y + ch, x:x + cw])
+        acrop = alpha[y:y + ch, x:x + cw]
+        if flavor == "2.5d_depth":
+            packed = pack_sbs_depth(crgb, acrop, depth_u8[i])
+        else:
+            packed = pack_sbs(crgb, acrop)
         if packed_w == 0:
             packed_h, packed_w = packed.shape[0], packed.shape[1]
         Image.fromarray(packed).save(os.path.join(packed_dir, f"{i:05d}.png"))
@@ -521,7 +539,10 @@ def _holo_process_frames_sync(
     poster_buf = io.BytesIO()
     Image.fromarray(poster_rgba, "RGBA").save(poster_buf, format="PNG")
 
-    manifest = build_manifest(packed_w, packed_h, cw, GUARD_PX, fps, (x, y, cw, ch), subject_height_m)
+    manifest = build_manifest(
+        packed_w, packed_h, cw, GUARD_PX, fps, (x, y, cw, ch), subject_height_m,
+        flavor=flavor, depth_scale_m=depth_scale_m,
+    )
     return mode, packed_w, packed_h, poster_buf.getvalue(), manifest
 
 
@@ -538,9 +559,10 @@ async def _execute_ar_hologram(
     """
     key_color = segment.hologram_key_color or "0x00b140"
     subject_height_m = segment.hologram_subject_height_m or 1.70
+    flavor = segment.hologram_flavor or "2d_matte"
     logger.info(
-        "=== AR hologram segment %d (job %s) === key=%s height=%.2fm",
-        segment.index, str(segment.job_id)[:8], key_color, subject_height_m,
+        "=== AR hologram segment %d (job %s) === key=%s height=%.2fm flavor=%s",
+        segment.index, str(segment.job_id)[:8], key_color, subject_height_m, flavor,
     )
     progress = ProgressLog(segment.id, queue)
     t0 = time.monotonic()
@@ -574,6 +596,7 @@ async def _execute_ar_hologram(
         mode, packed_w, packed_h, poster_bytes, manifest = await asyncio.to_thread(
             _holo_process_frames_sync, frame_files, packed_dir, key_color,
             subject_height_m, settings.rvm_model_path, fps,
+            flavor, settings.depth_model_path, settings.depth_model_url, settings.depth_scale_m,
         )
         await progress.log(f"[4/6] Matted ({mode}) + packed {len(frame_files)} frames")
 

--- a/daemon/hologram.py
+++ b/daemon/hologram.py
@@ -148,6 +148,21 @@ def pack_sbs(rgb: np.ndarray, alpha: np.ndarray, guard_px: int = GUARD_PX) -> np
     return packed
 
 
+def pack_sbs_depth(
+    rgb: np.ndarray, alpha: np.ndarray, depth_u8: np.ndarray, guard_px: int = GUARD_PX
+) -> np.ndarray:
+    """Pack one frame: [ color | guard | alpha-in-luma | guard | depth-in-luma ]. Even width."""
+    h = rgb.shape[0]
+    a8 = (np.clip(alpha, 0.0, 1.0) * 255).astype(np.uint8)
+    a3 = np.repeat(a8[:, :, None], 3, axis=2)
+    d3 = np.repeat(depth_u8[:, :, None], 3, axis=2)
+    guard = np.zeros((h, guard_px, 3), dtype=np.uint8)
+    packed = np.concatenate([rgb, guard, a3, guard, d3], axis=1)
+    if packed.shape[1] % 2:
+        packed = np.concatenate([packed, np.zeros((h, 1, 3), dtype=np.uint8)], axis=1)
+    return packed
+
+
 RVM_MODEL_URL = (
     "https://github.com/PeterL1n/RobustVideoMatting/releases/download/v1.0.0/"
     "rvm_mobilenetv3_fp32.onnx"
@@ -207,18 +222,25 @@ def rvm_matte(
 
 
 def build_manifest(packed_w: int, packed_h: int, color_w: int, guard_px: int, fps: float,
-                   crop_rect: tuple[int, int, int, int], subject_height_m: float) -> dict:
-    """Player manifest. UV rects (top-left origin, normalized) so the shader is resolution-agnostic."""
+                   crop_rect: tuple[int, int, int, int], subject_height_m: float,
+                   flavor: str = "2d_matte", depth_scale_m: float | None = None) -> dict:
+    """Player manifest. UV rects (top-left origin, normalized) so the shader is resolution-agnostic.
+
+    "2d_matte" packs [color | guard | alpha]; "2.5d_depth" appends [guard | depth] and adds the
+    depth region + relief scale so the player can displace a subdivided mesh (bright = near).
+    """
     total = float(packed_w)
-    return {
-        "tier": 0,
-        "layout": "sbs_color_alpha",
+    cw_uv = color_w / total
+    manifest = {
+        "tier": 1 if flavor == "2.5d_depth" else 0,
+        "flavor": flavor,
+        "layout": "sbs_color_alpha_depth" if flavor == "2.5d_depth" else "sbs_color_alpha",
         "codec": "h264",
         "fps": round(float(fps), 3),
         "video_width": int(packed_w),
         "video_height": int(packed_h),
-        "region_color_uv": {"x": 0.0, "y": 0.0, "w": color_w / total, "h": 1.0},
-        "region_alpha_uv": {"x": (color_w + guard_px) / total, "y": 0.0, "w": color_w / total, "h": 1.0},
+        "region_color_uv": {"x": 0.0, "y": 0.0, "w": cw_uv, "h": 1.0},
+        "region_alpha_uv": {"x": (color_w + guard_px) / total, "y": 0.0, "w": cw_uv, "h": 1.0},
         "guard_px": int(guard_px),
         "crop_rect": {"x": int(crop_rect[0]), "y": int(crop_rect[1]), "w": int(crop_rect[2]), "h": int(crop_rect[3])},
         "subject_px_height": int(crop_rect[3]),
@@ -226,3 +248,11 @@ def build_manifest(packed_w: int, packed_h: int, color_w: int, guard_px: int, fp
         "premultiplied": False,
         "alpha_encoding": "luma",
     }
+    if flavor == "2.5d_depth":
+        manifest["region_depth_uv"] = {
+            "x": (2 * color_w + 2 * guard_px) / total, "y": 0.0, "w": cw_uv, "h": 1.0,
+        }
+        manifest["depth_encoding"] = "disparity_luma"
+        manifest["depth_near_is"] = "bright"
+        manifest["depth_scale_m"] = float(depth_scale_m if depth_scale_m is not None else 0.12)
+    return manifest

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -60,6 +60,7 @@ class SegmentClaim(BaseModel):
     hologram_source_path: Optional[str] = None
     hologram_key_color: Optional[str] = None
     hologram_subject_height_m: Optional[float] = None
+    hologram_flavor: Optional[str] = None  # "2d_matte" (default) or "2.5d_depth"
     width: int
     height: int
     fps: int


### PR DESCRIPTION
Second of 3 PRs for **AR Tier-1 (2.5D depth)** (builds on api #119).

When the carrier flavor is `2.5d_depth`:
- **depth.py** — Depth Anything V2 small (ONNX, auto-downloaded ~100MB; `CUDAExecutionProvider` with CPU fallback). `estimate_depth` per full frame → `normalize_depth_clip` (per-clip 2/98th-percentile range + light temporal EMA, background pinned far, **bright = near**).
- **pack_sbs_depth** — third region: `[color | guard | alpha | guard | depth]`. Verified even width + manifest UVs land exactly on each slice.
- **build_manifest** — adds `region_depth_uv`, `depth_encoding`, `depth_near_is`, `depth_scale_m` (0.12 relief default), `tier:1`, `flavor`.
- executor threads flavor + depth settings through; `2d_matte` path unchanged.

Runs on CPU today (onnxruntime CPU build) — works, just slower; installing onnxruntime-gpu later speeds it up. **Daemon is not auto-deploy** — needs `git pull` + restart on the 3090 after merge. Syntax + import + packing-geometry checks pass.