### PR TITLE
fix(lynx): use fp16 not fp16_fast (torch too old for fp16 accumulation)

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -70,13 +70,17 @@ class Settings(BaseSettings):
     lynx_resampler: str = "lynx_lite_resampler_fp32.safetensors"
     lynx_ref_layers: str = "Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors"
     lynx_resampler_precision: str = "fp16"
-    # The base model file is ALREADY scaled-fp8 (_scaled_KJ), so the loader must not
-    # quantize it again: doing so leaves the fp16 Lynx adapter weights meeting fp8 base
-    # weights and the sampler dies with "self and mat2 must have the same dtype, but got
-    # Half and Float8_e4m3fn". These two values match Kijai's reference workflow.
-    # If you ever point lynx_t2v_model at an unquantized fp16 checkpoint, this is the
-    # pair to change (base_precision=fp16, quantization=fp8_e4m3fn_scaled).
-    lynx_base_precision: str = "fp16_fast"
+    # Loader precision pair. "disabled" does NOT mean unquantized — the node autoselects
+    # from the weights, which is what we want for an already-scaled fp8 checkpoint
+    # (_scaled_KJ). Quantizing it again leaves the fp16 Lynx adapters meeting fp8 base
+    # weights and the sampler dies with "self and mat2 must have the same dtype".
+    #
+    # Kijai's reference workflow pairs this with "fp16_fast", but that enables fp16
+    # accumulation via torch.backends.cuda.matmul.allow_fp16_accumulation, which needs a
+    # torch >= 2.7.0.dev2025-02-26 nightly. Our RunPod image ships an older torch, so
+    # fp16_fast fails at load. Plain fp16 is the same math without the fast-accumulate
+    # speedup. Valid values: fp32 | bf16 | fp16 | fp16_fast.
+    lynx_base_precision: str = "fp16"
     lynx_quantization: str = "disabled"
     # Wan2.1 T2V cfg-step-distill LoRA (the i2v lightx2v_* above are a different family and
     # do NOT apply to the 2.1 T2V base). Strength 0 drops it -> de-distilled path.

--- a/tests/golden/lynx_832x480_81f.json
+++ b/tests/golden/lynx_832x480_81f.json
@@ -28,7 +28,7 @@
     "class_type": "WanVideoModelLoader",
     "inputs": {
       "attention_mode": "sdpa",
-      "base_precision": "fp16_fast",
+      "base_precision": "fp16",
       "block_swap_args": [
         "600",
         0

--- a/tests/test_lynx_workflow.py
+++ b/tests/test_lynx_workflow.py
@@ -175,7 +175,26 @@ class TestGraphTopology:
         """
         wf = build_lynx_workflow(segment, "subject.png", 81)
         assert wf["610"]["inputs"]["quantization"] == "disabled"
-        assert wf["610"]["inputs"]["base_precision"] == "fp16_fast"
+
+    def test_base_precision_is_supported_by_the_pinned_torch(self, segment):
+        """fp16_fast enables fp16 accumulation, which needs a torch 2.7 nightly the
+        RunPod image does not ship — it fails at WanVideoModelLoader."""
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        assert wf["610"]["inputs"]["base_precision"] == "fp16"
+
+    def test_loader_values_are_accepted_by_the_wrapper(self, segment):
+        """Guard the enum values WanVideoModelLoader actually accepts."""
+        wf = build_lynx_workflow(segment, "subject.png", 81)
+        i = wf["610"]["inputs"]
+        assert i["base_precision"] in {"fp32", "bf16", "fp16", "fp16_fast"}
+        assert i["quantization"] in {
+            "disabled", "fp8_e4m3fn", "fp8_e4m3fn_fast", "fp8_e4m3fn_scaled",
+            "fp8_e4m3fn_scaled_fast", "fp8_e5m2", "fp8_e5m2_fast",
+            "fp8_e5m2_scaled", "fp8_e5m2_scaled_fast"}
+        assert i["load_device"] in {"main_device", "offload_device"}
+        assert i["attention_mode"] in {
+            "sdpa", "flash_attn_2", "flash_attn_3", "sageattn", "sageattn_3",
+            "radial_sage_attention", "sageattn_compiled"}
 
     def test_loader_precision_is_configurable(self, monkeypatch, segment):
         monkeypatch.setattr(settings, "lynx_base_precision", "fp16")


### PR DESCRIPTION
`WanVideoModelLoader` failed on the pod:

```
torch.backends.cuda.matmul.allow_fp16_accumulation is not available in this
version of torch, requires torch 2.7.0.dev2025 02 26 nightly minimum
```

`fp16_fast` — which I copied from Kijai's reference workflow in the previous fix — enables fp16 accumulation via `torch.backends.cuda.matmul.allow_fp16_accumulation`, needing a torch 2.7 nightly. Our RunPod image ships an older torch. Plain `fp16` is the same math without the fast-accumulate speedup.

`quantization: disabled` stays: it does **not** mean unquantized — the node autoselects from the weights, which is exactly right for an already-scaled fp8 checkpoint.

## Preventing the next one

I'd been fixing these one paid-GPU round-trip at a time. This PR adds a guard test pinning **every** loader enum (`base_precision`, `quantization`, `load_device`, `attention_mode`) to the values `WanVideoModelLoader` actually declares, so an unsupported value fails in unit tests instead of on the pod.

158 tests pass; ruff clean; golden regenerated.