### PR TITLE
fix(lynx): make startup model validation profile-aware

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -12,6 +12,13 @@ class Settings(BaseSettings):
     queue_api_key: str = ""
     poll_interval: int = 5
 
+    # Which model families this worker was provisioned with. Mirrors MODEL_PROFILE in
+    # wanly-runpod's download_models.sh, and drives startup model validation:
+    #   "full" — Wan 2.2 i2v + VACE + Lynx (the default)
+    #   "lynx" — Wan2.1 T2V + Lynx adapters only (a lean pod; no 2.2 i2v weights)
+    # A mismatch here fails startup on a perfectly healthy worker, so the two must agree.
+    model_profile: str = "full"
+
     # Model filenames (vary per GPU worker — override in .env)
     clip_model: str = "umt5_xxl_fp8_e4m3fn_scaled.safetensors"
     vae_model: str = "wan_2.1_vae.safetensors"

--- a/daemon/model_validator.py
+++ b/daemon/model_validator.py
@@ -24,14 +24,49 @@ MIN_SIZES = {
 # Map config setting names → (ComfyUI loader node, subfolder search list, min size key)
 # Multiple subfolders because ComfyUI searches several dirs per model type
 # (e.g. CLIPLoader searches both clip/ and text_encoders/)
-MODEL_CHECKS = [
-    ("clip_model",          "CLIPLoader",           ["clip", "text_encoders"],  MIN_SIZES["clip"]),
+
+# Shared by every profile.
+_COMMON_CHECKS = [
     ("vae_model",           "VAELoader",            ["vae"],                    MIN_SIZES["vae"]),
+]
+
+# Default Wan 2.2 i2v generation path.
+_WAN22_CHECKS = [
+    ("clip_model",          "CLIPLoader",           ["clip", "text_encoders"],  MIN_SIZES["clip"]),
     ("unet_high_model",     "UNETLoader",           ["diffusion_models", "unet"], MIN_SIZES["unet"]),
     ("unet_low_model",      "UNETLoader",           ["diffusion_models", "unet"], MIN_SIZES["unet"]),
     ("lightx2v_lora_high",  "LoraLoaderModelOnly",  ["loras"],                  MIN_SIZES["loras"]),
     ("lightx2v_lora_low",   "LoraLoaderModelOnly",  ["loras"],                  MIN_SIZES["loras"]),
 ]
+
+# Lynx-only worker: Wan2.1 T2V base + adapters. The 2.2 i2v models are absent by
+# design, so requiring them here would block startup on a correctly-provisioned pod.
+# The Lynx models load through WanVideoWrapper's own loaders (which read
+# diffusion_models/), not UNETLoader, so they are size-checked on disk rather than
+# looked up in a ComfyUI loader's dropdown.
+_LYNX_CHECKS = [
+    ("lynx_t2v_model",      None,                   ["diffusion_models"],       MIN_SIZES["unet"]),
+    ("lynx_ip_layers",      None,                   ["diffusion_models"],       MIN_SIZES["loras"]),
+    ("lynx_ref_layers",     None,                   ["diffusion_models"],       MIN_SIZES["loras"]),
+    ("lynx_resampler",      None,                   ["diffusion_models"],       MIN_SIZES["loras"]),
+]
+
+
+def get_model_checks() -> list[tuple]:
+    """Model checks for this worker's provisioned profile.
+
+    Mirrors MODEL_PROFILE in wanly-runpod's download_models.sh — a worker validates
+    exactly what it was provisioned to download. Keeping the two in sync matters: a
+    lynx-profile pod has no 2.2 i2v weights, and validating them would fail startup
+    on a perfectly healthy worker.
+    """
+    if settings.model_profile.strip().lower() == "lynx":
+        return _COMMON_CHECKS + _LYNX_CHECKS
+    return _COMMON_CHECKS + _WAN22_CHECKS
+
+
+# Back-compat for callers/tests that import the flat list (full profile).
+MODEL_CHECKS = _COMMON_CHECKS + _WAN22_CHECKS
 
 PARTIAL_EXTENSIONS = {".aria2", ".tmp", ".part"}
 
@@ -90,13 +125,19 @@ async def validate_models(comfyui_client) -> bool:
         logger.warning("COMFYUI_PATH not set — skipping model validation")
         return True
 
+    checks = get_model_checks()
+    logger.info("Validating models for profile=%s (%d checks)",
+                settings.model_profile, len(checks))
+
     # Try to get available models from ComfyUI's /object_info
     available_models: dict[str, set[str]] = {}
     try:
         resp = await comfyui_client.http.get("/object_info", timeout=30)
         if resp.status_code == 200:
             object_info = resp.json()
-            for _setting, loader_node, _subfolders, _min_size in MODEL_CHECKS:
+            for _setting, loader_node, _subfolders, _min_size in checks:
+                if loader_node is None:
+                    continue  # disk-only check (WanVideoWrapper loaders)
                 node_info = object_info.get(loader_node, {})
                 inputs = node_info.get("input", {}).get("required", {})
                 # Model filename is typically the first input parameter
@@ -110,13 +151,13 @@ async def validate_models(comfyui_client) -> bool:
     all_ok = True
     logger.info("--- Model validation ---")
 
-    for setting_name, loader_node, subfolders, min_size in MODEL_CHECKS:
-        filename = getattr(settings, setting_name)
+    for setting_name, loader_node, subfolders, min_size in checks:
+        filename = getattr(settings, setting_name, None)
         if not filename:
             continue
 
-        # Check if ComfyUI knows about it
-        known_models = available_models.get(loader_node)
+        # Check if ComfyUI knows about it (skipped for disk-only checks)
+        known_models = available_models.get(loader_node) if loader_node else None
         if known_models and filename not in known_models:
             logger.error("  MISSING %s=%s — not found in ComfyUI %s model list", setting_name, filename, loader_node)
             all_ok = False

--- a/tests/test_model_validator.py
+++ b/tests/test_model_validator.py
@@ -1,0 +1,146 @@
+"""Tests for profile-aware startup model validation.
+
+The regression these guard: a lynx-profile pod has no Wan 2.2 i2v weights by design.
+Validating them anyway fails startup on a perfectly healthy worker — which is exactly
+what happened on the first Lynx pod boot.
+"""
+
+import pytest
+
+from daemon import model_validator
+from daemon.model_validator import (
+    _LYNX_CHECKS,
+    _WAN22_CHECKS,
+    MODEL_CHECKS,
+    get_model_checks,
+    validate_models,
+)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class FakeHTTP:
+    def __init__(self, object_info=None):
+        self._object_info = object_info if object_info is not None else {}
+
+    async def get(self, path, timeout=None):
+        return FakeResponse(self._object_info)
+
+
+class FakeComfyUI:
+    def __init__(self, object_info=None):
+        self.http = FakeHTTP(object_info)
+
+
+class TestProfileSelection:
+    def test_full_profile_checks_wan22(self, monkeypatch):
+        monkeypatch.setattr(model_validator.settings, "model_profile", "full")
+        names = [c[0] for c in get_model_checks()]
+        assert "unet_high_model" in names
+        assert "lightx2v_lora_high" in names
+        assert "lynx_t2v_model" not in names
+
+    def test_lynx_profile_checks_lynx_only(self, monkeypatch):
+        monkeypatch.setattr(model_validator.settings, "model_profile", "lynx")
+        names = [c[0] for c in get_model_checks()]
+        assert "lynx_t2v_model" in names
+        assert "lynx_ip_layers" in names
+        assert "lynx_ref_layers" in names
+        assert "lynx_resampler" in names
+        # The 2.2 i2v weights are absent from a lynx pod by design.
+        assert "unet_high_model" not in names
+        assert "lightx2v_lora_high" not in names
+
+    @pytest.mark.parametrize("value", ["lynx", "LYNX", " Lynx ", "lYnX"])
+    def test_profile_match_is_case_and_space_insensitive(self, monkeypatch, value):
+        monkeypatch.setattr(model_validator.settings, "model_profile", value)
+        assert [c[0] for c in get_model_checks()] == [c[0] for c in
+                                                      (model_validator._COMMON_CHECKS + _LYNX_CHECKS)]
+
+    @pytest.mark.parametrize("value", ["full", "", "anything-else"])
+    def test_unknown_profile_falls_back_to_full(self, monkeypatch, value):
+        monkeypatch.setattr(model_validator.settings, "model_profile", value)
+        assert "unet_high_model" in [c[0] for c in get_model_checks()]
+
+    def test_vae_is_checked_in_both_profiles(self, monkeypatch):
+        for profile in ("full", "lynx"):
+            monkeypatch.setattr(model_validator.settings, "model_profile", profile)
+            assert "vae_model" in [c[0] for c in get_model_checks()]
+
+    def test_backcompat_flat_list_is_the_full_profile(self):
+        assert MODEL_CHECKS == model_validator._COMMON_CHECKS + _WAN22_CHECKS
+
+    def test_lynx_checks_are_disk_only(self):
+        """Lynx models load via WanVideoWrapper's loaders, not a ComfyUI dropdown."""
+        assert all(loader is None for _n, loader, _s, _m in _LYNX_CHECKS)
+
+
+class TestValidateModels:
+    @pytest.fixture(autouse=True)
+    def _comfy_path(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(model_validator.settings, "comfyui_path", str(tmp_path))
+        return tmp_path
+
+    @staticmethod
+    def _small(checks):
+        """Same checks with tiny minimums — the real ones are GB-scale."""
+        return [(n, loader, subs, 16) for n, loader, subs, _m in checks]
+
+    def _write(self, tmp_path, subfolder, name, size):
+        d = tmp_path / "models" / subfolder
+        d.mkdir(parents=True, exist_ok=True)
+        (d / name).write_bytes(b"\0" * size)
+
+    async def test_skips_entirely_without_comfyui_path(self, monkeypatch):
+        monkeypatch.setattr(model_validator.settings, "comfyui_path", "")
+        assert await validate_models(FakeComfyUI()) is True
+
+    async def test_lynx_profile_passes_without_wan22_models(self, monkeypatch, _comfy_path):
+        """The exact scenario that failed the first pod boot."""
+        monkeypatch.setattr(model_validator.settings, "model_profile", "lynx")
+        monkeypatch.setattr(model_validator, "get_model_checks",
+                            lambda: self._small(model_validator._COMMON_CHECKS + _LYNX_CHECKS))
+        # Only Lynx + VAE present — no 2.2 i2v weights anywhere.
+        self._write(_comfy_path, "vae", model_validator.settings.vae_model, 64)
+        for setting in ("lynx_t2v_model", "lynx_ip_layers", "lynx_ref_layers", "lynx_resampler"):
+            self._write(_comfy_path, "diffusion_models",
+                        getattr(model_validator.settings, setting), 64)
+        assert await validate_models(FakeComfyUI()) is True
+
+    async def test_lynx_profile_fails_when_an_adapter_is_missing(self, monkeypatch, _comfy_path):
+        monkeypatch.setattr(model_validator.settings, "model_profile", "lynx")
+        monkeypatch.setattr(model_validator, "get_model_checks",
+                            lambda: self._small(model_validator._COMMON_CHECKS + _LYNX_CHECKS))
+        self._write(_comfy_path, "vae", model_validator.settings.vae_model, 64)
+        self._write(_comfy_path, "diffusion_models",
+                    model_validator.settings.lynx_t2v_model, 64)
+        # ref layers + resampler absent
+        assert await validate_models(FakeComfyUI()) is False
+
+    async def test_undersized_file_is_rejected(self, monkeypatch, _comfy_path):
+        monkeypatch.setattr(model_validator.settings, "model_profile", "lynx")
+        self._write(_comfy_path, "vae", model_validator.settings.vae_model, 8)
+        assert await validate_models(FakeComfyUI()) is False
+
+    async def test_object_info_failure_is_non_fatal(self, monkeypatch, _comfy_path):
+        """A /object_info hiccup must not block startup on its own."""
+        monkeypatch.setattr(model_validator.settings, "model_profile", "lynx")
+        monkeypatch.setattr(model_validator, "get_model_checks",
+                            lambda: self._small(model_validator._COMMON_CHECKS + _LYNX_CHECKS))
+        self._write(_comfy_path, "vae", model_validator.settings.vae_model, 64)
+        for setting in ("lynx_t2v_model", "lynx_ip_layers", "lynx_ref_layers", "lynx_resampler"):
+            self._write(_comfy_path, "diffusion_models",
+                        getattr(model_validator.settings, setting), 64)
+
+        class Boom:
+            http = type("H", (), {"get": staticmethod(
+                lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no object_info")))})()
+
+        assert await validate_models(Boom()) is True


### PR DESCRIPTION
A lynx-profile pod has **no Wan 2.2 i2v weights by design**, but `model_validator` required them unconditionally — so a correctly-provisioned Lynx pod failed startup with `Model validation FAILED — cannot start`.

That is exactly what happened on the first Lynx pod boot:

```
ERROR MISSING unet_high_model=wan2.2_i2v_high_noise_14B_fp8_scaled.safetensors
ERROR MISSING unet_low_model=wan2.2_i2v_low_noise_14B_fp8_scaled.safetensors
ERROR MISSING lightx2v_lora_high=... / lightx2v_lora_low=...
ERROR --- Model validation FAILED — cannot start ---
```

My gap: wanly-runpod#25 changed *what gets downloaded* without changing *what the daemon validates*.

## Fix

Validation now mirrors `MODEL_PROFILE`:
- `lynx` → Wan2.1 T2V base + ip layers + ref layers + resampler
- `full` → the existing 2.2 i2v set (unchanged default)
- VAE is common to both

Lynx models load through WanVideoWrapper's own loaders rather than `UNETLoader`, so they're size-checked on disk instead of looked up in a ComfyUI dropdown (`loader_node=None`).

`start.sh` also writes `MODEL_PROFILE` into the daemon `.env`, so the download profile and the validation profile cannot silently disagree — a mismatch there is what turns a healthy pod into a boot failure.

## Tests

17 new tests, including the exact failing scenario (`test_lynx_profile_passes_without_wan22_models`). 154 daemon tests pass; ruff clean.