### PR TITLE
Hologram believability: depth quality fixes + per-request relief scale

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -58,8 +58,9 @@ class Settings(BaseSettings):
         "https://huggingface.co/onnx-community/depth-anything-v2-small/resolve/main/onnx/model.onnx"
     )
     # Relief depth in meters: how far the nearest subject pixels are pushed toward the viewer
-    # in the displaced mesh. Aesthetic knob — tune by eye on the Quest 3.
-    depth_scale_m: float = 0.12
+    # in the displaced mesh. Fallback only — the per-request value from the claim
+    # (hologram_depth_scale_m, set in the console dialog) wins when present.
+    depth_scale_m: float = 0.30
 
     # PainterLongVideo motion parameters (identity anchoring)
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion

--- a/daemon/depth.py
+++ b/daemon/depth.py
@@ -21,29 +21,34 @@ _MEAN = np.array([0.485, 0.456, 0.406], dtype=np.float32)
 _STD = np.array([0.229, 0.224, 0.225], dtype=np.float32)
 _DEFAULT_INPUT = 518  # Depth Anything V2 default square input
 
-_SESSION = None
+_SESSIONS: dict[str, object] = {}
 
 
 def ensure_depth_model(path: str, url: str) -> str:
-    """Return the depth ONNX path, downloading it (~100MB) on first use if missing."""
+    """Return the depth ONNX path, downloading it (~100MB) on first use if missing.
+
+    Downloads to a temp name then renames atomically — an interrupted download must not
+    leave a truncated file at `path` (existence is the only cache check).
+    """
     if not os.path.exists(path):
         os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
         import urllib.request
 
-        urllib.request.urlretrieve(url, path)
+        tmp = f"{path}.tmp"
+        urllib.request.urlretrieve(url, tmp)
+        os.replace(tmp, path)
     return path
 
 
 def _session(model_path: str):
-    global _SESSION
-    if _SESSION is None:
+    if model_path not in _SESSIONS:
         import onnxruntime as ort
 
         # Prefer GPU; onnxruntime silently falls back to CPU when CUDA isn't available.
-        _SESSION = ort.InferenceSession(
+        _SESSIONS[model_path] = ort.InferenceSession(
             model_path, providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
         )
-    return _SESSION
+    return _SESSIONS[model_path]
 
 
 def _input_size(sess) -> tuple[int, int]:
@@ -53,21 +58,41 @@ def _input_size(sess) -> tuple[int, int]:
     return int(h), int(w)
 
 
-def estimate_depth(frame_rgb: np.ndarray, model_path: str) -> np.ndarray:
+def estimate_depth(
+    frame_rgb: np.ndarray, model_path: str, alpha: np.ndarray | None = None
+) -> np.ndarray:
     """Relative depth (float32 HxW, larger = nearer) at the frame's native resolution.
 
-    Run on the full frame (scene context) — the caller crops the result to the subject bbox.
+    When `alpha` (the matte) is given, background pixels are replaced with mid-gray before
+    estimation: a flat chroma plate is a degenerate scene for the model and compresses the
+    subject's own disparity range. The frame is letterboxed (not squashed) into the model's
+    square input so subject proportions — the geometry the relief comes from — are preserved.
     """
     sess = _session(model_path)
     inp = sess.get_inputs()[0]
     ih, iw = _input_size(sess)
     H, W = frame_rgb.shape[:2]
 
-    img = cv2.resize(frame_rgb, (iw, ih), interpolation=cv2.INTER_CUBIC).astype(np.float32) / 255.0
+    src = frame_rgb
+    if alpha is not None:
+        src = src.copy()
+        src[alpha <= 0.5] = 128
+
+    scale = min(iw / W, ih / H)
+    rw, rh = max(1, round(W * scale)), max(1, round(H * scale))
+    resized = cv2.resize(src, (rw, rh), interpolation=cv2.INTER_CUBIC)
+    canvas = np.full((ih, iw, 3), 128, dtype=np.uint8)
+    ox, oy = (iw - rw) // 2, (ih - rh) // 2
+    canvas[oy:oy + rh, ox:ox + rw] = resized
+
+    img = canvas.astype(np.float32) / 255.0
     img = (img - _MEAN) / _STD
     x = img.transpose(2, 0, 1)[None].astype(np.float32)  # [1,3,ih,iw]
 
     out = np.asarray(sess.run(None, {inp.name: x})[0]).squeeze()  # -> HxW (model resolution)
+    oh, ow = out.shape[:2]
+    sy, sx = oh / ih, ow / iw  # output may not be at input resolution
+    out = out[int(oy * sy):int(round((oy + rh) * sy)), int(ox * sx):int(round((ox + rw) * sx))]
     return cv2.resize(out.astype(np.float32), (W, H), interpolation=cv2.INTER_CUBIC)
 
 
@@ -99,9 +124,11 @@ def normalize_depth_clip(
     prev: np.ndarray | None = None
     for c, m in zip(cd, ca):
         n = np.clip((c - lo) / rng, 0.0, 1.0)  # larger raw depth -> brighter -> nearer
-        n = np.where(m > 0.5, n, 0.0)  # background pinned to far/black
         if prev is not None:
             n = ema * n + (1.0 - ema) * prev
         prev = n
+        # Pin background AFTER the EMA: pinning first leaks (1-ema) of the previous frame's
+        # subject depth into background pixels, displacing a ghost skirt around motion.
+        n = np.where(m > 0.5, n, 0.0)
         out.append((n * 255.0).astype(np.uint8))
     return out

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -635,8 +635,9 @@ def _holo_process_frames_sync(
     if flavor == "2.5d_depth":
         mode += "+depth"
         dpath = ensure_depth_model(depth_model_path, depth_model_url)
-        # Depth on the full frame (scene context); normalize_depth_clip crops to the subject bbox.
-        raw_depths = [estimate_depth(arr, dpath) for arr in arrs]
+        # Depth on the full frame with the backdrop neutralized via the matte (a flat chroma
+        # plate flattens the model's subject disparity); normalize_depth_clip crops to the bbox.
+        raw_depths = [estimate_depth(arr, dpath, alpha=a) for arr, a in zip(arrs, alphas)]
         depth_u8 = normalize_depth_clip(raw_depths, alphas, (x, y, cw, ch))
 
     packed_w = packed_h = 0
@@ -677,9 +678,10 @@ async def _execute_ar_hologram(
     key_color = segment.hologram_key_color or "0x00b140"
     subject_height_m = segment.hologram_subject_height_m or 1.70
     flavor = segment.hologram_flavor or "2d_matte"
+    depth_scale_m = segment.hologram_depth_scale_m or settings.depth_scale_m
     logger.info(
-        "=== AR hologram segment %d (job %s) === key=%s height=%.2fm flavor=%s",
-        segment.index, str(segment.job_id)[:8], key_color, subject_height_m, flavor,
+        "=== AR hologram segment %d (job %s) === key=%s height=%.2fm flavor=%s depth_scale=%.2fm",
+        segment.index, str(segment.job_id)[:8], key_color, subject_height_m, flavor, depth_scale_m,
     )
     progress = ProgressLog(segment.id, queue)
     t0 = time.monotonic()
@@ -713,15 +715,19 @@ async def _execute_ar_hologram(
         mode, packed_w, packed_h, poster_bytes, manifest = await asyncio.to_thread(
             _holo_process_frames_sync, frame_files, packed_dir, key_color,
             subject_height_m, settings.rvm_model_path, fps,
-            flavor, settings.depth_model_path, settings.depth_model_url, settings.depth_scale_m,
+            flavor, settings.depth_model_path, settings.depth_model_url, depth_scale_m,
         )
         await progress.log(f"[4/6] Matted ({mode}) + packed {len(frame_files)} frames")
 
         await progress.log("[5/6] Encoding packed mp4...")
         packed_mp4 = os.path.join(tmpdir, "hologram.mp4")
+        # Explicit limited-range + bt709 tags: untagged output makes some decoders (Quest
+        # included) guess the range, which crushes/clips the depth + alpha luma regions.
         await _run_ffmpeg([
             "-framerate", f"{fps}", "-i", os.path.join(packed_dir, "%05d.png"),
             "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "12",
+            "-color_range", "tv", "-colorspace", "bt709",
+            "-color_primaries", "bt709", "-color_trc", "bt709",
             "-movflags", "+faststart", packed_mp4,
         ])
         with open(packed_mp4, "rb") as f:

--- a/daemon/hologram.py
+++ b/daemon/hologram.py
@@ -254,5 +254,5 @@ def build_manifest(packed_w: int, packed_h: int, color_w: int, guard_px: int, fp
         }
         manifest["depth_encoding"] = "disparity_luma"
         manifest["depth_near_is"] = "bright"
-        manifest["depth_scale_m"] = float(depth_scale_m if depth_scale_m is not None else 0.12)
+        manifest["depth_scale_m"] = float(depth_scale_m if depth_scale_m is not None else 0.30)
     return manifest

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -65,6 +65,7 @@ class SegmentClaim(BaseModel):
     hologram_key_color: Optional[str] = None
     hologram_subject_height_m: Optional[float] = None
     hologram_flavor: Optional[str] = None  # "2d_matte" (default) or "2.5d_depth"
+    hologram_depth_scale_m: Optional[float] = None  # relief depth override (2.5d only)
     # Foundry smashcut (reprocess_type="smashcut_concat"): ordered clip paths + transition.
     smashcut_clip_paths: Optional[list[str]] = None
     smashcut_transition: Optional[str] = None


### PR DESCRIPTION
Part of the AR hologram believability pass (audit 2026-07-27; sibling PRs in wanly-api + wanly-console).

- Accept `hologram_depth_scale_m` from the claim (new console dialog knob, api#130); config `depth_scale_m` becomes the fallback and its default rises 0.12 → 0.30 (0.12 of relief on a 1.7m figure was below the perceptual floor).
- Depth estimation quality: mask the chroma plate to mid-gray via the matte before running Depth Anything (flat colored wall = degenerate scene that flattens subject disparity), and letterbox into the 518² input instead of squashing aspect.
- Temporal EMA now runs BEFORE the background far-pin — the old order leaked (1-ema) of the previous frame's subject depth into background pixels, displacing ghost skirts around motion.
- Atomic model download (tmp + `os.replace`) and per-path session cache.
- Packed mp4 gets explicit `tv`-range bt709 tags so the Quest decoder doesn't guess the range and crush the depth/alpha luma.

Deploy: NOT auto — needs `git pull` + service restart on 3090.