### PR TITLE
Foundry Phase 3: smashcut assembler — daemon

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -743,6 +743,75 @@ async def _execute_ar_hologram(
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+async def _generate_black(path: str, duration: float, width: int, height: int, fps: int) -> None:
+    """Generate a black mp4 clip for dip-to-black smashcut transitions."""
+    await _run_ffmpeg([
+        "-f", "lavfi", "-i", f"color=c=black:s={width}x{height}:r={fps}:d={duration}",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p", path,
+    ])
+
+
+async def _execute_smashcut_concat(segment: SegmentClaim, queue: QueueClient) -> None:
+    """Concatenate hand-picked clips (same resolution) into one montage. Pure ffmpeg, no ComfyUI.
+
+    seamless = stream-copy concat (fast, lossless); black = insert black dips + re-encode concat.
+    """
+    paths = segment.smashcut_clip_paths or []
+    black = segment.smashcut_transition == "black"
+    logger.info("=== Smashcut concat %s: %d clips, transition=%s ===",
+                str(segment.id)[:8], len(paths), segment.smashcut_transition)
+    progress = ProgressLog(segment.id, queue)
+    start = time.monotonic()
+    try:
+        if len(paths) < 2:
+            raise RuntimeError("smashcut needs at least 2 clips")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            await progress.log(f"[1/3] Downloading {len(paths)} clips...")
+            local = []
+            for i, p in enumerate(paths):
+                data = await _download_with_retry(lambda p=p: queue.download_file(p), "smashcut_clip")
+                fn = os.path.join(tmp, f"clip_{i:03d}.mp4")
+                with open(fn, "wb") as f:
+                    f.write(data)
+                local.append(fn)
+
+            await progress.log("[2/3] Concatenating...")
+            items = []
+            for i, fn in enumerate(local):
+                items.append(fn)
+                if black and i < len(local) - 1:
+                    bp = os.path.join(tmp, f"black_{i:03d}.mp4")
+                    await _generate_black(bp, 0.4, segment.width, segment.height, segment.fps)
+                    items.append(bp)
+
+            # concat demuxer resolves relative paths against the list file's dir → basenames in tmp.
+            list_path = os.path.join(tmp, "concat.txt")
+            with open(list_path, "w") as f:
+                for fn in items:
+                    f.write(f"file '{os.path.basename(fn)}'\n")
+
+            out = os.path.join(tmp, "smashcut.mp4")
+            if black:
+                await _run_ffmpeg(["-f", "concat", "-safe", "0", "-i", list_path,
+                                   "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18", out])
+            else:
+                await _run_ffmpeg(["-f", "concat", "-safe", "0", "-i", list_path, "-c", "copy", out])
+
+            with open(out, "rb") as f:
+                result = f.read()
+
+            await progress.log("[3/3] Uploading...")
+            await queue.upload_smashcut_output(segment.id, result)
+        logger.info("Smashcut %s complete in %.1fs", str(segment.id)[:8], time.monotonic() - start)
+    except Exception as e:
+        logger.exception("Smashcut concat failed: %s", e)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=str(e)[:2000], progress_log=progress.text),
+        )
+
+
 async def execute_segment(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -754,6 +823,9 @@ async def execute_segment(
 
     if segment.reprocess_type == "ar_hologram":
         return await _execute_ar_hologram(segment, comfyui, queue)
+
+    if segment.reprocess_type == "smashcut_concat":
+        return await _execute_smashcut_concat(segment, queue)
 
     # VACE video-conditioned continuation (resolved API-side). Capability-gated: a worker
     # without the Fun-VACE models/nodes silently falls through to the traditional i2v path.

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -100,6 +100,17 @@ class QueueClient:
             _raise_with_details(resp, f"upload_hologram_output {segment_id}")
         logger.info("Uploaded hologram output via API for %s", segment_id)
 
+    async def upload_smashcut_output(self, segment_id: uuid.UUID, video_data: bytes) -> None:
+        """Upload the concatenated smashcut video; the API creates the container job's Video."""
+        resp = await self.client.post(
+            f"/segments/{segment_id}/smashcut_upload",
+            files={"video": ("smashcut.mp4", video_data, "video/mp4")},
+            timeout=300,
+        )
+        if not resp.is_success:
+            _raise_with_details(resp, f"upload_smashcut_output {segment_id}")
+        logger.info("Uploaded smashcut output via API for %s", segment_id)
+
     async def upload_identity_reference(self, job_id: str, image_data: bytes) -> None:
         """Upload a job's canonical VACE identity reference (a face crop from seg0)."""
         resp = await self.client.post(

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -65,6 +65,9 @@ class SegmentClaim(BaseModel):
     hologram_key_color: Optional[str] = None
     hologram_subject_height_m: Optional[float] = None
     hologram_flavor: Optional[str] = None  # "2d_matte" (default) or "2.5d_depth"
+    # Foundry smashcut (reprocess_type="smashcut_concat"): ordered clip paths + transition.
+    smashcut_clip_paths: Optional[list[str]] = None
+    smashcut_transition: Optional[str] = None
     width: int
     height: int
     fps: int


### PR DESCRIPTION
Daemon side of Foundry smashcut. Pure ffmpeg (no ComfyUI), rides the CPU reprocess track alongside holograms.

- `_execute_smashcut_concat` — download the ordered clips, concat (seamless = stream-copy; dip-to-black = insert `_generate_black` clips + re-encode), upload via `upload_smashcut_output`.
- Dispatch on `reprocess_type==smashcut_concat`; `SegmentClaim` gains the smashcut fields.

Pairs with wanly-api #128. **Deploy (git pull + restart) after the current test run wraps.**