### PR TITLE
fix(lynx): do not re-quantize an already-scaled fp8 checkpoint

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -70,6 +70,14 @@ class Settings(BaseSettings):
     lynx_resampler: str = "lynx_lite_resampler_fp32.safetensors"
     lynx_ref_layers: str = "Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors"
     lynx_resampler_precision: str = "fp16"
+    # The base model file is ALREADY scaled-fp8 (_scaled_KJ), so the loader must not
+    # quantize it again: doing so leaves the fp16 Lynx adapter weights meeting fp8 base
+    # weights and the sampler dies with "self and mat2 must have the same dtype, but got
+    # Half and Float8_e4m3fn". These two values match Kijai's reference workflow.
+    # If you ever point lynx_t2v_model at an unquantized fp16 checkpoint, this is the
+    # pair to change (base_precision=fp16, quantization=fp8_e4m3fn_scaled).
+    lynx_base_precision: str = "fp16_fast"
+    lynx_quantization: str = "disabled"
     # Wan2.1 T2V cfg-step-distill LoRA (the i2v lightx2v_* above are a different family and
     # do NOT apply to the 2.1 T2V base). Strength 0 drops it -> de-distilled path.
     lynx_distill_lora: str = "lightx2v_T2V_14B_cfg_step_distill_v2_lora_rank64_bf16.safetensors"

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -734,8 +734,8 @@ def build_lynx_workflow(
         lora_counter += 1
 
     loader_inputs: dict[str, Any] = {
-        "model": settings.lynx_t2v_model, "base_precision": "fp16",
-        "quantization": "fp8_e4m3fn_scaled", "load_device": "offload_device",
+        "model": settings.lynx_t2v_model, "base_precision": settings.lynx_base_precision,
+        "quantization": settings.lynx_quantization, "load_device": "offload_device",
         "attention_mode": "sdpa", "extra_model": ["602", 0], "block_swap_args": ["600", 0]}
     if lora_ref is not None:
         loader_inputs["lora"] = lora_ref

--- a/tests/golden/lynx_832x480_81f.json
+++ b/tests/golden/lynx_832x480_81f.json
@@ -28,7 +28,7 @@
     "class_type": "WanVideoModelLoader",
     "inputs": {
       "attention_mode": "sdpa",
-      "base_precision": "fp16",
+      "base_precision": "fp16_fast",
       "block_swap_args": [
         "600",
         0
@@ -43,7 +43,7 @@
         0
       ],
       "model": "Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors",
-      "quantization": "fp8_e4m3fn_scaled"
+      "quantization": "disabled"
     }
   },
   "620": {

--- a/tests/test_lynx_workflow.py
+++ b/tests/test_lynx_workflow.py
@@ -160,12 +160,29 @@ class TestGraphTopology:
             assert wf[nid]["class_type"] == "WanVideoTextEncodeCached"
             assert wf[nid]["inputs"]["model_name"] == settings.lynx_t5_model
 
-    def test_block_swap_and_fp8_quantisation(self, segment):
+    def test_block_swap_and_offload(self, segment):
         wf = build_lynx_workflow(segment, "subject.png", 81)
-        assert wf["610"]["inputs"]["quantization"] == "fp8_e4m3fn_scaled"
         assert wf["610"]["inputs"]["load_device"] == "offload_device"
         assert wf["610"]["inputs"]["block_swap_args"] == ["600", 0]
         assert wf["600"]["inputs"]["blocks_to_swap"] == settings.lynx_blocks_to_swap
+
+    def test_does_not_requantise_an_already_scaled_fp8_checkpoint(self, segment):
+        """Regression: the base file is already _scaled_KJ fp8.
+
+        Quantizing it again leaves the fp16 Lynx adapters meeting fp8 base weights and
+        WanVideoSampler dies with "self and mat2 must have the same dtype, but got Half
+        and Float8_e4m3fn". Kijai's reference workflow pairs fp16_fast with disabled.
+        """
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["610"]["inputs"]["quantization"] == "disabled"
+        assert wf["610"]["inputs"]["base_precision"] == "fp16_fast"
+
+    def test_loader_precision_is_configurable(self, monkeypatch, segment):
+        monkeypatch.setattr(settings, "lynx_base_precision", "fp16")
+        monkeypatch.setattr(settings, "lynx_quantization", "fp8_e4m3fn_scaled")
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["610"]["inputs"]["base_precision"] == "fp16"
+        assert wf["610"]["inputs"]["quantization"] == "fp8_e4m3fn_scaled"
 
     def test_sampler_consumes_lynx_embeds_not_raw_latents(self, segment):
         wf = build_lynx_workflow(segment, "subject.png", 81)


### PR DESCRIPTION
First live Lynx run failed in `WanVideoSampler`:

```
self and mat2 must have the same dtype, but got Half and Float8_e4m3fn
```

## Cause

The base model file is **already** scaled-fp8 (`Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors`), but the loader was told to quantize it again (`quantization: fp8_e4m3fn_scaled`). That leaves the fp16 Lynx adapter weights meeting fp8 base weights at matmul time.

I had copied the loader config from the VACE path, where `fp8_e4m3fn_scaled` **is** correct — because those checkpoints (`wan2.2_t2v_*_fp16`) are unquantized fp16 and do need it. The Lynx base does not.

## Fix

Matches Kijai's reference workflow: `base_precision: fp16_fast`, `quantization: disabled`. Both are now settings rather than hardcoded, so pointing `lynx_t2v_model` at an unquantized fp16 checkpoint is a config flip, not a code change.

## Useful data from the failed run

Model loading itself was fine (727/727 blocks) and **VRAM peaked at 11.8 GB of 24 GB** — the fp8 + block-swap-35 footprint has far more headroom than expected, which is a good sign for the 720p bucket and for eventually running this on the 3090.

Regression test asserts the pairing, plus a test that the values stay configurable. Golden file regenerated. 156 tests pass; ruff clean.