### PR TITLE
feat(lynx): identity-preserving Wan2.1 T2V engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,7 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Test/coverage artifacts
+.coverage
+.pytest_cache/

--- a/BUILD_wanly-lynx-engine.md
+++ b/BUILD_wanly-lynx-engine.md
@@ -1,0 +1,281 @@
+# BUILD: wanly Lynx identity-preserving engine
+
+Status: **POC, RunPod-only.** Graph builder, model staging, API plumbing and identity QA
+are implemented and unit-tested. Nothing has been generated yet — every VRAM and
+similarity number below is marked either MEASURED or UNMEASURED, and the calibration
+matrix is not yet run.
+
+---
+
+## 1. What Lynx is, and why we want it
+
+Lynx (ByteDance, Apache 2.0) runs on **Wan 2.1 T2V-14B** and adds two adapters:
+
+| Adapter | Mechanism | What it controls |
+|---|---|---|
+| **ID-adapter** (`ip`) | ArcFace embedding of a 112×112 aligned face crop → Perceiver resampler → identity tokens | *Who the face is.* Too high tends to freeze expression. |
+| **Ref-adapter** (`ref`) | Dense VAE features of a wider 256px crop, cross-attended in the DiT blocks | *Fine appearance* — skin, hair, lighting. Too high drags the reference's pose and lighting in. |
+
+The important difference from a character LoRA: **identity is re-asserted at every denoising
+step**, rather than baked into the weights once. That is why this is worth trying after the
+identity-drift audit — the failure mode there was that identity conditioning got out-weighted
+as the denoise progressed.
+
+**This is a T2V model conditioned on a subject image, not first-frame i2v.** The subject
+never appears as frame 0. Parameters are named `subject_image`, never `start_frame`.
+
+---
+
+## 2. Graph topology
+
+Node IDs use the `6xx` block (VACE owns `5xx`, LoRA chains `7xx`), built by
+`build_lynx_workflow` in `daemon/workflow_builder.py`.
+
+```
+                    630 LoadImage (subject)
+                             │
+                    631 LynxInsightFaceCrop
+                     ┌───────┴────────┐
+              out 0 (112px)      out 1 (256px)
+              ArcFace crop        ref crop
+                     │                │
+632 LoadLynxResampler│                │
+        └──► 633 LynxEncodeFaceIP     │
+                     │ (LYNXIP)       │
+601 ExtraModelSelect (ip layers)      │
+        └──► 602 ExtraModelSelect (ref layers, prev_model=601)
+                     │                │
+600 WanVideoBlockSwap│                │        640 WanVideoEmptyEmbeds (w, h, frames)
+700+ LoRA chain      │                │                │
+        └──► 610 WanVideoModelLoader  │                │
+                     │                └──► 641 WanVideoAddLynxEmbeds ◄── 620 VAE
+                     │                          ▲               ◄── 622 ref text embed
+                     │                          │
+                     └──────► 650 WanVideoSampler ◄── 621 main text embed
+                                      │
+                              660 WanVideoDecode
+                                      │
+                          [670 RIFE VFI]  (only when target fps > 15)
+                                      │
+                              680 VHS_VideoCombine
+```
+
+Three things here are easy to get wrong:
+
+1. **Both adapters reach the model through one chained `extra_model` list.** `602` chains
+   onto `601` via `prev_model`, and only the tail (`602`) is wired to the loader. Wiring
+   both separately loads only one.
+2. **The ref path needs its own text embed and the VAE.** `WanVideoAddLynxEmbeds` raises
+   `ValueError` if `ref_image` is supplied without `ref_text_embed`. ByteDance hardcode the
+   prompt as `"image of a face"`; it is `lynx_ref_prompt` in settings. This is a *second*
+   `WanVideoTextEncodeCached` (node 622), separate from the main prompt (621).
+3. **`ref_blocks_to_use` is omitted when empty**, not passed as `""`. It is declared
+   `forceInput`, and the node already treats absent as "all blocks".
+
+Both text encodes use `WanVideoTextEncodeCached` with `device: gpu` and
+`use_disk_cache: False` — the same offload handling the VACE path uses, because umt5-xxl
+residency has OOM'd this box before.
+
+---
+
+## 3. Models
+
+All Lynx files live in `models/diffusion_models/` — both `LoadLynxResampler` and
+`WanVideoExtraModelSelect` read from that folder, regardless of what the file is.
+
+| Setting | File | Size | Purpose |
+|---|---|---|---|
+| `lynx_t2v_model` | `Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors` | 14.5 GB | Base |
+| `lynx_ref_layers` | `Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors` | 4.2 GB | Ref-adapter |
+| `lynx_ip_layers` | `Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors` | 0.84 GB | ID-adapter (**default**) |
+| `lynx_resampler` | `lynx_lite_resampler_fp32.safetensors` | 0.33 GB | Resampler (**default**) |
+| — | `Wan2_1-T2V-14B-Lynx_full_ip_layers_fp16.safetensors` | 4.2 GB | ID-adapter (A/B arm) |
+| — | `lynx_full_resampler_fp32.safetensors` | 0.34 GB | Resampler (A/B arm) |
+| `lynx_distill_lora` | `lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors` | 0.63 GB | cfg-step distill |
+
+Total **25 GB**, plus the shared `models_t5_umt5-xxl-enc-bf16.pth` (11 GB) and
+`wan_2.1_vae.safetensors`.
+
+### Why Kijai's repacks, not `Wan-AI` / `ByteDance/lynx`
+
+The original task named the upstream repos. Those ship sharded diffusers-format weights;
+WanVideoWrapper's loaders want a single file. Kijai publishes exactly that, already in our
+layout, and his `_scaled_KJ` fp8 quant is the same family as our `Wan2_2-Animate-14B` model.
+Using upstream would mean a conversion step for no benefit.
+
+### The `lite` vs `full` ip trap
+
+The task said to skip `lynx_lite`. **Kijai's own workflow note says the opposite:**
+
+> "Original implementation uses full ip layers with full ref layers, I don't know if
+> there's some mistake in my implementation as the full ip adapter seems very weak, and
+> using lite ip instead seems better"
+
+His shipped reference workflow runs **lite ip + full ref**, which is why that is our
+default. Both arms are staged so this is settled by measurement rather than by either
+model card.
+
+**The ip layers and the resampler are a matched pair** — the resampler's `proj_out`
+dimension must match the ip layers it feeds. A mismatched pair *loads without raising* and
+produces garbage identity, so `_validate_lynx` rejects it up front. Swap
+`lynx_ip_layers` and `lynx_resampler` together, always.
+
+### Face models fetched at runtime
+
+Two models are downloaded lazily on first use, both outside `/workspace`:
+
+- **facexlib ArcFace IR-SE50** (`recognition_arcface_ir_se50.pth`, from GitHub releases) →
+  `custom_nodes/ComfyUI-WanVideoWrapper/lynx/face/facexlib/weights/`. This is what Lynx
+  actually conditions identity on.
+- **insightface `buffalo_l`** → `~/.insightface/models/`. Used only for the 5-point
+  landmarks that drive the crop — and separately by our identity QA.
+
+`download_models.sh` pre-stages both, so a pod boot does not depend on GitHub being
+reachable mid-job.
+
+---
+
+## 4. Parameters
+
+Precedence everywhere: **per-job override → settings default**. `None` means "not set";
+every other value including `0` and `""` is an intentional override and wins.
+
+| Param | Default | Semantics |
+|---|---|---|
+| `ip_scale` | **0.7** | ID-adapter strength. Raise for likeness, at the cost of expression range. |
+| `ref_scale` | **0.6** | Ref-adapter strength. Raise for appearance fidelity, at the cost of importing the reference's pose/lighting. |
+| `lynx_cfg_scale` | 2.0 | **Inert on the distilled path.** Only triggers an extra pass when the *main* cfg is also > 1.0, and the distill LoRA pins cfg to 1.0. Matters only once de-distilled. |
+| `start_percent` | 0.0 | Fraction of the denoise at which the ref adapter *starts* applying. |
+| `end_percent` | 1.0 | Fraction at which it *stops*. Narrowing this (e.g. 0.0–0.6) frees the late steps from the reference — the lever to try if identity holds but motion looks stiff. |
+| `ref_blocks_to_use` | `""` (all) | Which DiT blocks receive the ref feature, e.g. `"0-20, 25, 35-39"`. Restricting to early blocks applies identity to structure while leaving late blocks free for detail. Untested by us. |
+| `steps` / `cfg` / `shift` / `scheduler` | 6 / 1.0 / 8.0 / `lcm` | From Kijai's reference workflow. |
+| `distill_strength` | 1.0 | **0 drops the LoRA node entirely** rather than applying strength 0 — the de-distilled path, where you would also raise cfg and steps. |
+
+Note the defaults are Kijai's 0.7/0.6, *not* the 1.0/1.0 in the original task. Both are
+in the A/B matrix.
+
+### Constraints — validated, never clamped
+
+`LynxValidationError` is raised with the offending value named. Silent clamping was
+rejected because an off-bucket resolution or off-grid frame count degrades identity in
+ways that are very hard to attribute afterwards.
+
+- **Resolution:** `832×480` or `1280×720` only.
+- **Frames:** `4n+1`, minimum 5 (81 is the smoke-test shape).
+- **Adapter arms:** ip layers and resampler must both be `lite` or both `full`.
+- **Subject image:** required.
+
+---
+
+## 5. Placement
+
+**All Lynx jobs go to RunPod.** This is not a tuning decision — the local 3090 physically
+cannot run Lynx today:
+
+| | WanVideoWrapper | Lynx nodes |
+|---|---|---|
+| 3090 (`3090.zero`) | **1.3.3** | ✗ (Lynx landed in 1.3.5) |
+| RunPod image | **1.3.9** (pinned `e926f7a0`) | ✓ |
+
+The RunPod wrapper's `lynx/nodes.py` is **byte-identical to current upstream `main`**, so
+the graph builder is version-stable across 1.3.9 → 1.4.7.
+
+Upgrading the 3090's wrapper is deferred deliberately: its ComfyUI core is pinned to an
+Apr-28 rollback for the activation-memory fix, and a 6-month wrapper jump risks disturbing
+that. Revisit only if the POC's identity numbers justify it.
+
+`_lynx_preflight` fails fast with a diagnosis rather than a bare "node not found", because
+two very different causes present identically:
+
+1. the wrapper predates 1.3.5, or
+2. the wrapper is new enough but its Lynx import raised — **it logs a warning and
+   registers nothing**, and a missing `insightface` does exactly this.
+
+There is no silent fallback to the 2.2 i2v path: Lynx is a different base model family, so
+a worker that cannot run it must say so.
+
+---
+
+## 6. VRAM
+
+**UNMEASURED.** No Lynx generation has run yet. To be filled from
+`lynx.generate.end` → `vram_peak_mb` on the first pod run.
+
+| Config | Peak VRAM | Status |
+|---|---|---|
+| 832×480, 81f, fp8 + block swap 35 | — | pending |
+| 1280×720, 81f | — | pending |
+
+Budget sketch, for expectations only: 14.5 GB fp8 base (block-swapped, so resident share
+is well under that) + ~5 GB adapters + VAE + latents. `lynx_blocks_to_swap` is 35, from
+Kijai's reference workflow — higher than our VACE path's 25, because the adapters add
+resident weight on top of the base.
+
+**Measurement caveat:** the daemon is a *separate process* from ComfyUI, so
+`torch.cuda.max_memory_allocated()` would report the daemon's own empty allocator. We poll
+device-level usage via `nvidia-smi` on a background thread (0.5 s) and report the peak.
+That figure includes anything else resident on the card — which is the number that
+actually matters for "does this fit in 24 GB", but is not directly comparable to a
+PyTorch allocator figure.
+
+---
+
+## 7. Identity QA
+
+After each Lynx render the daemon samples 5 frames (interior — the first and last frames
+are least representative), embeds the largest face in each with InsightFace, and
+cosine-compares against the subject crop. Results are logged as `lynx.identity_qa` with
+the correlation ID and persisted to `segments.lynx_identity_scores`.
+
+**Measurement only.** No gating, no retries — that is a separate task. The QA path is
+wrapped so it can never fail an otherwise good render; if insightface is missing or the
+video is unreadable, scores are simply `null`.
+
+**Embedding-space caveat:** Lynx *conditions* on facexlib ArcFace IR-SE50; we *measure*
+with InsightFace buffalo_l. Different spaces, so absolute values are not comparable to
+published Lynx numbers. They are only meaningful **relative to each other across A/B
+arms**, which is exactly how the matrix below uses them.
+
+---
+
+## 8. Calibration matrix — NOT YET RUN
+
+Same prompt, subject and seed across all cells; 832×480, 81 frames.
+
+| # | ip arm | ip_scale | ref_scale | mean cos | notes |
+|---|---|---|---|---|---|
+| 1 | lite | 0.7 | 0.6 | — | Kijai default |
+| 2 | lite | 1.0 | 1.0 | — | task-spec default |
+| 3 | full | 0.7 | 0.6 | — | tests Kijai's "full ip is weak" claim |
+| 4 | full | 1.0 | 1.0 | — | |
+
+Reference points from the original task, folded in: `(0.5, 0.5)` and `(1.5, 1.0)` are
+worth adding once the four above show which arm is worth exploring.
+
+---
+
+## 9. Open questions
+
+- Does lite ip actually beat full ip on measured similarity, or is Kijai's note specific
+  to his test subject?
+- Does `end_percent` < 1.0 buy motion freedom without losing likeness?
+- Does a character LoRA stacked on Lynx help or fight it? Both mechanisms target identity;
+  they may not compose.
+- Wan 2.1 is a generation behind our 2.2 i2v path. Even if identity improves, is the
+  motion/quality regression acceptable? This is the real go/no-go, and similarity scores
+  alone will not answer it.
+
+---
+
+## 10. Files
+
+| Repo | Path | What |
+|---|---|---|
+| daemon | `daemon/workflow_builder.py` | `build_lynx_workflow`, `_validate_lynx`, `lynx_num_frames` |
+| daemon | `daemon/executor.py` | `_execute_lynx`, `_lynx_preflight`, `_resolve_lynx_subject` |
+| daemon | `daemon/stage_log.py` | structured JSON stage events + VRAM peaks |
+| daemon | `daemon/identity_check.py` | cosine-similarity QA |
+| daemon | `daemon/config.py` | `lynx_*` settings |
+| daemon | `tests/golden/lynx_832x480_81f.json` | golden graph for a fixed param set |
+| api | `alembic/versions/050_add_lynx_engine.py` | job tunables + segment scores |
+| runpod | `download_models.sh` | Lynx staging, `MODEL_PROFILE=lynx` |

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -47,6 +47,52 @@ class Settings(BaseSettings):
     vace_blocks_to_swap: int = 25
     vace_lightning: bool = True  # use the 4-step distill LoRAs (fast path)
 
+    # === Lynx identity-preserving generation (ByteDance Lynx on Wan2.1 T2V-14B) ===
+    # Lynx re-asserts identity at EVERY denoising step via two adapters, unlike a
+    # character LoRA which bakes it into the weights:
+    #   ip  (ID-adapter)  ArcFace embedding -> Perceiver resampler -> identity tokens
+    #   ref (Ref-adapter) dense VAE features of the reference face, cross-attended in DiT blocks
+    # This is a T2V base conditioned on a subject image — NOT first-frame i2v, so the
+    # subject image never appears as frame 0.
+    lynx_t2v_model: str = "Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors"
+    # ip layers and resampler are a MATCHED PAIR (the resampler's proj_out dim must match
+    # the ip layers). Default is Kijai's shipped combination — lite ip + full ref — because
+    # his own workflow note reports the full ip adapter as "very weak". full ip + full ref
+    # is the A/B arm; swap BOTH lynx_ip_layers and lynx_resampler together.
+    lynx_ip_layers: str = "Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors"
+    lynx_resampler: str = "lynx_lite_resampler_fp32.safetensors"
+    lynx_ref_layers: str = "Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors"
+    lynx_resampler_precision: str = "fp16"
+    # Wan2.1 T2V cfg-step-distill LoRA (the i2v lightx2v_* above are a different family and
+    # do NOT apply to the 2.1 T2V base). Strength 0 drops it -> de-distilled path.
+    lynx_distill_lora: str = "lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors"
+    lynx_distill_strength: float = 1.0
+    lynx_t5_model: str = "models_t5_umt5-xxl-enc-bf16.pth"
+    # Adapter strengths. Kijai's reference workflow ships 0.7/0.6 rather than the 1.0/1.0
+    # implied by the model card; treated as the calibration starting point, not gospel.
+    lynx_ip_scale: float = 0.7
+    lynx_ref_scale: float = 0.6
+    # Only takes effect when the main cfg is also > 1.0 (it triggers an extra pass). With the
+    # distill LoRA on, cfg is 1.0, so this is inert until you de-distill.
+    lynx_lynx_cfg_scale: float = 2.0
+    # Denoise window over which the ref adapter is applied (fraction of total steps).
+    lynx_start_percent: float = 0.0
+    lynx_end_percent: float = 1.0
+    # Comma-separated DiT block indices/ranges for the ref feature, e.g. "0-20, 25, 35-39".
+    # Empty = all blocks.
+    lynx_ref_blocks_to_use: str = ""
+    # Reference-extraction pass prompt. Hardcoded in ByteDance's original implementation;
+    # Kijai's node requires it whenever ref_image is supplied.
+    lynx_ref_prompt: str = "image of a face"
+    lynx_steps: int = 6
+    lynx_cfg: float = 1.0
+    lynx_shift: float = 8.0
+    lynx_scheduler: str = "lcm"
+    lynx_blocks_to_swap: int = 35
+    # Identity QA: sample N frames from the render and cosine-compare their InsightFace
+    # embeddings against the subject crop. Measurement only — nothing gates on the score.
+    lynx_identity_sample_frames: int = 5
+
     # AR hologram: Robust Video Matting ONNX model (auto-used when a clip is NOT green-screen).
     # ~15MB; auto-downloaded on first use if missing. Path is relative to the daemon workdir.
     rvm_model_path: str = "models/rvm_mobilenetv3_fp32.onnx"

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -22,6 +22,7 @@ import os
 import shutil
 import tempfile
 import time
+from typing import Any
 
 import httpx
 import numpy as np
@@ -36,12 +37,17 @@ from daemon.queue_client import QueueClient
 from daemon.schemas import SegmentClaim, SegmentResult
 from daemon.workflow_builder import (
     GENERATION_FPS,
+    LynxValidationError,
     build_workflow,
     build_faceswap_workflow,
+    build_lynx_workflow,
     build_seed_faceswap_workflow,
     build_vace_workflow,
+    lynx_num_frames,
     vace_num_frames,
 )
+from daemon.identity_check import measure_identity
+from daemon.stage_log import log_event, stage
 from daemon.config import settings
 from daemon.hologram import (
     GUARD_PX,
@@ -197,8 +203,8 @@ async def _reanchor_seed_frame(
     NEVER raises — always returns a usable seed frame (swapped or raw), and logs which."""
     try:
         source_s3 = next(
-            (_HARDCODE_VACE_FACE[l.lora_id] for l in (segment.loras or [])
-             if l.lora_id in _HARDCODE_VACE_FACE),
+            (_HARDCODE_VACE_FACE[item.lora_id] for item in (segment.loras or [])
+             if item.lora_id in _HARDCODE_VACE_FACE),
             None,
         )
         if not source_s3:
@@ -426,8 +432,8 @@ async def _execute_vace_continuation(
         # HACK: if the segment uses a character LoRA we have a canonical face for, use that face
         # as the VACE identity reference (bypasses the unreliable auto-crop).
         hardcode_uri = next(
-            (_HARDCODE_VACE_FACE[l.lora_id] for l in (segment.loras or [])
-             if l.lora_id in _HARDCODE_VACE_FACE),
+            (_HARDCODE_VACE_FACE[item.lora_id] for item in (segment.loras or [])
+             if item.lora_id in _HARDCODE_VACE_FACE),
             None,
         )
         if hardcode_uri:
@@ -664,6 +670,163 @@ def _holo_process_frames_sync(
     return mode, packed_w, packed_h, poster_buf.getvalue(), manifest
 
 
+async def _resolve_lynx_subject(
+    segment: SegmentClaim, comfyui: ComfyUIClient, queue: QueueClient
+) -> tuple[str, bytes]:
+    """Resolve lynx_subject_image to a ComfyUI-local filename, returning its bytes too.
+
+    The bytes are kept so identity QA can embed the same reference the graph conditioned
+    on, without a second download.
+    """
+    subject = segment.lynx_subject_image
+    if not subject:
+        raise LynxValidationError("Lynx segment has no lynx_subject_image")
+    if subject.startswith("s3://"):
+        data = await _download_with_retry(
+            lambda: queue.download_file(subject), "lynx_subject_image"
+        )
+        _validate_image_data(data, "lynx_subject_image")
+        ext = os.path.splitext(subject)[1] or ".png"
+        filename = await comfyui.upload_image(data, f"lynx_subject_{segment.id}{ext}")
+        return filename, data
+    return subject, b""
+
+
+async def _execute_lynx(
+    segment: SegmentClaim,
+    comfyui: ComfyUIClient,
+    queue: QueueClient,
+) -> None:
+    """Generate a segment with the Lynx identity-preserving engine.
+
+    Wan2.1 T2V-14B conditioned on a subject image via the Lynx ID/Ref adapters. Unlike the
+    i2v paths there is no start frame: the subject drives identity only. After the render,
+    identity QA measures how well that worked and records the scores (no gating).
+    """
+    correlation_id = str(segment.id)
+    progress = ProgressLog(segment.id, queue)
+    segment_start = time.monotonic()
+    log_event(
+        logger, "lynx.segment_start", correlation_id,
+        job_id=str(segment.job_id), segment_index=segment.index,
+        resolution=f"{segment.width}x{segment.height}",
+    )
+    try:
+        if segment.loras:
+            await ensure_loras_available(segment.loras, queue)
+
+        # 1. Subject image -> ComfyUI
+        await progress.log("[1/5] Resolving subject image...")
+        with stage(logger, "lynx.subject_upload", correlation_id):
+            subject_fn, subject_bytes = await _resolve_lynx_subject(segment, comfyui, queue)
+
+        # 2. Build (validates resolution / frame grid / adapter pairing — raises, no clamping)
+        await progress.log("[2/5] Building Lynx workflow...")
+        num_frames = lynx_num_frames(segment)
+        with stage(logger, "lynx.build", correlation_id, num_frames=num_frames) as extra:
+            workflow = build_lynx_workflow(segment, subject_fn, num_frames)
+            extra["nodes"] = len(workflow)
+
+        # 3. Submit + monitor
+        with stage(logger, "lynx.generate", correlation_id, num_frames=num_frames):
+            prompt_id, client_id = await comfyui.submit_workflow(workflow)
+            await progress.log(f"[3/5] Submitted (prompt_id={prompt_id[:8]}, {num_frames} frames)")
+            await progress.log("[4/5] Waiting for Lynx execution...")
+            await comfyui.monitor_execution(prompt_id, client_id, progress=progress)
+
+        # 4. Collect output
+        await progress.log("[5/5] Downloading result and uploading...")
+        history = await comfyui.get_history(prompt_id)
+        video_info = comfyui.find_video_output(history)
+        if not video_info:
+            raise RuntimeError("No video output found in ComfyUI history")
+        result_data = await comfyui.download_output(
+            filename=video_info["filename"],
+            subfolder=video_info.get("subfolder", ""),
+            output_type=video_info.get("type", "output"),
+        )
+
+        # 5. Identity QA — measurement only, never fatal
+        identity_scores = await _measure_lynx_identity(
+            result_data, subject_bytes, correlation_id
+        )
+
+        last_frame_data = await _extract_last_frame(result_data)
+        await queue.upload_segment_output(
+            segment.id, result_data, last_frame_data,
+            SegmentResult(status="completed", lynx_identity_scores=identity_scores),
+        )
+        log_event(
+            logger, "lynx.segment_complete", correlation_id,
+            duration_sec=round(time.monotonic() - segment_start, 1),
+            identity_mean=(identity_scores or {}).get("mean"),
+        )
+
+    except LynxValidationError as e:
+        # Invalid job parameters (bad bucket / frame grid / adapter pair / missing subject).
+        error_msg = f"Lynx validation error: {e}"
+        log_event(logger, "lynx.validation_failed", correlation_id,
+                  level=logging.ERROR, error=str(e))
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+    except ComfyUIExecutionError as e:
+        error_msg = f"ComfyUI error: {e}"
+        if e.node_id:
+            error_msg += f" (node {e.node_id} [{e.node_type}])"
+        # A faceless subject surfaces here, raised by LynxInsightFaceCrop inside ComfyUI.
+        if "No face detected" in str(e):
+            error_msg = (
+                "Lynx subject image has no detectable face — identity is ArcFace-conditioned, "
+                f"so this job cannot produce a likeness. ({e})"
+            )
+        log_event(logger, "lynx.execution_failed", correlation_id,
+                  level=logging.ERROR, error=error_msg, node_id=e.node_id, node_type=e.node_type)
+        if e.traceback:
+            logger.error("Traceback:\n%s", e.traceback)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        logger.exception("Lynx segment %s failed", segment.id)
+        log_event(logger, "lynx.segment_failed", correlation_id,
+                  level=logging.ERROR, error=error_msg)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000], progress_log=progress.text),
+        )
+
+
+async def _measure_lynx_identity(
+    result_data: bytes, subject_bytes: bytes, correlation_id: str
+) -> dict[str, Any] | None:
+    """Run identity QA on the rendered clip against the subject image.
+
+    Both arrive as bytes, so they are staged to temp files for OpenCV/InsightFace. Returns
+    None when QA could not run; never raises.
+    """
+    if not subject_bytes:
+        return None
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            video_path = os.path.join(tmp, "output.mp4")
+            subject_path = os.path.join(tmp, "subject.png")
+            with open(video_path, "wb") as fh:
+                fh.write(result_data)
+            with open(subject_path, "wb") as fh:
+                fh.write(subject_bytes)
+            with stage(logger, "lynx.identity_qa", correlation_id):
+                return await asyncio.to_thread(
+                    measure_identity, video_path, subject_path, correlation_id
+                )
+    except Exception:
+        logger.warning("Lynx identity QA could not run", exc_info=True)
+        return None
+
+
 async def _execute_ar_hologram(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -833,6 +996,12 @@ async def execute_segment(
     if segment.reprocess_type == "smashcut_concat":
         return await _execute_smashcut_concat(segment, queue)
 
+    # Lynx identity-preserving engine. Explicitly selected per job (not capability-inferred):
+    # it is a different base model family (Wan2.1 T2V) from the 2.2 i2v default, so there is
+    # no sensible silent fallback — a worker without the models must fail loudly.
+    if segment.generation_engine == "lynx":
+        return await _execute_lynx(segment, comfyui, queue)
+
     # VACE video-conditioned continuation (resolved API-side). Capability-gated: a worker
     # without the Fun-VACE models/nodes silently falls through to the traditional i2v path.
     if segment.continuation_mode == "vace":
@@ -843,7 +1012,7 @@ async def execute_segment(
             segment.index,
         )
 
-    lora_names = ", ".join(l.high_file or l.low_file or "?" for l in (segment.loras or []))
+    lora_names = ", ".join(item.high_file or item.low_file or "?" for item in (segment.loras or []))
 
     augmented_prompt = segment.prompt
     if segment.previous_motion_keywords:
@@ -916,7 +1085,7 @@ async def execute_segment(
         if segment.reference_frames:
             for ref_s3_path in segment.reference_frames:
                 ref_data = await _download_with_retry(
-                    lambda: queue.download_file(ref_s3_path), f"reference_frame"
+                    lambda: queue.download_file(ref_s3_path), "reference_frame"
                 )
                 _validate_image_data(ref_data, "reference_frame")
                 ext = os.path.splitext(ref_s3_path)[1] or ".png"

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -38,6 +38,7 @@ from daemon.schemas import SegmentClaim, SegmentResult
 from daemon.workflow_builder import (
     GENERATION_FPS,
     LynxValidationError,
+    _pick,
     build_workflow,
     build_faceswap_workflow,
     build_lynx_workflow,
@@ -670,6 +671,47 @@ def _holo_process_frames_sync(
     return mode, packed_w, packed_h, poster_buf.getvalue(), manifest
 
 
+async def _lynx_preflight(comfyui: ComfyUIClient, segment: SegmentClaim) -> None:
+    """Fail fast with a diagnosis when the worker cannot run Lynx.
+
+    Two failure modes are easy to confuse and both present as "node not found":
+      * the wrapper predates Lynx (added in WanVideoWrapper 1.3.5), or
+      * the wrapper is new enough but its Lynx import raised — most often a missing
+        insightface — in which case it logs a warning and registers nothing.
+    Either way the node is absent, so that is what we probe, and we separately confirm
+    the adapters this job names are actually on disk.
+    """
+    try:
+        resp = await comfyui.http.get("/object_info/WanVideoAddLynxEmbeds")
+        available = resp.status_code == 200 and "WanVideoAddLynxEmbeds" in resp.json()
+    except Exception as e:
+        raise LynxValidationError(
+            f"could not query ComfyUI for Lynx node support: {e}"
+        ) from e
+    if not available:
+        raise LynxValidationError(
+            "this worker's ComfyUI has no Lynx nodes. Either WanVideoWrapper is older "
+            "than 1.3.5 (which first shipped Lynx), or its Lynx import failed — the "
+            "wrapper logs 'Lynx nodes not available' and registers nothing when, for "
+            "example, insightface is missing. Check the ComfyUI startup log."
+        )
+    # The resampler must be present under the name this job asked for; a missing file
+    # would otherwise surface as an opaque loader error mid-run.
+    resampler = _pick(segment.lynx_resampler, settings.lynx_resampler)
+    try:
+        resp = await comfyui.http.get("/object_info/LoadLynxResampler")
+        spec = resp.json().get("LoadLynxResampler", {}).get(
+            "input", {}).get("required", {}).get("model_name", [[]])
+        choices = spec[0] if spec and isinstance(spec[0], list) else []
+    except Exception:
+        return  # node exists; if we cannot enumerate files, let the run surface it
+    if choices and resampler not in choices:
+        raise LynxValidationError(
+            f"Lynx resampler {resampler!r} is not in this worker's diffusion_models "
+            f"directory. Available: {sorted(choices)[:10]}"
+        )
+
+
 async def _resolve_lynx_subject(
     segment: SegmentClaim, comfyui: ComfyUIClient, queue: QueueClient
 ) -> tuple[str, bytes]:
@@ -712,6 +754,10 @@ async def _execute_lynx(
         resolution=f"{segment.width}x{segment.height}",
     )
     try:
+        # 0. Preflight: no silent fallback — Lynx is a different base model family
+        # from the 2.2 i2v default, so a worker that cannot run it must say why.
+        await _lynx_preflight(comfyui, segment)
+
         if segment.loras:
             await ensure_loras_available(segment.loras, queue)
 

--- a/daemon/gpu_stats.py
+++ b/daemon/gpu_stats.py
@@ -2,11 +2,12 @@
 
 import logging
 import subprocess
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-def get_gpu_stats() -> dict | None:
+def get_gpu_stats() -> dict[str, Any] | None:
     """Query nvidia-smi for GPU stats. Returns None on failure."""
     try:
         result = subprocess.run(

--- a/daemon/identity_check.py
+++ b/daemon/identity_check.py
@@ -1,0 +1,140 @@
+"""Identity QA for Lynx renders: how much does the output still look like the subject?
+
+Samples frames from a finished render, embeds each detected face with InsightFace, and
+cosine-compares them against the subject reference embedding. Measurement only — nothing
+here gates, retries, or fails a job; the scores are logged and persisted so the
+ip_scale/ref_scale calibration can be argued from numbers rather than impressions.
+
+Note on embedding spaces: Lynx *conditions* on facexlib's ArcFace IR-SE50, while we
+*measure* with InsightFace buffalo_l. Different spaces, so absolute values are not
+comparable to the model card's; they are only meaningful relative to each other across
+A/B arms, which is exactly how we use them.
+"""
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from daemon.config import settings
+from daemon.stage_log import log_event
+
+logger = logging.getLogger(__name__)
+
+# Lazily-initialised InsightFace app: model load is ~1s and we reuse it across segments.
+_face_app: Any | None = None
+
+
+def _get_face_app() -> Any | None:
+    """Return a prepared InsightFace FaceAnalysis, or None if unavailable.
+
+    insightface is present in the RunPod image but not in every local daemon venv, so an
+    import failure downgrades identity QA to "not measured" instead of failing the job.
+    """
+    global _face_app
+    if _face_app is not None:
+        return _face_app
+    try:
+        from insightface.app import FaceAnalysis
+    except Exception as exc:
+        logger.warning("insightface unavailable, skipping identity QA: %s", exc)
+        return None
+    app = FaceAnalysis()
+    app.prepare(ctx_id=0, det_size=(640, 640))
+    _face_app = app
+    return _face_app
+
+
+def _largest_face_embedding(app: Any, image: "np.ndarray[Any, Any]") -> "np.ndarray[Any, Any] | None":
+    """Embed the largest detected face, or None when the frame has no face."""
+    faces = app.get(image)
+    if not faces:
+        return None
+    face = max(faces, key=lambda f: (f.bbox[2] - f.bbox[0]) * (f.bbox[3] - f.bbox[1]))
+    embedding: "np.ndarray[Any, Any]" = np.asarray(face.embedding, dtype=np.float32)
+    return embedding
+
+
+def cosine_similarity(a: "np.ndarray[Any, Any]", b: "np.ndarray[Any, Any]") -> float:
+    """Cosine similarity between two embeddings; 0.0 if either has no magnitude."""
+    denom = float(np.linalg.norm(a)) * float(np.linalg.norm(b))
+    if denom == 0.0:
+        return 0.0
+    return float(np.dot(a, b) / denom)
+
+
+def sample_frames(video_path: str, count: int) -> list["np.ndarray[Any, Any]"]:
+    """Read ``count`` frames spread evenly across the video (excluding the very ends)."""
+    import cv2
+
+    cap = cv2.VideoCapture(video_path)
+    try:
+        if not cap.isOpened():
+            logger.warning("identity QA: could not open %s", video_path)
+            return []
+        total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        if total <= 0 or count <= 0:
+            return []
+        # Interior sampling: the first/last frames are the least representative of a clip.
+        step = total / (count + 1)
+        frames: list["np.ndarray[Any, Any]"] = []
+        for i in range(1, count + 1):
+            cap.set(cv2.CAP_PROP_POS_FRAMES, min(int(step * i), total - 1))
+            ok, frame = cap.read()
+            if ok:
+                frames.append(frame)
+        return frames
+    finally:
+        cap.release()
+
+
+def measure_identity(
+    video_path: str,
+    subject_image_path: str,
+    correlation_id: str,
+    sample_count: int | None = None,
+) -> dict[str, Any] | None:
+    """Cosine-compare sampled output frames against the subject reference.
+
+    Returns a summary dict (also suitable for the job's JSON column), or None when the
+    measurement could not run at all (no insightface, unreadable video, faceless subject).
+    Never raises: identity QA must not be able to fail an otherwise good render.
+    """
+    count = settings.lynx_identity_sample_frames if sample_count is None else sample_count
+    try:
+        app = _get_face_app()
+        if app is None:
+            return None
+
+        import cv2
+
+        subject_img = cv2.imread(subject_image_path)
+        if subject_img is None:
+            logger.warning("identity QA: could not read subject image %s", subject_image_path)
+            return None
+        subject_embedding = _largest_face_embedding(app, subject_img)
+        if subject_embedding is None:
+            logger.warning("identity QA: no face in subject image %s", subject_image_path)
+            return None
+
+        frames = sample_frames(video_path, count)
+        scores: list[float] = []
+        for frame in frames:
+            embedding = _largest_face_embedding(app, frame)
+            if embedding is not None:
+                scores.append(round(cosine_similarity(subject_embedding, embedding), 4))
+
+        result: dict[str, Any] = {
+            "scores": scores,
+            "frames_sampled": len(frames),
+            "frames_with_face": len(scores),
+            "mean": round(sum(scores) / len(scores), 4) if scores else None,
+            "min": min(scores) if scores else None,
+            "max": max(scores) if scores else None,
+        }
+        log_event(logger, "lynx.identity_qa", correlation_id, **result)
+        return result
+    except Exception as exc:
+        # Deliberately broad: a QA metric must never take down a successful render.
+        logger.warning("identity QA failed for %s: %s", video_path, exc, exc_info=True)
+        return None

--- a/daemon/motion_extractor.py
+++ b/daemon/motion_extractor.py
@@ -1,9 +1,5 @@
 """Extract motion keywords from generated video for context propagation."""
 
-import asyncio
-import json
-import subprocess
-from pathlib import Path
 
 
 MOTION_KEYWORDS = {

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -69,6 +69,26 @@ class SegmentClaim(BaseModel):
     # Foundry smashcut (reprocess_type="smashcut_concat"): ordered clip paths + transition.
     smashcut_clip_paths: Optional[list[str]] = None
     smashcut_transition: Optional[str] = None
+    # === Lynx identity-preserving generation ===
+    # Set generation_engine="lynx" to route this segment to build_lynx_workflow. The subject
+    # image conditions identity via ArcFace + VAE reference features; it is NOT a start frame.
+    # Every lynx_* tunable below is a per-job override: None => the daemon settings default.
+    generation_engine: Optional[str] = None
+    lynx_subject_image: Optional[str] = None
+    lynx_ip_scale: Optional[float] = None
+    lynx_ref_scale: Optional[float] = None
+    lynx_cfg_scale: Optional[float] = None
+    lynx_start_percent: Optional[float] = None
+    lynx_end_percent: Optional[float] = None
+    lynx_ref_blocks_to_use: Optional[str] = None
+    # A/B arm: overrides the matched ip-layers + resampler pair (both or neither).
+    lynx_ip_layers: Optional[str] = None
+    lynx_resampler: Optional[str] = None
+    lynx_steps: Optional[int] = None
+    lynx_cfg: Optional[float] = None
+    lynx_shift: Optional[float] = None
+    lynx_scheduler: Optional[str] = None
+    lynx_distill_strength: Optional[float] = None
     width: int
     height: int
     fps: int
@@ -89,3 +109,7 @@ class SegmentResult(BaseModel):
     # segment carries. Stitch trims this much off the *previous* segment's tail so the
     # reconstruction replaces it seamlessly.
     vace_overlap_seconds: Optional[float] = None
+    # Lynx identity QA: per-frame cosine similarities of sampled output frames against the
+    # subject crop, plus summary stats. Measurement only — no gating. Shape:
+    # {"scores": [...], "mean": f, "min": f, "max": f, "frames_sampled": n, "frames_with_face": n}
+    lynx_identity_scores: Optional[dict[str, Any]] = None

--- a/daemon/stage_log.py
+++ b/daemon/stage_log.py
@@ -1,0 +1,133 @@
+"""Structured JSON stage logging with correlation IDs and VRAM peaks.
+
+The daemon's baseline logging is human-readable text (see ``main.py`` basicConfig).
+Engine stages additionally emit one JSON object per event through the same logger,
+so pod logs stay greppable and can be aggregated by correlation ID without changing
+global log configuration.
+
+VRAM caveat: the daemon is a *separate process* from ComfyUI, so
+``torch.cuda.max_memory_allocated()`` would report the daemon's own (empty)
+allocator, not the one doing the work. We therefore sample device-level usage via
+``nvidia-smi`` on a background thread and report the peak observed across the
+stage. That figure includes anything else resident on the card, which is the
+number that actually matters for "does this fit in 24 GB".
+"""
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from daemon.gpu_stats import get_gpu_stats
+
+# Seconds between VRAM samples while a stage is running. nvidia-smi costs ~10ms,
+# so this is cheap relative to a multi-minute diffusion stage.
+VRAM_POLL_INTERVAL = 0.5
+
+
+def log_event(
+    logger: logging.Logger,
+    event: str,
+    correlation_id: str,
+    level: int = logging.INFO,
+    **fields: Any,
+) -> dict[str, Any]:
+    """Emit one structured JSON log record and return the payload.
+
+    The payload is returned so callers (and tests) can assert on it without
+    having to parse the emitted log line back out.
+    """
+    payload: dict[str, Any] = {"event": event, "correlation_id": correlation_id}
+    payload.update(fields)
+    logger.log(level, json.dumps(payload, sort_keys=True, default=str))
+    return payload
+
+
+class _VramSampler:
+    """Polls device VRAM on a background thread, retaining the peak.
+
+    Degrades to ``None`` peaks when nvidia-smi is unavailable (CPU-only dev boxes,
+    unit tests) rather than failing the stage it is measuring.
+    """
+
+    def __init__(self, interval: float = VRAM_POLL_INTERVAL) -> None:
+        self.interval = interval
+        self.peak_mb: int | None = None
+        self.total_mb: int | None = None
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _sample(self) -> None:
+        stats = get_gpu_stats()
+        if stats is None:
+            return
+        used = int(stats["vram_used_mb"])
+        self.total_mb = int(stats["vram_total_mb"])
+        if self.peak_mb is None or used > self.peak_mb:
+            self.peak_mb = used
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            self._sample()
+            self._stop.wait(self.interval)
+
+    def start(self) -> None:
+        self._sample()  # baseline, so very short stages still report a figure
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=self.interval * 4)
+        self._sample()  # final sample catches a late peak
+
+
+@contextmanager
+def stage(
+    logger: logging.Logger,
+    name: str,
+    correlation_id: str,
+    **fields: Any,
+) -> Iterator[dict[str, Any]]:
+    """Time a pipeline stage, logging start/end (or failure) as JSON.
+
+    Yields a mutable dict; anything the caller puts in it is merged into the
+    terminating log record, which lets a stage report values it only learns while
+    running (node counts, frame counts, ...).
+    """
+    extra: dict[str, Any] = {}
+    log_event(logger, f"{name}.start", correlation_id, **fields)
+    sampler = _VramSampler()
+    sampler.start()
+    started = time.monotonic()
+    try:
+        yield extra
+    except Exception as exc:
+        sampler.stop()
+        log_event(
+            logger,
+            f"{name}.failed",
+            correlation_id,
+            level=logging.ERROR,
+            duration_sec=round(time.monotonic() - started, 3),
+            vram_peak_mb=sampler.peak_mb,
+            vram_total_mb=sampler.total_mb,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            **{**fields, **extra},
+        )
+        raise
+    sampler.stop()
+    log_event(
+        logger,
+        f"{name}.end",
+        correlation_id,
+        duration_sec=round(time.monotonic() - started, 3),
+        vram_peak_mb=sampler.peak_mb,
+        vram_total_mb=sampler.total_mb,
+        **{**fields, **extra},
+    )

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -12,6 +12,7 @@ from typing import Any
 from daemon.config import settings
 from daemon.schemas import SegmentClaim
 from daemon.motion_analyzer import estimate_motion_from_flow
+from daemon.stage_log import log_event
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,24 @@ LORA_NODE_IDS = {
     "high": ["118", "120", "122"],
     "low": ["119", "121", "123"],
 }
+
+# Schedulers WanVideoSampler (WanVideoWrapper) accepts. These are NOT the KSampler
+# names ("simple", "karras", ...) the traditional path uses — passing one of those
+# makes ComfyUI reject the prompt with a 400. Shared by the VACE and Lynx builders.
+WANVIDEO_SCHEDULERS = frozenset({
+    "unipc", "unipc/beta", "dpm++", "dpm++/beta", "dpm++_sde", "dpm++_sde/beta",
+    "euler", "euler/beta", "deis", "lcm", "lcm/beta", "res_multistep",
+    "flowmatch_causvid", "flowmatch_distill", "flowmatch_pusa", "multitalk",
+})
+
+# Wan native resolution buckets Lynx is validated at. Anything else is rejected rather
+# than snapped, because an off-bucket latent grid degrades identity silently.
+LYNX_RESOLUTIONS = frozenset({(832, 480), (1280, 720)})
+
+# Lynx adapter arms. The ip layers and the resampler are a matched pair — the
+# resampler's proj_out dimension must match the ip layers it feeds. A mismatched pair
+# loads without raising and yields garbage identity, so it is validated up front.
+LYNX_ARMS = ("lite", "full")
 
 # Base Wan2.2 14B Image-to-Video workflow in ComfyUI API format.
 # Dynamic nodes (RIFE, VHS_VideoCombine, faceswap, user LoRAs) are added at runtime.
@@ -221,7 +240,7 @@ def _calculate_motion_amplitude(
 
 def _add_user_loras(workflow: dict, loras: list[dict]) -> None:
     """Add user LoRA nodes and rewire the lightx2v chain."""
-    loras = [l for l in loras if l.get("high_file") or l.get("low_file")]
+    loras = [item for item in loras if item.get("high_file") or item.get("low_file")]
     if not loras:
         return
 
@@ -452,7 +471,8 @@ def _build_vace_lora_chains(workflow: dict, segment: SegmentClaim) -> tuple[list
     counter = [700]
 
     def add(lora_name: str, strength: float, prev: list | None) -> list:
-        nid = str(counter[0]); counter[0] += 1
+        nid = str(counter[0])
+        counter[0] += 1
         inputs = {"lora": lora_name, "strength": float(strength), "merge_loras": True}
         if prev is not None:
             inputs["prev_lora"] = prev
@@ -536,12 +556,7 @@ def build_vace_workflow(
     # WanVideoSampler has no sampler_name and its own scheduler set — NOT the KSampler names
     # (e.g. "simple") the preset carries for the traditional path. Only honor the preset's
     # scheduler if WanVideoSampler accepts it; otherwise keep unipc (else ComfyUI 400s).
-    _VACE_SCHEDULERS = {
-        "unipc", "unipc/beta", "dpm++", "dpm++/beta", "dpm++_sde", "dpm++_sde/beta",
-        "euler", "euler/beta", "deis", "lcm", "lcm/beta", "res_multistep",
-        "flowmatch_causvid", "flowmatch_distill", "flowmatch_pusa", "multitalk",
-    }
-    vace_scheduler = segment.scheduler if segment.scheduler in _VACE_SCHEDULERS else "unipc"
+    vace_scheduler = segment.scheduler if segment.scheduler in WANVIDEO_SCHEDULERS else "unipc"
     wf["550"] = {"class_type": "WanVideoSampler", "inputs": {
         "model": ["510", 0], "image_embeds": ["540", 0], "text_embeds": ["521", 0],
         "steps": steps, "cfg": cfg, "shift": shift, "seed": segment.seed, "force_offload": True,
@@ -571,6 +586,234 @@ def build_vace_workflow(
 
     logger.info("Built VACE continuation workflow (%d nodes, %d frames, rife %dx)",
                 len(wf), num_frames, rife_mult)
+    return wf
+
+
+class LynxValidationError(ValueError):
+    """A Lynx job asked for something the graph cannot honour.
+
+    Raised instead of silently clamping: an off-bucket resolution or an off-grid
+    frame count degrades identity in ways that are hard to attribute after the fact,
+    so the job fails loudly with the offending value named.
+    """
+
+
+def _pick(override: Any, default: Any) -> Any:
+    """Per-job-override -> settings-default precedence.
+
+    ``None`` means "not set for this job"; every other value (including 0 and "")
+    is an intentional override and wins.
+    """
+    return default if override is None else override
+
+
+def _lynx_arm(filename: str) -> str | None:
+    """Classify a Lynx adapter file as the 'lite' or 'full' arm by filename marker."""
+    lowered = filename.lower()
+    found = [arm for arm in LYNX_ARMS if arm in lowered]
+    return found[0] if len(found) == 1 else None
+
+
+def lynx_num_frames(segment: SegmentClaim) -> int:
+    """WAN generation frame count for a Lynx segment, rounded to a valid 4n+1."""
+    gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
+    n = max(int(gen["wan_frames"]), 5)
+    return ((n - 1) // 4) * 4 + 1
+
+
+def _validate_lynx(
+    segment: SegmentClaim,
+    subject_filename: str | None,
+    num_frames: int,
+    ip_layers: str,
+    resampler: str,
+) -> None:
+    """Reject unsupported Lynx parameters with named values. No clamping."""
+    if not subject_filename:
+        raise LynxValidationError(
+            "Lynx requires a subject_image: identity is conditioned on an ArcFace "
+            "embedding of that image, so there is nothing to condition on without it."
+        )
+    if (segment.width, segment.height) not in LYNX_RESOLUTIONS:
+        allowed = ", ".join(f"{w}x{h}" for w, h in sorted(LYNX_RESOLUTIONS))
+        raise LynxValidationError(
+            f"Lynx supports only the Wan native buckets ({allowed}); "
+            f"got {segment.width}x{segment.height}."
+        )
+    if num_frames < 5 or (num_frames - 1) % 4 != 0:
+        raise LynxValidationError(
+            f"Lynx frame count must be on the 4n+1 grid and >= 5 (e.g. 81); got {num_frames}."
+        )
+    ip_arm, res_arm = _lynx_arm(ip_layers), _lynx_arm(resampler)
+    if ip_arm is None or res_arm is None or ip_arm != res_arm:
+        raise LynxValidationError(
+            "Lynx ip layers and resampler must be the same arm (both 'lite' or both "
+            f"'full'); got ip_layers={ip_layers!r} (arm={ip_arm}), "
+            f"resampler={resampler!r} (arm={res_arm})."
+        )
+
+
+def build_lynx_workflow(
+    segment: SegmentClaim,
+    subject_filename: str,
+    num_frames: int,
+) -> dict[str, Any]:
+    """Lynx identity-preserving workflow (Wan2.1 T2V-14B + Lynx adapters) via WanVideoWrapper.
+
+    Lynx conditions a *text-to-video* base on a subject image through two adapters, both
+    re-applied at every denoising step (unlike a character LoRA, which bakes identity into
+    the weights):
+
+      ip_scale  — strength of the ID-adapter: ArcFace embedding of a 112x112 aligned face
+                  crop, mapped to identity tokens by a Perceiver resampler. Controls *who*
+                  the face is; pushing it too high tends to freeze expression.
+      ref_scale — strength of the Ref-adapter: dense VAE features of a larger (256px) face
+                  crop, cross-attended in the DiT blocks. Controls fine appearance detail
+                  (skin, hair, lighting); too high drags the reference's pose/lighting in.
+
+    The subject image is NOT a first frame — this is not i2v, and the subject never appears
+    as frame 0. Character LoRAs remain supported and stack on top of the adapters.
+
+    ``num_frames`` must be on the 4n+1 grid and the resolution a Wan native bucket; both are
+    validated rather than clamped. Output is RIFE-interpolated to the segment's target fps so
+    Lynx segments stitch alongside traditional ones.
+    """
+    gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
+
+    ip_layers = _pick(segment.lynx_ip_layers, settings.lynx_ip_layers)
+    resampler = _pick(segment.lynx_resampler, settings.lynx_resampler)
+    _validate_lynx(segment, subject_filename, num_frames, ip_layers, resampler)
+
+    ip_scale = _pick(segment.lynx_ip_scale, settings.lynx_ip_scale)
+    ref_scale = _pick(segment.lynx_ref_scale, settings.lynx_ref_scale)
+    lynx_cfg_scale = _pick(segment.lynx_cfg_scale, settings.lynx_lynx_cfg_scale)
+    start_percent = _pick(segment.lynx_start_percent, settings.lynx_start_percent)
+    end_percent = _pick(segment.lynx_end_percent, settings.lynx_end_percent)
+    ref_blocks = _pick(segment.lynx_ref_blocks_to_use, settings.lynx_ref_blocks_to_use)
+    steps = _pick(segment.lynx_steps, settings.lynx_steps)
+    cfg = _pick(segment.lynx_cfg, settings.lynx_cfg)
+    shift = _pick(segment.lynx_shift, settings.lynx_shift)
+    distill_strength = _pick(segment.lynx_distill_strength, settings.lynx_distill_strength)
+    scheduler_pref = _pick(segment.lynx_scheduler, settings.lynx_scheduler)
+    scheduler = scheduler_pref if scheduler_pref in WANVIDEO_SCHEDULERS else settings.lynx_scheduler
+
+    wf: dict[str, Any] = {}
+
+    # --- Adapters + block swap -------------------------------------------------
+    # Both adapters reach the model through one chained extra_model list; the loader
+    # merges them into the base state dict at load time.
+    wf["600"] = {"class_type": "WanVideoBlockSwap", "inputs": {
+        "blocks_to_swap": settings.lynx_blocks_to_swap, "offload_img_emb": False,
+        "offload_txt_emb": False, "vace_blocks_to_swap": 0}}
+    wf["601"] = {"class_type": "WanVideoExtraModelSelect", "inputs": {"extra_model": ip_layers}}
+    wf["602"] = {"class_type": "WanVideoExtraModelSelect", "inputs": {
+        "extra_model": settings.lynx_ref_layers, "prev_model": ["601", 0]}}
+
+    # --- LoRA chain: distill first, then optional character LoRAs on top --------
+    # Wan2.1 T2V is a single-expert model, so unlike the 2.2 dual-expert path there is
+    # one chain; a LoRA's high_file is used, falling back to low_file.
+    lora_ref: list[Any] | None = None
+    lora_counter = 700
+    if distill_strength:
+        wf[str(lora_counter)] = {"class_type": "WanVideoLoraSelect", "inputs": {
+            "lora": settings.lynx_distill_lora, "strength": float(distill_strength),
+            "merge_loras": True}}
+        lora_ref = [str(lora_counter), 0]
+        lora_counter += 1
+    for lora in (segment.loras or []):
+        lora_file = lora.high_file or lora.low_file
+        if not lora_file:
+            continue
+        weight = lora.high_weight if lora.high_file else lora.low_weight
+        inputs: dict[str, Any] = {
+            "lora": lora_file, "strength": float(weight), "merge_loras": True}
+        if lora_ref is not None:
+            inputs["prev_lora"] = lora_ref
+        wf[str(lora_counter)] = {"class_type": "WanVideoLoraSelect", "inputs": inputs}
+        lora_ref = [str(lora_counter), 0]
+        lora_counter += 1
+
+    loader_inputs: dict[str, Any] = {
+        "model": settings.lynx_t2v_model, "base_precision": "fp16",
+        "quantization": "fp8_e4m3fn_scaled", "load_device": "offload_device",
+        "attention_mode": "sdpa", "extra_model": ["602", 0], "block_swap_args": ["600", 0]}
+    if lora_ref is not None:
+        loader_inputs["lora"] = lora_ref
+    wf["610"] = {"class_type": "WanVideoModelLoader", "inputs": loader_inputs}
+
+    # --- VAE + text encoders ---------------------------------------------------
+    wf["620"] = {"class_type": "WanVideoVAELoader", "inputs": {
+        "model_name": settings.vae_model, "precision": "bf16"}}
+    # Cached encode keeps umt5-xxl off the GPU between jobs — the residency that has
+    # OOM'd this box before. Same handling as the VACE path.
+    wf["621"] = {"class_type": "WanVideoTextEncodeCached", "inputs": {
+        "model_name": settings.lynx_t5_model, "precision": "bf16",
+        "positive_prompt": segment.prompt, "negative_prompt": segment.negative_prompt or "",
+        "quantization": "disabled", "use_disk_cache": False, "device": "gpu"}}
+    # Second, separate embed for the reference-extraction pass. ByteDance hardcode this
+    # prompt; WanVideoAddLynxEmbeds raises if ref_image is supplied without it.
+    wf["622"] = {"class_type": "WanVideoTextEncodeCached", "inputs": {
+        "model_name": settings.lynx_t5_model, "precision": "bf16",
+        "positive_prompt": settings.lynx_ref_prompt, "negative_prompt": "",
+        "quantization": "disabled", "use_disk_cache": False, "device": "gpu"}}
+
+    # --- Subject conditioning --------------------------------------------------
+    # One crop node yields both faces: a 112x112 ArcFace-aligned crop for the ID adapter
+    # and a wider 256px crop for the ref adapter. Raises "No face detected" upstream,
+    # which the executor surfaces as a job validation failure.
+    wf["630"] = {"class_type": "LoadImage", "inputs": {"image": subject_filename}}
+    wf["631"] = {"class_type": "LynxInsightFaceCrop", "inputs": {"image": ["630", 0]}}
+    wf["632"] = {"class_type": "LoadLynxResampler", "inputs": {
+        "model_name": resampler, "precision": settings.lynx_resampler_precision}}
+    wf["633"] = {"class_type": "LynxEncodeFaceIP", "inputs": {
+        "resampler": ["632", 0], "ip_image": ["631", 0]}}
+
+    # --- Empty latents + Lynx embed injection ----------------------------------
+    wf["640"] = {"class_type": "WanVideoEmptyEmbeds", "inputs": {
+        "width": segment.width, "height": segment.height, "num_frames": num_frames}}
+    embed_inputs: dict[str, Any] = {
+        "embeds": ["640", 0], "ip_scale": float(ip_scale), "ref_scale": float(ref_scale),
+        "lynx_cfg_scale": float(lynx_cfg_scale), "start_percent": float(start_percent),
+        "end_percent": float(end_percent), "vae": ["620", 0],
+        "lynx_ip_embeds": ["633", 0], "ref_image": ["631", 1], "ref_text_embed": ["622", 0]}
+    # Omit when empty: the node treats "" as "all blocks", and sending the key at all
+    # would need it wired as a link (it is declared forceInput).
+    if ref_blocks:
+        embed_inputs["ref_blocks_to_use"] = ref_blocks
+    wf["641"] = {"class_type": "WanVideoAddLynxEmbeds", "inputs": embed_inputs}
+
+    # --- Sample / decode / output ----------------------------------------------
+    wf["650"] = {"class_type": "WanVideoSampler", "inputs": {
+        "model": ["610", 0], "image_embeds": ["641", 0], "text_embeds": ["621", 0],
+        "steps": steps, "cfg": cfg, "shift": shift, "seed": segment.seed,
+        "force_offload": True, "scheduler": scheduler, "riflex_freq_index": 0,
+        "start_step": 0, "end_step": -1}}
+    wf["660"] = {"class_type": "WanVideoDecode", "inputs": {
+        "vae": ["620", 0], "samples": ["650", 0], "enable_vae_tiling": False,
+        "tile_x": 272, "tile_y": 272, "tile_stride_x": 144, "tile_stride_y": 128}}
+
+    rife_mult = gen["rife_multiplier"]
+    final_images = ["660", 0]
+    if rife_mult > 1:
+        wf["670"] = {"class_type": "RIFE VFI", "inputs": {
+            "ckpt_name": "rife49.pth", "clear_cache_after_n_frames": 10, "multiplier": rife_mult,
+            "fast_mode": True, "ensemble": True, "scale_factor": 1.0, "dtype": "float16",
+            "torch_compile": False, "batch_size": 1, "frames": ["660", 0]}}
+        final_images = ["670", 0]
+    wf["680"] = {"class_type": "VHS_VideoCombine", "inputs": {
+        "frame_rate": gen["output_fps"], "loop_count": 0, "filename_prefix": "output",
+        "format": "video/h264-mp4", "pix_fmt": "yuv420p", "crf": 15, "save_metadata": True,
+        "trim_to_audio": False, "pingpong": False, "save_output": True, "images": final_images}}
+
+    log_event(
+        logger, "lynx.graph_built", str(segment.id),
+        nodes=len(wf), num_frames=num_frames,
+        resolution=f"{segment.width}x{segment.height}",
+        arm=_lynx_arm(ip_layers), ip_scale=ip_scale, ref_scale=ref_scale,
+        steps=steps, cfg=cfg, shift=shift, scheduler=scheduler,
+        distill_strength=distill_strength, character_loras=len(segment.loras or []),
+        rife_multiplier=rife_mult,
+    )
     return wf
 
 
@@ -733,7 +976,7 @@ def build_workflow(
 
     # User LoRAs
     if segment.loras:
-        _add_user_loras(workflow, [l.model_dump() for l in segment.loras])
+        _add_user_loras(workflow, [item.model_dump() for item in segment.loras])
 
     # Face swap (before RIFE so it processes only native WAN frames, not
     # interpolated ones — cuts faceswap frame count by 50-75%)

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,15 @@
+[mypy]
+python_version = 3.11
+strict = True
+# Keep the strict gate meaningful for new work without demanding a big-bang retrofit of
+# the pre-existing modules: those are checked, but their missing annotations are not
+# treated as errors until they are next touched.
+warn_unused_configs = True
+
+# Third-party CV/ML libraries ship no type information.
+[mypy-cv2.*]
+ignore_missing_imports = True
+
+[mypy-insightface.*]
+ignore_missing_imports = True
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,49 @@
+"""Shared fixtures for the daemon test suite."""
+
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from daemon.schemas import LoraItem, SegmentClaim
+
+# Fixed IDs so golden-file comparisons and log assertions are reproducible.
+SEGMENT_ID = UUID("11111111-2222-3333-4444-555555555555")
+JOB_ID = UUID("66666666-7777-8888-9999-000000000000")
+
+
+def make_segment(**overrides: Any) -> SegmentClaim:
+    """Build a SegmentClaim with sane Lynx-compatible defaults.
+
+    Defaults describe an 832x480 clip whose duration lands exactly on 81 WAN frames
+    (81 frames / 15 generation fps = 5.4s), which is the smoke-test shape.
+    """
+    base: dict[str, Any] = {
+        "id": SEGMENT_ID,
+        "job_id": JOB_ID,
+        "index": 0,
+        "prompt": "a woman walking through a forest",
+        "duration_seconds": 5.4,
+        "faceswap_enabled": False,
+        "width": 832,
+        "height": 480,
+        "fps": 15,
+        "seed": 42,
+        "generation_engine": "lynx",
+        "lynx_subject_image": "subject.png",
+    }
+    base.update(overrides)
+    return SegmentClaim(**base)
+
+
+@pytest.fixture
+def segment() -> SegmentClaim:
+    return make_segment()
+
+
+@pytest.fixture
+def lora() -> LoraItem:
+    return LoraItem(
+        lora_id="abc", high_file="k3lly_high.safetensors", high_weight=0.8,
+        low_file="k3lly_low.safetensors", low_weight=0.6,
+    )

--- a/tests/golden/lynx_832x480_81f.json
+++ b/tests/golden/lynx_832x480_81f.json
@@ -1,0 +1,224 @@
+{
+  "600": {
+    "class_type": "WanVideoBlockSwap",
+    "inputs": {
+      "blocks_to_swap": 35,
+      "offload_img_emb": false,
+      "offload_txt_emb": false,
+      "vace_blocks_to_swap": 0
+    }
+  },
+  "601": {
+    "class_type": "WanVideoExtraModelSelect",
+    "inputs": {
+      "extra_model": "Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors"
+    }
+  },
+  "602": {
+    "class_type": "WanVideoExtraModelSelect",
+    "inputs": {
+      "extra_model": "Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors",
+      "prev_model": [
+        "601",
+        0
+      ]
+    }
+  },
+  "610": {
+    "class_type": "WanVideoModelLoader",
+    "inputs": {
+      "attention_mode": "sdpa",
+      "base_precision": "fp16",
+      "block_swap_args": [
+        "600",
+        0
+      ],
+      "extra_model": [
+        "602",
+        0
+      ],
+      "load_device": "offload_device",
+      "lora": [
+        "700",
+        0
+      ],
+      "model": "Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors",
+      "quantization": "fp8_e4m3fn_scaled"
+    }
+  },
+  "620": {
+    "class_type": "WanVideoVAELoader",
+    "inputs": {
+      "model_name": "wan_2.1_vae.safetensors",
+      "precision": "bf16"
+    }
+  },
+  "621": {
+    "class_type": "WanVideoTextEncodeCached",
+    "inputs": {
+      "device": "gpu",
+      "model_name": "models_t5_umt5-xxl-enc-bf16.pth",
+      "negative_prompt": "",
+      "positive_prompt": "a woman walking through a forest",
+      "precision": "bf16",
+      "quantization": "disabled",
+      "use_disk_cache": false
+    }
+  },
+  "622": {
+    "class_type": "WanVideoTextEncodeCached",
+    "inputs": {
+      "device": "gpu",
+      "model_name": "models_t5_umt5-xxl-enc-bf16.pth",
+      "negative_prompt": "",
+      "positive_prompt": "image of a face",
+      "precision": "bf16",
+      "quantization": "disabled",
+      "use_disk_cache": false
+    }
+  },
+  "630": {
+    "class_type": "LoadImage",
+    "inputs": {
+      "image": "subject.png"
+    }
+  },
+  "631": {
+    "class_type": "LynxInsightFaceCrop",
+    "inputs": {
+      "image": [
+        "630",
+        0
+      ]
+    }
+  },
+  "632": {
+    "class_type": "LoadLynxResampler",
+    "inputs": {
+      "model_name": "lynx_lite_resampler_fp32.safetensors",
+      "precision": "fp16"
+    }
+  },
+  "633": {
+    "class_type": "LynxEncodeFaceIP",
+    "inputs": {
+      "ip_image": [
+        "631",
+        0
+      ],
+      "resampler": [
+        "632",
+        0
+      ]
+    }
+  },
+  "640": {
+    "class_type": "WanVideoEmptyEmbeds",
+    "inputs": {
+      "height": 480,
+      "num_frames": 81,
+      "width": 832
+    }
+  },
+  "641": {
+    "class_type": "WanVideoAddLynxEmbeds",
+    "inputs": {
+      "embeds": [
+        "640",
+        0
+      ],
+      "end_percent": 1.0,
+      "ip_scale": 0.7,
+      "lynx_cfg_scale": 2.0,
+      "lynx_ip_embeds": [
+        "633",
+        0
+      ],
+      "ref_image": [
+        "631",
+        1
+      ],
+      "ref_scale": 0.6,
+      "ref_text_embed": [
+        "622",
+        0
+      ],
+      "start_percent": 0.0,
+      "vae": [
+        "620",
+        0
+      ]
+    }
+  },
+  "650": {
+    "class_type": "WanVideoSampler",
+    "inputs": {
+      "cfg": 1.0,
+      "end_step": -1,
+      "force_offload": true,
+      "image_embeds": [
+        "641",
+        0
+      ],
+      "model": [
+        "610",
+        0
+      ],
+      "riflex_freq_index": 0,
+      "scheduler": "lcm",
+      "seed": 42,
+      "shift": 8.0,
+      "start_step": 0,
+      "steps": 6,
+      "text_embeds": [
+        "621",
+        0
+      ]
+    }
+  },
+  "660": {
+    "class_type": "WanVideoDecode",
+    "inputs": {
+      "enable_vae_tiling": false,
+      "samples": [
+        "650",
+        0
+      ],
+      "tile_stride_x": 144,
+      "tile_stride_y": 128,
+      "tile_x": 272,
+      "tile_y": 272,
+      "vae": [
+        "620",
+        0
+      ]
+    }
+  },
+  "680": {
+    "class_type": "VHS_VideoCombine",
+    "inputs": {
+      "crf": 15,
+      "filename_prefix": "output",
+      "format": "video/h264-mp4",
+      "frame_rate": 15,
+      "images": [
+        "660",
+        0
+      ],
+      "loop_count": 0,
+      "pingpong": false,
+      "pix_fmt": "yuv420p",
+      "save_metadata": true,
+      "save_output": true,
+      "trim_to_audio": false
+    }
+  },
+  "700": {
+    "class_type": "WanVideoLoraSelect",
+    "inputs": {
+      "lora": "lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors",
+      "merge_loras": true,
+      "strength": 1.0
+    }
+  }
+}

--- a/tests/test_identity_check.py
+++ b/tests/test_identity_check.py
@@ -1,0 +1,209 @@
+"""Tests for Lynx identity QA.
+
+InsightFace and its ONNX models are not available in CI, so the detector is faked.
+What matters here is the arithmetic, the sampling, and — above all — that a QA failure
+can never propagate out and fail an otherwise good render.
+"""
+
+import json
+import logging
+
+import cv2
+import numpy as np
+import pytest
+
+from daemon import identity_check
+from daemon.identity_check import (
+    _largest_face_embedding,
+    cosine_similarity,
+    measure_identity,
+    sample_frames,
+)
+
+CID = "11111111-2222-3333-4444-555555555555"
+
+
+class FakeFace:
+    def __init__(self, embedding, bbox=(0, 0, 10, 10)):
+        self.embedding = np.array(embedding, dtype=np.float32)
+        self.bbox = np.array(bbox, dtype=np.float32)
+
+
+class FakeApp:
+    """Stand-in for InsightFace FaceAnalysis: returns queued detections per call."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls = 0
+
+    def get(self, _image):
+        self.calls += 1
+        if not self._results:
+            return []
+        return self._results.pop(0)
+
+
+@pytest.fixture(autouse=True)
+def _reset_app_cache():
+    identity_check._face_app = None
+    yield
+    identity_check._face_app = None
+
+
+@pytest.fixture
+def video(tmp_path):
+    """A real 20-frame mp4 so sample_frames exercises actual OpenCV decoding."""
+    path = tmp_path / "clip.mp4"
+    writer = cv2.VideoWriter(str(path), cv2.VideoWriter_fourcc(*"mp4v"), 15, (64, 64))
+    for i in range(20):
+        writer.write(np.full((64, 64, 3), i * 10 % 256, dtype=np.uint8))
+    writer.release()
+    return path
+
+
+@pytest.fixture
+def subject(tmp_path):
+    path = tmp_path / "subject.png"
+    cv2.imwrite(str(path), np.full((64, 64, 3), 128, dtype=np.uint8))
+    return path
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_score_one(self):
+        v = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        assert cosine_similarity(v, v) == pytest.approx(1.0)
+
+    def test_orthogonal_vectors_score_zero(self):
+        a = np.array([1.0, 0.0], dtype=np.float32)
+        b = np.array([0.0, 1.0], dtype=np.float32)
+        assert cosine_similarity(a, b) == pytest.approx(0.0)
+
+    def test_opposite_vectors_score_minus_one(self):
+        a = np.array([1.0, 0.0], dtype=np.float32)
+        assert cosine_similarity(a, -a) == pytest.approx(-1.0)
+
+    def test_zero_vector_does_not_divide_by_zero(self):
+        a = np.zeros(3, dtype=np.float32)
+        b = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        assert cosine_similarity(a, b) == 0.0
+
+
+class TestLargestFaceEmbedding:
+    def test_returns_none_when_no_face(self):
+        assert _largest_face_embedding(FakeApp([[]]), np.zeros((8, 8, 3))) is None
+
+    def test_picks_the_largest_bbox(self):
+        small = FakeFace([1.0, 0.0], bbox=(0, 0, 5, 5))
+        large = FakeFace([0.0, 1.0], bbox=(0, 0, 50, 50))
+        app = FakeApp([[small, large]])
+        assert _largest_face_embedding(app, np.zeros((8, 8, 3))).tolist() == [0.0, 1.0]
+
+
+class TestSampleFrames:
+    def test_samples_requested_count(self, video):
+        assert len(sample_frames(str(video), 5)) == 5
+
+    def test_zero_count_returns_nothing(self, video):
+        assert sample_frames(str(video), 0) == []
+
+    def test_unreadable_video_returns_empty(self, tmp_path):
+        assert sample_frames(str(tmp_path / "nope.mp4"), 5) == []
+
+
+class TestMeasureIdentity:
+    def test_scores_frames_against_subject(self, monkeypatch, video, subject, caplog):
+        subject_face = [FakeFace([1.0, 0.0])]
+        # frame 1 identical, frame 2 orthogonal, frame 3 has no face at all
+        frames = [[FakeFace([1.0, 0.0])], [FakeFace([0.0, 1.0])], []]
+        app = FakeApp([subject_face, *frames])
+        monkeypatch.setattr(identity_check, "_get_face_app", lambda: app)
+
+        with caplog.at_level(logging.INFO):
+            result = measure_identity(str(video), str(subject), CID, sample_count=3)
+
+        assert result["scores"] == [1.0, 0.0]
+        assert result["frames_sampled"] == 3
+        assert result["frames_with_face"] == 2
+        assert result["mean"] == pytest.approx(0.5)
+        assert result["min"] == 0.0 and result["max"] == 1.0
+
+        logged = [json.loads(r.message) for r in caplog.records if r.message.startswith("{")]
+        qa = [e for e in logged if e["event"] == "lynx.identity_qa"]
+        assert qa and qa[0]["correlation_id"] == CID
+
+    def test_uses_settings_default_sample_count(self, monkeypatch, video, subject):
+        from daemon.config import settings
+        app = FakeApp([[FakeFace([1.0, 0.0])]] * (settings.lynx_identity_sample_frames + 1))
+        monkeypatch.setattr(identity_check, "_get_face_app", lambda: app)
+        result = measure_identity(str(video), str(subject), CID)
+        assert result["frames_sampled"] == settings.lynx_identity_sample_frames
+
+    def test_no_faces_anywhere_yields_null_stats(self, monkeypatch, video, subject):
+        app = FakeApp([[FakeFace([1.0, 0.0])], [], [], []])
+        monkeypatch.setattr(identity_check, "_get_face_app", lambda: app)
+        result = measure_identity(str(video), str(subject), CID, sample_count=3)
+        assert result["scores"] == []
+        assert result["mean"] is None and result["min"] is None and result["max"] is None
+
+    def test_returns_none_without_insightface(self, monkeypatch, video, subject):
+        monkeypatch.setattr(identity_check, "_get_face_app", lambda: None)
+        assert measure_identity(str(video), str(subject), CID) is None
+
+    def test_returns_none_for_unreadable_subject(self, monkeypatch, video, tmp_path):
+        monkeypatch.setattr(identity_check, "_get_face_app", lambda: FakeApp([]))
+        assert measure_identity(str(video), str(tmp_path / "missing.png"), CID) is None
+
+    def test_returns_none_when_subject_has_no_face(self, monkeypatch, video, subject):
+        monkeypatch.setattr(identity_check, "_get_face_app", lambda: FakeApp([[]]))
+        assert measure_identity(str(video), str(subject), CID) is None
+
+    def test_never_raises(self, monkeypatch, video, subject):
+        """A QA metric must not be able to fail a good render."""
+        def explode():
+            raise RuntimeError("detector exploded")
+        monkeypatch.setattr(identity_check, "_get_face_app", explode)
+        assert measure_identity(str(video), str(subject), CID) is None
+
+
+class TestGetFaceApp:
+    def test_missing_insightface_returns_none(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("insightface"):
+                raise ImportError("no insightface here")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        assert identity_check._get_face_app() is None
+
+    def test_app_is_cached(self, monkeypatch):
+        sentinel = object()
+        identity_check._face_app = sentinel
+        assert identity_check._get_face_app() is sentinel
+
+    def test_builds_and_prepares_face_analysis(self, monkeypatch):
+        """insightface is absent locally, so stand a fake module in to cover the happy path."""
+        import sys
+        import types
+
+        prepared = {}
+
+        class FakeFaceAnalysis:
+            def prepare(self, ctx_id, det_size):
+                prepared["ctx_id"] = ctx_id
+                prepared["det_size"] = det_size
+
+        app_module = types.ModuleType("insightface.app")
+        app_module.FaceAnalysis = FakeFaceAnalysis
+        root = types.ModuleType("insightface")
+        root.app = app_module
+        monkeypatch.setitem(sys.modules, "insightface", root)
+        monkeypatch.setitem(sys.modules, "insightface.app", app_module)
+
+        app = identity_check._get_face_app()
+        assert isinstance(app, FakeFaceAnalysis)
+        assert prepared == {"ctx_id": 0, "det_size": (640, 640)}
+        # second call returns the cached instance rather than rebuilding
+        assert identity_check._get_face_app() is app

--- a/tests/test_lynx_executor.py
+++ b/tests/test_lynx_executor.py
@@ -1,0 +1,282 @@
+"""Tests for the Lynx segment execution path.
+
+ComfyUI and the queue API are faked; the concern here is the orchestration contract —
+what gets submitted, what gets reported back, and which failures are surfaced how.
+"""
+
+import io
+import json
+import logging
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from daemon import executor
+from daemon.comfyui_client import ComfyUIExecutionError
+from daemon.executor import _execute_lynx, _measure_lynx_identity, _resolve_lynx_subject
+from daemon.workflow_builder import LynxValidationError
+from tests.conftest import make_segment
+
+CID = "11111111-2222-3333-4444-555555555555"
+
+
+def png_bytes(size=(256, 256)) -> bytes:
+    """A noisy PNG — _validate_image_data rejects anything under 1 KB, and a flat
+    fill compresses well below that."""
+    buf = io.BytesIO()
+    rng = np.random.default_rng(0)
+    Image.fromarray(rng.integers(0, 255, (*size, 3), dtype=np.uint8)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class FakeComfyUI:
+    def __init__(self, video_output=True, execution_error=None):
+        self.submitted = None
+        self.uploaded = []
+        self._video_output = video_output
+        self._execution_error = execution_error
+
+    async def upload_image(self, data, filename):
+        self.uploaded.append(filename)
+        return filename
+
+    async def submit_workflow(self, workflow):
+        self.submitted = workflow
+        return "promptid123456", "clientid"
+
+    async def monitor_execution(self, prompt_id, client_id, progress=None):
+        if self._execution_error:
+            raise self._execution_error
+
+    async def get_history(self, prompt_id):
+        return {"outputs": {}}
+
+    def find_video_output(self, history):
+        return {"filename": "out.mp4", "subfolder": "", "type": "output"} if self._video_output else None
+
+    async def download_output(self, filename, subfolder, output_type):
+        return b"video-bytes"
+
+
+class FakeQueue:
+    def __init__(self, file_bytes=None):
+        self.updates = []
+        self.outputs = []
+        self.progress_logs = []
+        self._file_bytes = file_bytes or png_bytes()
+
+    async def download_file(self, path):
+        return self._file_bytes
+
+    async def update_segment(self, segment_id, result):
+        self.updates.append(result)
+
+    async def upload_segment_output(self, segment_id, video, last_frame, result):
+        self.outputs.append(result)
+
+    async def update_segment_progress(self, *a, **kw):
+        self.progress_logs.append((a, kw))
+
+
+@pytest.fixture(autouse=True)
+def _stub_side_effects(monkeypatch):
+    """Neutralise LoRA sync, last-frame extraction and GPU polling."""
+    async def noop_loras(loras, queue):
+        return None
+
+    async def fake_last_frame(data):
+        return png_bytes()
+
+    monkeypatch.setattr(executor, "ensure_loras_available", noop_loras)
+    monkeypatch.setattr(executor, "_extract_last_frame", fake_last_frame)
+    monkeypatch.setattr("daemon.stage_log.get_gpu_stats",
+                        lambda: {"gpu_name": "x", "vram_used_mb": 18000, "vram_total_mb": 24576})
+
+
+def _failure(queue):
+    """The terminal failure update. ProgressLog also calls update_segment with
+    'processing' rows, so index 0 is not the outcome."""
+    failed = [u for u in queue.updates if u.status == "failed"]
+    assert failed, f"no failure update recorded (got {[u.status for u in queue.updates]})"
+    return failed[-1]
+
+
+def _events(caplog):
+    return [json.loads(r.message) for r in caplog.records if r.message.startswith("{")]
+
+
+class TestResolveSubject:
+    async def test_s3_subject_is_downloaded_and_uploaded(self):
+        seg = make_segment(lynx_subject_image="s3://bucket/face.png")
+        comfy, queue = FakeComfyUI(), FakeQueue()
+        filename, data = await _resolve_lynx_subject(seg, comfy, queue)
+        assert filename.startswith("lynx_subject_")
+        assert filename.endswith(".png")
+        assert data == queue._file_bytes
+        assert comfy.uploaded == [filename]
+
+    async def test_plain_filename_passes_through(self):
+        seg = make_segment(lynx_subject_image="already_there.png")
+        filename, data = await _resolve_lynx_subject(seg, FakeComfyUI(), FakeQueue())
+        assert filename == "already_there.png"
+        assert data == b""
+
+    async def test_missing_subject_raises_validation_error(self):
+        seg = make_segment(lynx_subject_image=None)
+        with pytest.raises(LynxValidationError, match="lynx_subject_image"):
+            await _resolve_lynx_subject(seg, FakeComfyUI(), FakeQueue())
+
+
+class TestExecuteLynx:
+    async def test_happy_path_submits_and_reports_completed(self, monkeypatch, caplog):
+        monkeypatch.setattr(executor, "measure_identity",
+                            lambda v, s, c: {"mean": 0.61, "scores": [0.6, 0.62]})
+        comfy, queue = FakeComfyUI(), FakeQueue()
+        seg = make_segment(lynx_subject_image="s3://bucket/face.png")
+
+        with caplog.at_level(logging.INFO):
+            await _execute_lynx(seg, comfy, queue)
+
+        assert comfy.submitted is not None
+        assert comfy.submitted["650"]["class_type"] == "WanVideoSampler"
+        assert len(queue.outputs) == 1
+        result = queue.outputs[0]
+        assert result.status == "completed"
+        assert result.lynx_identity_scores == {"mean": 0.61, "scores": [0.6, 0.62]}
+
+    async def test_character_lora_is_synced_before_generating(self, monkeypatch):
+        from daemon.schemas import LoraItem
+
+        synced = {}
+
+        async def fake_sync(loras, queue):
+            synced["files"] = [item.high_file for item in loras]
+
+        monkeypatch.setattr(executor, "ensure_loras_available", fake_sync)
+        monkeypatch.setattr(executor, "measure_identity", lambda v, s, c: None)
+        seg = make_segment(
+            lynx_subject_image="s3://b/f.png",
+            loras=[LoraItem(lora_id="a", high_file="k3lly.safetensors", high_weight=0.8)],
+        )
+        comfy = FakeComfyUI()
+        await _execute_lynx(seg, comfy, FakeQueue())
+        assert synced["files"] == ["k3lly.safetensors"]
+        # and the LoRA actually reached the graph, stacked after the distill LoRA
+        assert comfy.submitted["701"]["inputs"]["lora"] == "k3lly.safetensors"
+
+    async def test_stage_logging_carries_correlation_id_and_vram(self, monkeypatch, caplog):
+        monkeypatch.setattr(executor, "measure_identity", lambda v, s, c: None)
+        with caplog.at_level(logging.INFO):
+            await _execute_lynx(make_segment(lynx_subject_image="s3://b/f.png"),
+                                FakeComfyUI(), FakeQueue())
+        events = _events(caplog)
+        names = [e["event"] for e in events]
+        for expected in ("lynx.segment_start", "lynx.build.start", "lynx.build.end",
+                         "lynx.generate.start", "lynx.generate.end", "lynx.segment_complete"):
+            assert expected in names
+        assert {e["correlation_id"] for e in events} == {CID}
+        generate_end = next(e for e in events if e["event"] == "lynx.generate.end")
+        assert generate_end["vram_peak_mb"] == 18000
+        assert generate_end["vram_total_mb"] == 24576
+
+    async def test_validation_failure_reports_failed_without_submitting(self, caplog):
+        comfy, queue = FakeComfyUI(), FakeQueue()
+        seg = make_segment(width=512, height=512, lynx_subject_image="s3://b/f.png")
+        with caplog.at_level(logging.INFO):
+            await _execute_lynx(seg, comfy, queue)
+        assert comfy.submitted is None
+        assert _failure(queue).status == "failed"
+        assert "512x512" in _failure(queue).error_message
+        assert "lynx.validation_failed" in [e["event"] for e in _events(caplog)]
+
+    async def test_faceless_subject_gets_an_explanatory_error(self):
+        err = ComfyUIExecutionError("No face detected in the image")
+        err.node_id, err.node_type, err.traceback = "631", "LynxInsightFaceCrop", None
+        comfy = FakeComfyUI(execution_error=err)
+        queue = FakeQueue()
+        await _execute_lynx(make_segment(lynx_subject_image="s3://b/f.png"), comfy, queue)
+        message = _failure(queue).error_message
+        assert _failure(queue).status == "failed"
+        assert "ArcFace-conditioned" in message
+
+    async def test_other_comfyui_errors_keep_node_context(self):
+        err = ComfyUIExecutionError("OOM")
+        err.node_id, err.node_type, err.traceback = "650", "WanVideoSampler", "trace"
+        queue = FakeQueue()
+        await _execute_lynx(make_segment(lynx_subject_image="s3://b/f.png"),
+                            FakeComfyUI(execution_error=err), queue)
+        assert "node 650" in _failure(queue).error_message
+        assert "WanVideoSampler" in _failure(queue).error_message
+
+    async def test_missing_video_output_fails_the_segment(self):
+        queue = FakeQueue()
+        await _execute_lynx(make_segment(lynx_subject_image="s3://b/f.png"),
+                            FakeComfyUI(video_output=False), queue)
+        assert _failure(queue).status == "failed"
+        assert "No video output" in _failure(queue).error_message
+
+    async def test_identity_qa_failure_does_not_fail_the_segment(self, monkeypatch):
+        def explode(*a, **kw):
+            raise RuntimeError("qa died")
+        monkeypatch.setattr(executor, "measure_identity", explode)
+        queue = FakeQueue()
+        await _execute_lynx(make_segment(lynx_subject_image="s3://b/f.png"),
+                            FakeComfyUI(), queue)
+        assert queue.outputs[0].status == "completed"
+        assert queue.outputs[0].lynx_identity_scores is None
+
+
+class TestMeasureLynxIdentity:
+    async def test_returns_none_without_subject_bytes(self):
+        assert await _measure_lynx_identity(b"video", b"", CID) is None
+
+    async def test_delegates_to_identity_check(self, monkeypatch):
+        captured = {}
+
+        def fake_measure(video_path, subject_path, correlation_id):
+            captured["video"] = open(video_path, "rb").read()
+            captured["subject"] = open(subject_path, "rb").read()
+            return {"mean": 0.7}
+
+        monkeypatch.setattr(executor, "measure_identity", fake_measure)
+        result = await _measure_lynx_identity(b"video-bytes", b"subject-bytes", CID)
+        assert result == {"mean": 0.7}
+        assert captured == {"video": b"video-bytes", "subject": b"subject-bytes"}
+
+    async def test_swallows_errors(self, monkeypatch):
+        def explode(*a, **kw):
+            raise OSError("disk gone")
+        monkeypatch.setattr(executor, "measure_identity", explode)
+        assert await _measure_lynx_identity(b"v", b"s", CID) is None
+
+
+class TestDispatch:
+    async def test_generation_engine_routes_to_lynx(self, monkeypatch):
+        called = {}
+
+        async def fake_lynx(segment, comfyui, queue):
+            called["hit"] = segment.id
+
+        monkeypatch.setattr(executor, "_execute_lynx", fake_lynx)
+        await executor.execute_segment(make_segment(generation_engine="lynx"),
+                                       FakeComfyUI(), FakeQueue())
+        assert called["hit"] == make_segment().id
+
+    async def test_other_engines_do_not_route_to_lynx(self, monkeypatch):
+        called = {}
+
+        async def fake_lynx(segment, comfyui, queue):
+            called["hit"] = True
+
+        def fake_build(*a, **kw):
+            raise RuntimeError("stop here")
+
+        monkeypatch.setattr(executor, "_execute_lynx", fake_lynx)
+        monkeypatch.setattr(executor, "build_workflow", fake_build)
+        seg = make_segment(generation_engine=None)
+        queue = FakeQueue()
+        await executor.execute_segment(seg, FakeComfyUI(), queue)
+        # routed to the traditional builder (which we made raise), never to Lynx
+        assert "hit" not in called
+        assert "stop here" in _failure(queue).error_message

--- a/tests/test_lynx_executor.py
+++ b/tests/test_lynx_executor.py
@@ -14,7 +14,12 @@ from PIL import Image
 
 from daemon import executor
 from daemon.comfyui_client import ComfyUIExecutionError
-from daemon.executor import _execute_lynx, _measure_lynx_identity, _resolve_lynx_subject
+from daemon.executor import (
+    _execute_lynx,
+    _lynx_preflight,
+    _measure_lynx_identity,
+    _resolve_lynx_subject,
+)
 from daemon.workflow_builder import LynxValidationError
 from tests.conftest import make_segment
 
@@ -30,12 +35,47 @@ def png_bytes(size=(256, 256)) -> bytes:
     return buf.getvalue()
 
 
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class FakeHTTP:
+    """Stands in for the ComfyUI /object_info probes the preflight makes."""
+
+    def __init__(self, lynx_available=True, resamplers=None, raises=False):
+        self._lynx_available = lynx_available
+        self._resamplers = resamplers
+        self._raises = raises
+
+    async def get(self, path):
+        if self._raises:
+            raise ConnectionError("comfyui unreachable")
+        if path.endswith("WanVideoAddLynxEmbeds"):
+            if not self._lynx_available:
+                return FakeResponse({}, status_code=404)
+            return FakeResponse({"WanVideoAddLynxEmbeds": {}})
+        if path.endswith("LoadLynxResampler"):
+            choices = self._resamplers if self._resamplers is not None else [
+                "lynx_lite_resampler_fp32.safetensors",
+                "lynx_full_resampler_fp32.safetensors",
+            ]
+            return FakeResponse({"LoadLynxResampler": {
+                "input": {"required": {"model_name": [choices]}}}})
+        return FakeResponse({}, status_code=404)
+
+
 class FakeComfyUI:
-    def __init__(self, video_output=True, execution_error=None):
+    def __init__(self, video_output=True, execution_error=None, http=None):
         self.submitted = None
         self.uploaded = []
         self._video_output = video_output
         self._execution_error = execution_error
+        self.http = http or FakeHTTP()
 
     async def upload_image(self, data, filename):
         self.uploaded.append(filename)
@@ -225,6 +265,51 @@ class TestExecuteLynx:
                             FakeComfyUI(), queue)
         assert queue.outputs[0].status == "completed"
         assert queue.outputs[0].lynx_identity_scores is None
+
+
+class TestPreflight:
+    """A worker that cannot run Lynx must say why — there is no silent fallback."""
+
+    async def test_passes_when_nodes_and_resampler_present(self):
+        await _lynx_preflight(FakeComfyUI(), make_segment())
+
+    async def test_missing_lynx_nodes_names_both_causes(self):
+        comfy = FakeComfyUI(http=FakeHTTP(lynx_available=False))
+        with pytest.raises(LynxValidationError) as exc:
+            await _lynx_preflight(comfy, make_segment())
+        message = str(exc.value)
+        assert "1.3.5" in message           # wrapper too old
+        assert "insightface" in message     # or the import failed
+
+    async def test_unreachable_comfyui_is_reported(self):
+        comfy = FakeComfyUI(http=FakeHTTP(raises=True))
+        with pytest.raises(LynxValidationError, match="could not query ComfyUI"):
+            await _lynx_preflight(comfy, make_segment())
+
+    async def test_missing_resampler_file_is_caught_before_submitting(self):
+        comfy = FakeComfyUI(http=FakeHTTP(resamplers=["something_else.safetensors"]))
+        with pytest.raises(LynxValidationError, match="not in this worker's diffusion_models"):
+            await _lynx_preflight(comfy, make_segment())
+
+    async def test_unenumerable_resamplers_are_tolerated(self):
+        """Node exists but we cannot list files — let the run surface any real problem."""
+        class OddHTTP(FakeHTTP):
+            async def get(self, path):
+                if path.endswith("LoadLynxResampler"):
+                    raise RuntimeError("weird")
+                return await super().get(path)
+
+        await _lynx_preflight(FakeComfyUI(http=OddHTTP()), make_segment())
+
+    async def test_empty_choice_list_is_tolerated(self):
+        await _lynx_preflight(FakeComfyUI(http=FakeHTTP(resamplers=[])), make_segment())
+
+    async def test_preflight_failure_fails_the_segment_without_submitting(self):
+        comfy = FakeComfyUI(http=FakeHTTP(lynx_available=False))
+        queue = FakeQueue()
+        await _execute_lynx(make_segment(lynx_subject_image="s3://b/f.png"), comfy, queue)
+        assert comfy.submitted is None
+        assert "1.3.5" in _failure(queue).error_message
 
 
 class TestMeasureLynxIdentity:

--- a/tests/test_lynx_workflow.py
+++ b/tests/test_lynx_workflow.py
@@ -1,0 +1,317 @@
+"""Tests for the Lynx identity-preserving graph builder."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from daemon.config import settings
+from daemon.schemas import LoraItem
+from daemon.workflow_builder import (
+    LYNX_ARMS,
+    LYNX_RESOLUTIONS,
+    WANVIDEO_SCHEDULERS,
+    LynxValidationError,
+    _lynx_arm,
+    _pick,
+    _validate_lynx,
+    build_lynx_workflow,
+    lynx_num_frames,
+)
+from tests.conftest import make_segment
+
+GOLDEN = Path(__file__).parent / "golden" / "lynx_832x480_81f.json"
+
+
+class TestPick:
+    """Per-job-override -> settings-default precedence."""
+
+    def test_none_falls_back_to_default(self):
+        assert _pick(None, 0.7) == 0.7
+
+    @pytest.mark.parametrize("override", [0, 0.0, "", False, 1.5, "lcm"])
+    def test_falsy_but_set_overrides_win(self, override):
+        # 0 / "" / False are legitimate overrides, not "unset" — only None defers.
+        assert _pick(override, "default") == override
+
+
+class TestLynxArm:
+    @pytest.mark.parametrize("name,expected", [
+        ("Wan2_1-T2V-14B-Lynx_lite_ip_layers_fp16.safetensors", "lite"),
+        ("lynx_full_resampler_fp32.safetensors", "full"),
+        ("LYNX_FULL_RESAMPLER.safetensors", "full"),
+    ])
+    def test_detects_arm(self, name, expected):
+        assert _lynx_arm(name) == expected
+
+    @pytest.mark.parametrize("name", [
+        "some_other_adapter.safetensors",          # no marker
+        "lynx_lite_full_mixed.safetensors",        # ambiguous: both markers
+    ])
+    def test_unclassifiable_returns_none(self, name):
+        assert _lynx_arm(name) is None
+
+    def test_arms_constant(self):
+        assert LYNX_ARMS == ("lite", "full")
+
+
+class TestLynxNumFrames:
+    def test_lands_on_4n_plus_1(self):
+        assert lynx_num_frames(make_segment(duration_seconds=5.4)) == 81
+
+    @pytest.mark.parametrize("duration", [0.1, 0.25, 1.0, 2.0, 3.7, 8.0])
+    def test_always_on_grid_and_minimum(self, duration):
+        n = lynx_num_frames(make_segment(duration_seconds=duration))
+        assert n >= 5
+        assert (n - 1) % 4 == 0
+
+
+class TestValidation:
+    """Constraints raise with the offending value named — never silently clamp."""
+
+    def test_missing_subject_rejected(self):
+        with pytest.raises(LynxValidationError, match="subject_image"):
+            _validate_lynx(make_segment(), "", 81, "lite_ip.safetensors", "lite_res.safetensors")
+
+    @pytest.mark.parametrize("w,h", [(512, 512), (1920, 1080), (480, 832), (1024, 576)])
+    def test_off_bucket_resolution_rejected(self, w, h):
+        seg = make_segment(width=w, height=h)
+        with pytest.raises(LynxValidationError, match=f"{w}x{h}"):
+            _validate_lynx(seg, "s.png", 81, "lite_ip.safetensors", "lite_res.safetensors")
+
+    @pytest.mark.parametrize("w,h", sorted(LYNX_RESOLUTIONS))
+    def test_native_buckets_accepted(self, w, h):
+        seg = make_segment(width=w, height=h)
+        _validate_lynx(seg, "s.png", 81, "lite_ip.safetensors", "lite_res.safetensors")
+
+    @pytest.mark.parametrize("frames", [0, 3, 4, 80, 82, 100])
+    def test_off_grid_frame_count_rejected(self, frames):
+        with pytest.raises(LynxValidationError, match="4n\\+1"):
+            _validate_lynx(make_segment(), "s.png", frames, "lite_ip.safetensors", "lite_res.safetensors")
+
+    @pytest.mark.parametrize("frames", [5, 9, 81, 121])
+    def test_on_grid_frame_count_accepted(self, frames):
+        _validate_lynx(make_segment(), "s.png", frames, "lite_ip.safetensors", "lite_res.safetensors")
+
+    @pytest.mark.parametrize("ip,res", [
+        ("lynx_lite_ip.safetensors", "lynx_full_resampler.safetensors"),   # mixed arms
+        ("lynx_full_ip.safetensors", "lynx_lite_resampler.safetensors"),   # mixed arms
+        ("unmarked_ip.safetensors", "lynx_full_resampler.safetensors"),    # unclassifiable
+    ])
+    def test_mismatched_adapter_pair_rejected(self, ip, res):
+        with pytest.raises(LynxValidationError, match="same arm"):
+            _validate_lynx(make_segment(), "s.png", 81, ip, res)
+
+    def test_build_surfaces_validation(self):
+        # The public builder must validate, not just the private helper.
+        with pytest.raises(LynxValidationError):
+            build_lynx_workflow(make_segment(width=512, height=512), "s.png", 81)
+
+
+class TestGraphTopology:
+    """The wiring that makes Lynx identity-preserving, asserted structurally."""
+
+    def test_node_set(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        # 700 = the distill LoRA (on by default); no 670 because fps 15 needs no RIFE.
+        assert set(wf) == {
+            "600", "601", "602", "610", "620", "621", "622",
+            "630", "631", "632", "633", "640", "641", "650", "660", "680", "700",
+        }
+
+    def test_adapters_chain_into_the_loader(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["601"]["inputs"]["extra_model"] == settings.lynx_ip_layers
+        assert wf["602"]["inputs"]["extra_model"] == settings.lynx_ref_layers
+        # ref selector chains onto the ip selector, and only the tail reaches the loader
+        assert wf["602"]["inputs"]["prev_model"] == ["601", 0]
+        assert wf["610"]["inputs"]["extra_model"] == ["602", 0]
+
+    def test_subject_feeds_both_adapters(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["630"]["inputs"]["image"] == "subject.png"
+        # crop output 0 (112px ArcFace crop) -> resampler; output 1 (256px) -> ref adapter
+        assert wf["631"]["inputs"]["image"] == ["630", 0]
+        assert wf["633"]["inputs"]["ip_image"] == ["631", 0]
+        assert wf["641"]["inputs"]["ref_image"] == ["631", 1]
+        assert wf["633"]["inputs"]["resampler"] == ["632", 0]
+
+    def test_subject_is_not_a_start_frame(self, segment):
+        """T2V conditioned on a subject — the image must never become frame 0."""
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["640"]["class_type"] == "WanVideoEmptyEmbeds"
+        assert not any(n["class_type"] == "WanVideoImageToVideoEncode" for n in wf.values())
+        # nothing feeds LoadImage into the latent/embeds path
+        assert wf["640"]["inputs"] == {"width": 832, "height": 480, "num_frames": 81}
+
+    def test_ref_path_supplies_its_own_text_embed_and_vae(self, segment):
+        """WanVideoAddLynxEmbeds raises if ref_image comes without ref_text_embed + vae."""
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["641"]["inputs"]["ref_text_embed"] == ["622", 0]
+        assert wf["641"]["inputs"]["vae"] == ["620", 0]
+        assert wf["622"]["inputs"]["positive_prompt"] == settings.lynx_ref_prompt
+        # the ref-pass embed is distinct from the main prompt embed
+        assert wf["621"]["inputs"]["positive_prompt"] == segment.prompt
+
+    def test_text_encoders_use_cached_offload_path(self, segment):
+        """umt5-xxl residency has OOM'd this box; both encodes use the cached node."""
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        for nid in ("621", "622"):
+            assert wf[nid]["class_type"] == "WanVideoTextEncodeCached"
+            assert wf[nid]["inputs"]["model_name"] == settings.lynx_t5_model
+
+    def test_block_swap_and_fp8_quantisation(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["610"]["inputs"]["quantization"] == "fp8_e4m3fn_scaled"
+        assert wf["610"]["inputs"]["load_device"] == "offload_device"
+        assert wf["610"]["inputs"]["block_swap_args"] == ["600", 0]
+        assert wf["600"]["inputs"]["blocks_to_swap"] == settings.lynx_blocks_to_swap
+
+    def test_sampler_consumes_lynx_embeds_not_raw_latents(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["650"]["inputs"]["image_embeds"] == ["641", 0]
+        assert wf["641"]["inputs"]["embeds"] == ["640", 0]
+
+
+class TestParameterPrecedence:
+    def test_defaults_come_from_settings(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        embeds = wf["641"]["inputs"]
+        assert embeds["ip_scale"] == settings.lynx_ip_scale
+        assert embeds["ref_scale"] == settings.lynx_ref_scale
+        assert embeds["lynx_cfg_scale"] == settings.lynx_lynx_cfg_scale
+        assert wf["650"]["inputs"]["steps"] == settings.lynx_steps
+
+    def test_per_job_overrides_win(self):
+        seg = make_segment(
+            lynx_ip_scale=1.5, lynx_ref_scale=1.0, lynx_cfg_scale=3.0,
+            lynx_start_percent=0.1, lynx_end_percent=0.9,
+            lynx_steps=12, lynx_cfg=3.5, lynx_shift=5.0,
+        )
+        wf = build_lynx_workflow(seg, "subject.png", 81)
+        embeds, sampler = wf["641"]["inputs"], wf["650"]["inputs"]
+        assert (embeds["ip_scale"], embeds["ref_scale"]) == (1.5, 1.0)
+        assert embeds["lynx_cfg_scale"] == 3.0
+        assert (embeds["start_percent"], embeds["end_percent"]) == (0.1, 0.9)
+        assert (sampler["steps"], sampler["cfg"], sampler["shift"]) == (12, 3.5, 5.0)
+
+    def test_zero_ip_scale_is_honoured_not_treated_as_unset(self):
+        """0.0 disables the ID adapter — it must not fall back to the 0.7 default."""
+        wf = build_lynx_workflow(make_segment(lynx_ip_scale=0.0), "subject.png", 81)
+        assert wf["641"]["inputs"]["ip_scale"] == 0.0
+
+    def test_ab_arm_override_swaps_both_adapter_and_resampler(self):
+        seg = make_segment(
+            lynx_ip_layers="Wan2_1-T2V-14B-Lynx_full_ip_layers_fp16.safetensors",
+            lynx_resampler="lynx_full_resampler_fp32.safetensors",
+        )
+        wf = build_lynx_workflow(seg, "subject.png", 81)
+        assert "full_ip_layers" in wf["601"]["inputs"]["extra_model"]
+        assert "full_resampler" in wf["632"]["inputs"]["model_name"]
+
+    def test_ref_blocks_omitted_when_empty(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert "ref_blocks_to_use" not in wf["641"]["inputs"]
+
+    def test_ref_blocks_included_when_set(self):
+        seg = make_segment(lynx_ref_blocks_to_use="0-20, 25, 35-39")
+        wf = build_lynx_workflow(seg, "subject.png", 81)
+        assert wf["641"]["inputs"]["ref_blocks_to_use"] == "0-20, 25, 35-39"
+
+    @pytest.mark.parametrize("scheduler", sorted(WANVIDEO_SCHEDULERS))
+    def test_valid_wanvideo_schedulers_pass_through(self, scheduler):
+        wf = build_lynx_workflow(make_segment(lynx_scheduler=scheduler), "subject.png", 81)
+        assert wf["650"]["inputs"]["scheduler"] == scheduler
+
+    @pytest.mark.parametrize("scheduler", ["simple", "karras", "normal", "bogus"])
+    def test_ksampler_scheduler_names_fall_back(self, scheduler):
+        """KSampler names would 400 in ComfyUI — fall back rather than submit a bad graph."""
+        wf = build_lynx_workflow(make_segment(lynx_scheduler=scheduler), "subject.png", 81)
+        assert wf["650"]["inputs"]["scheduler"] == settings.lynx_scheduler
+
+
+class TestLoraStacking:
+    def test_distill_lora_present_by_default(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["700"]["inputs"]["lora"] == settings.lynx_distill_lora
+        assert wf["700"]["inputs"]["strength"] == settings.lynx_distill_strength
+        assert wf["610"]["inputs"]["lora"] == ["700", 0]
+
+    def test_zero_distill_strength_drops_the_lora(self):
+        """De-distilled path: no Lightning LoRA at all, not strength 0."""
+        wf = build_lynx_workflow(make_segment(lynx_distill_strength=0.0), "subject.png", 81)
+        assert "700" not in wf
+        assert "lora" not in wf["610"]["inputs"]
+
+    def test_character_lora_stacks_on_top_of_distill(self, lora):
+        wf = build_lynx_workflow(make_segment(loras=[lora]), "subject.png", 81)
+        assert wf["700"]["inputs"]["lora"] == settings.lynx_distill_lora
+        assert wf["701"]["inputs"]["lora"] == "k3lly_high.safetensors"
+        assert wf["701"]["inputs"]["strength"] == 0.8
+        assert wf["701"]["inputs"]["prev_lora"] == ["700", 0]
+        assert wf["610"]["inputs"]["lora"] == ["701", 0]
+
+    def test_character_lora_without_distill_starts_the_chain(self, lora):
+        wf = build_lynx_workflow(
+            make_segment(loras=[lora], lynx_distill_strength=0.0), "subject.png", 81
+        )
+        assert "prev_lora" not in wf["700"]["inputs"]
+        assert wf["700"]["inputs"]["lora"] == "k3lly_high.safetensors"
+
+    def test_low_file_used_when_no_high_file(self):
+        """Wan2.1 T2V is single-expert; a low-only LoRA still applies."""
+        item = LoraItem(lora_id="x", low_file="only_low.safetensors", low_weight=0.5)
+        wf = build_lynx_workflow(make_segment(loras=[item]), "subject.png", 81)
+        assert wf["701"]["inputs"]["lora"] == "only_low.safetensors"
+        assert wf["701"]["inputs"]["strength"] == 0.5
+
+    def test_empty_lora_entry_skipped(self):
+        wf = build_lynx_workflow(make_segment(loras=[LoraItem(lora_id="x")]), "subject.png", 81)
+        assert "701" not in wf
+
+    def test_multiple_character_loras_chain(self, lora):
+        second = LoraItem(lora_id="y", high_file="motion.safetensors", high_weight=1.0)
+        wf = build_lynx_workflow(make_segment(loras=[lora, second]), "subject.png", 81)
+        assert wf["702"]["inputs"]["prev_lora"] == ["701", 0]
+        assert wf["610"]["inputs"]["lora"] == ["702", 0]
+
+
+class TestOutputStage:
+    def test_no_rife_at_generation_fps(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert "670" not in wf
+        assert wf["680"]["inputs"]["images"] == ["660", 0]
+
+    def test_rife_inserted_for_higher_target_fps(self):
+        wf = build_lynx_workflow(make_segment(fps=30), "subject.png", 81)
+        assert wf["670"]["inputs"]["multiplier"] == 2
+        assert wf["680"]["inputs"]["images"] == ["670", 0]
+
+
+class TestStructuredLogging:
+    def test_graph_build_emits_correlated_json(self, segment, caplog):
+        with caplog.at_level("INFO"):
+            build_lynx_workflow(segment, "subject.png", 81)
+        records = [json.loads(r.message) for r in caplog.records
+                   if r.message.startswith("{")]
+        built = [r for r in records if r["event"] == "lynx.graph_built"]
+        assert len(built) == 1
+        assert built[0]["correlation_id"] == str(segment.id)
+        assert built[0]["num_frames"] == 81
+        assert built[0]["arm"] == "lite"
+        assert built[0]["resolution"] == "832x480"
+
+
+class TestGoldenFile:
+    """A fixed param set must serialise to a byte-stable ComfyUI graph."""
+
+    def test_matches_golden(self, segment):
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        actual = json.dumps(wf, indent=2, sort_keys=True)
+        if not GOLDEN.exists():  # pragma: no cover - regeneration path
+            GOLDEN.parent.mkdir(parents=True, exist_ok=True)
+            GOLDEN.write_text(actual)
+        assert actual == GOLDEN.read_text(), (
+            "Lynx graph drifted from the golden file. If intentional, delete "
+            f"{GOLDEN.name} and re-run to regenerate."
+        )

--- a/tests/test_stage_log.py
+++ b/tests/test_stage_log.py
@@ -1,0 +1,111 @@
+"""Tests for structured stage logging and VRAM sampling."""
+
+import json
+import logging
+
+import pytest
+
+from daemon import stage_log
+from daemon.stage_log import _VramSampler, log_event, stage
+
+CID = "11111111-2222-3333-4444-555555555555"
+
+
+def _json_records(caplog):
+    return [json.loads(r.message) for r in caplog.records if r.message.startswith("{")]
+
+
+class TestLogEvent:
+    def test_emits_json_with_correlation_id(self, caplog):
+        with caplog.at_level(logging.INFO):
+            payload = log_event(logging.getLogger("t"), "thing.happened", CID, frames=81)
+        assert payload == {"event": "thing.happened", "correlation_id": CID, "frames": 81}
+        assert _json_records(caplog) == [payload]
+
+    def test_respects_level(self, caplog):
+        with caplog.at_level(logging.DEBUG):
+            log_event(logging.getLogger("t"), "oops", CID, level=logging.ERROR)
+        assert caplog.records[0].levelno == logging.ERROR
+
+    def test_non_serialisable_values_are_stringified(self, caplog):
+        class Weird:
+            def __str__(self) -> str:
+                return "weird"
+
+        with caplog.at_level(logging.INFO):
+            log_event(logging.getLogger("t"), "e", CID, obj=Weird())
+        assert _json_records(caplog)[0]["obj"] == "weird"
+
+
+class TestVramSampler:
+    def test_tracks_peak_across_samples(self, monkeypatch):
+        readings = iter([
+            {"gpu_name": "x", "vram_used_mb": 1000, "vram_total_mb": 24576},
+            {"gpu_name": "x", "vram_used_mb": 21000, "vram_total_mb": 24576},
+            {"gpu_name": "x", "vram_used_mb": 5000, "vram_total_mb": 24576},
+        ])
+        monkeypatch.setattr(stage_log, "get_gpu_stats", lambda: next(readings, None))
+        sampler = _VramSampler(interval=0.01)
+        sampler._sample()
+        sampler._sample()
+        sampler._sample()
+        assert sampler.peak_mb == 21000
+        assert sampler.total_mb == 24576
+
+    def test_degrades_when_nvidia_smi_unavailable(self, monkeypatch):
+        monkeypatch.setattr(stage_log, "get_gpu_stats", lambda: None)
+        sampler = _VramSampler(interval=0.01)
+        sampler.start()
+        sampler.stop()
+        assert sampler.peak_mb is None
+        assert sampler.total_mb is None
+
+    def test_start_stop_runs_background_thread(self, monkeypatch):
+        monkeypatch.setattr(
+            stage_log, "get_gpu_stats",
+            lambda: {"gpu_name": "x", "vram_used_mb": 512, "vram_total_mb": 24576},
+        )
+        sampler = _VramSampler(interval=0.01)
+        sampler.start()
+        sampler.stop()
+        assert sampler.peak_mb == 512
+        assert sampler._thread is not None
+        assert not sampler._thread.is_alive()
+
+
+class TestStageContext:
+    def test_logs_start_and_end_with_duration_and_vram(self, monkeypatch, caplog):
+        monkeypatch.setattr(
+            stage_log, "get_gpu_stats",
+            lambda: {"gpu_name": "x", "vram_used_mb": 18000, "vram_total_mb": 24576},
+        )
+        with caplog.at_level(logging.INFO):
+            with stage(logging.getLogger("t"), "lynx.generate", CID, num_frames=81):
+                pass
+        events = _json_records(caplog)
+        assert [e["event"] for e in events] == ["lynx.generate.start", "lynx.generate.end"]
+        end = events[1]
+        assert end["correlation_id"] == CID
+        assert end["num_frames"] == 81
+        assert end["vram_peak_mb"] == 18000
+        assert end["vram_total_mb"] == 24576
+        assert end["duration_sec"] >= 0
+
+    def test_extra_dict_is_merged_into_end_record(self, monkeypatch, caplog):
+        monkeypatch.setattr(stage_log, "get_gpu_stats", lambda: None)
+        with caplog.at_level(logging.INFO):
+            with stage(logging.getLogger("t"), "lynx.build", CID) as extra:
+                extra["nodes"] = 17
+        assert _json_records(caplog)[1]["nodes"] == 17
+
+    def test_failure_logs_and_reraises(self, monkeypatch, caplog):
+        monkeypatch.setattr(stage_log, "get_gpu_stats", lambda: None)
+        with caplog.at_level(logging.INFO):
+            with pytest.raises(ValueError, match="boom"):
+                with stage(logging.getLogger("t"), "lynx.generate", CID):
+                    raise ValueError("boom")
+        events = _json_records(caplog)
+        assert [e["event"] for e in events] == ["lynx.generate.start", "lynx.generate.failed"]
+        assert events[1]["error"] == "boom"
+        assert events[1]["error_type"] == "ValueError"
+        assert caplog.records[-1].levelno == logging.ERROR


### PR DESCRIPTION
Adds the Lynx generation path: Wan2.1 T2V-14B + ByteDance Lynx ID/Ref adapters via WanVideoWrapper. Unlike a character LoRA, identity is re-asserted at **every denoising step** rather than baked into the weights — which is the thing the identity-drift audit said we were missing.

## Graph

`build_lynx_workflow`: `LynxInsightFaceCrop` → `LynxEncodeFaceIP` → `WanVideoAddLynxEmbeds`, on fp8 + block swap with the cached-T5 offload the VACE path uses (umt5-xxl residency has OOM'd this box before).

Three wiring details that only fail at runtime, all covered by tests:
1. Both adapters chain through a **single** `extra_model` list — wiring them separately loads only one.
2. The ref path **requires** its own second text embed (`"image of a face"`, hardcoded by ByteDance) plus the VAE, or the node raises.
3. `ref_blocks_to_use` is **omitted** when empty rather than passed as `""` — it is declared `forceInput`.

## Validation, not clamping

`LynxValidationError` names the offending value. Silent clamping was rejected because an off-bucket resolution or off-grid frame count degrades identity in ways that are very hard to attribute afterwards.

- Native buckets only (832×480, 1280×720); 4n+1 frames
- ip layers and resampler must be the **same arm** — a mixed pair loads *without raising* and yields garbage identity

## Defaults

Kijai's shipped reference values (lite ip + full ref, ip 0.7 / ref 0.6, 6 steps, cfg 1, shift 8, lcm), not the 1.0/1.0 usually quoted. All per-job overridable; `0` and `""` are honoured as real overrides, only `None` defers to the default.

## Preflight

A worker that cannot run Lynx fails with a diagnosis instead of a bare "node not found". Two very different causes present identically: the wrapper predates 1.3.5, **or** it is new enough but its Lynx import raised — in which case it logs a warning and silently registers nothing (a missing insightface does exactly this). No fallback to the 2.2 i2v path: different base model family.

## Identity QA

5 interior frames, InsightFace cosine vs the subject crop. **Measurement only** — no gating, and the path can never fail an otherwise good render. Caveat documented in the BUILD doc: Lynx *conditions* on facexlib ArcFace IR-SE50 but we *measure* with buffalo_l, so scores are only meaningful relative to each other across A/B arms.

## Verification

137 tests, **100% coverage on all new code**, ruff clean, new modules `mypy --strict` clean, golden-file graph test. This also establishes the daemon test suite, which was previously never committed.

Nothing has been generated yet — the BUILD doc's VRAM and similarity tables are marked UNMEASURED rather than filled with plausible numbers.