### PR TITLE
feat(vace): canonical seg0 face-crop identity reference

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -55,6 +55,7 @@ from daemon.hologram import (
     union_alpha_bbox,
 )
 from daemon.depth import ensure_depth_model, estimate_depth, normalize_depth_clip
+from daemon.face_crop import extract_best_face
 
 logger = logging.getLogger(__name__)
 
@@ -326,14 +327,29 @@ async def _execute_vace_continuation(
             prev_data, keep_n, num_frames, segment.width, segment.height
         )
 
-        # 3. Reference image (identity anchor): job start image, else prev last frame
+        # 3. Reference image (identity anchor). Canonical seg0 face crop, persisted on the job and
+        # reused for every downstream segment so identity re-anchors at each cut. On the FIRST
+        # continuation the job has no crop yet (ref_source is the job's start image), so derive it
+        # from seg0 (= prev_data here) and persist it for the segments that follow.
         ref_source = segment.initial_reference_image
-        if ref_source and ref_source.startswith("s3://"):
-            ref_data = await _download_with_retry(
-                lambda: queue.download_file(ref_source), "vace_reference"
-            )
-        else:
-            ref_data = await _extract_last_frame(prev_data)
+        is_persisted_crop = bool(ref_source) and "identity_reference.png" in ref_source
+        ref_data = None
+        if not is_persisted_crop:
+            face_png = await asyncio.to_thread(extract_best_face, prev_data)
+            if face_png:
+                await progress.log("[3/7] Cropped canonical identity face from seg0")
+                try:
+                    await queue.upload_identity_reference(str(segment.job_id), face_png)
+                except Exception:
+                    logger.exception("identity reference upload failed (non-fatal)")
+                ref_data = face_png
+        if ref_data is None:
+            if ref_source and ref_source.startswith("s3://"):
+                ref_data = await _download_with_retry(
+                    lambda: queue.download_file(ref_source), "vace_reference"
+                )
+            else:
+                ref_data = await _extract_last_frame(prev_data)
 
         # 4. Upload control assets to ComfyUI
         await progress.log("[3/7] Uploading control assets to ComfyUI...")

--- a/daemon/face_crop.py
+++ b/daemon/face_crop.py
@@ -1,0 +1,84 @@
+"""Best-face crop from a clip — the canonical VACE identity reference.
+
+Pure/CPU (cv2 Haar + ffmpeg), no ComfyUI. Used to pull one clean, frontal face crop out of
+seg0 so every downstream VACE continuation anchors identity to the *same* face (no drift).
+cv2's bundled Haar frontal detector keeps this dependency-free; if it finds nothing the caller
+falls back to the job's start image.
+"""
+from __future__ import annotations
+
+import glob
+import io
+import os
+import shutil
+import subprocess
+import tempfile
+
+import cv2
+import numpy as np
+from PIL import Image
+
+_CASCADE = None
+
+
+def _cascade():
+    global _CASCADE
+    if _CASCADE is None:
+        _CASCADE = cv2.CascadeClassifier(
+            cv2.data.haarcascades + "haarcascade_frontalface_default.xml"
+        )
+    return _CASCADE
+
+
+def extract_best_face(
+    video_bytes: bytes, pad_frac: float = 0.4, sample_fps: int = 4, max_frames: int = 24
+) -> bytes | None:
+    """Return a padded PNG crop of the best frontal face in the clip, or None if none found.
+
+    Samples frames at `sample_fps`, detects frontal faces, and scores each by area * sqrt(sharpness)
+    (Laplacian variance) so it prefers a large, in-focus, front-facing face. Crops with `pad_frac`
+    headroom around the detection box.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="face_")
+    try:
+        vpath = os.path.join(tmpdir, "v.mp4")
+        with open(vpath, "wb") as f:
+            f.write(video_bytes)
+        frames_dir = os.path.join(tmpdir, "f")
+        os.makedirs(frames_dir)
+        subprocess.run(
+            ["ffmpeg", "-i", vpath, "-vf", f"fps={sample_fps}", "-vsync", "0",
+             os.path.join(frames_dir, "%04d.png")],
+            check=True, capture_output=True,
+        )
+        files = sorted(glob.glob(os.path.join(frames_dir, "*.png")))
+        if len(files) > max_frames:
+            files = files[:: max(1, len(files) // max_frames)][:max_frames]
+
+        cas = _cascade()
+        best_score = -1.0
+        best_crop: np.ndarray | None = None
+        for fp in files:
+            img = cv2.imread(fp)
+            if img is None:
+                continue
+            gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+            faces = cas.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=5, minSize=(64, 64))
+            for (x, y, w, h) in faces:
+                sharp = float(cv2.Laplacian(gray[y:y + h, x:x + w], cv2.CV_64F).var())
+                score = (w * h) * (sharp ** 0.5)
+                if score > best_score:
+                    px, py = int(w * pad_frac), int(h * pad_frac)
+                    x0, y0 = max(0, x - px), max(0, y - py)
+                    x1, y1 = min(img.shape[1], x + w + px), min(img.shape[0], y + h + py)
+                    best_score = score
+                    best_crop = img[y0:y1, x0:x1].copy()
+
+        if best_crop is None:
+            return None
+        rgb = cv2.cvtColor(best_crop, cv2.COLOR_BGR2RGB)
+        buf = io.BytesIO()
+        Image.fromarray(rgb).save(buf, format="PNG")
+        return buf.getvalue()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -100,6 +100,17 @@ class QueueClient:
             _raise_with_details(resp, f"upload_hologram_output {segment_id}")
         logger.info("Uploaded hologram output via API for %s", segment_id)
 
+    async def upload_identity_reference(self, job_id: str, image_data: bytes) -> None:
+        """Upload a job's canonical VACE identity reference (a face crop from seg0)."""
+        resp = await self.client.post(
+            f"/jobs/{job_id}/identity_reference",
+            files={"image": ("identity_reference.png", image_data, "image/png")},
+            timeout=120,
+        )
+        if not resp.is_success:
+            _raise_with_details(resp, f"upload_identity_reference {job_id}")
+        logger.info("Uploaded identity reference via API for job %s", job_id)
+
     async def download_file(self, s3_path: str) -> bytes:
         """Download a file from S3 via a presigned URL redirect.
 


### PR DESCRIPTION
Second of 3 PRs (with api #120). Turns your idea into the pipeline: **crop the best face from seg0, reuse it as the identity reference for every downstream segment.**

- **face_crop.py** — `extract_best_face` (cv2 Haar frontal detector, already in the daemon venv; scores by area × √sharpness, pads the crop; returns None if no face → caller falls back to the start image).
- **executor** — on the first VACE continuation (where the previous tail *is* seg0), derive the crop, persist it via the API, and use it. Downstream segments get it back through the claim's `initial_reference_image` (detected by the `identity_reference.png` URL).
- **queue_client** — `upload_identity_reference` → `POST /jobs/{id}/identity_reference`.

Runs once per job (first continuation), reusing the already-downloaded seg0 video — no extra download. Syntax + graceful no-face fallback verified. **Daemon needs `git pull` + restart on the 3090 after merge.**