### PR TITLE
fix(lynx): point at the fp16 base (fp8 incompatible with adapters)

### DIFF
--- a/BUILD_wanly-lynx-engine.md
+++ b/BUILD_wanly-lynx-engine.md
@@ -184,6 +184,27 @@ Upgrading the 3090's wrapper is deferred deliberately: its ComfyUI core is pinne
 Apr-28 rollback for the activation-memory fix, and a 6-month wrapper jump risks disturbing
 that. Revisit only if the POC's identity numbers justify it.
 
+### Pod provisioning
+
+A Lynx pod is booted from the `Wanly22-GPU` template with **`MODEL_PROFILE=lynx` overridden
+at launch** — not set on the template itself, which would break normal Wan 2.2 jobs booted
+from the same template.
+
+The lean profile matters for more than speed: the full stack is ~135 GB against the
+template's 80 GB `/workspace` volume, so a `full`-profile pod cannot even complete its
+download. Lynx alone is ~36 GB and fits comfortably.
+
+`download_models.sh` and the daemon's `model_validator` both read `MODEL_PROFILE`; a
+mismatch means the daemon validates models the pod was never provisioned with and exits
+before registering. `start.sh` writes the value into the daemon `.env` so the two cannot
+silently diverge.
+
+Note the daemon is **re-cloned from `main` at every boot** (`start.sh` step 2), so a pod
+restart is enough to pick up daemon changes — no image rebuild needed. Changes to
+`start.sh` or `download_models.sh` *do* require a rebuild, since those are baked in.
+
+### Preflight
+
 `_lynx_preflight` fails fast with a diagnosis rather than a bare "node not found", because
 two very different causes present identically:
 
@@ -198,18 +219,50 @@ a worker that cannot run it must say so.
 
 ## 6. VRAM
 
-**UNMEASURED.** No Lynx generation has run yet. To be filled from
-`lynx.generate.end` → `vram_peak_mb` on the first pod run.
+| Config | Peak VRAM | Card | Status |
+|---|---|---|---|
+| 832×480, 81f, fp8 + block swap 35 | **11.8 GB / 24 GB** | RTX 4090 | MEASURED 2026-07-28 |
+| 1280×720, 81f | — | | pending |
 
-| Config | Peak VRAM | Status |
+The 832×480 figure comes from a run that loaded the model fully (727/727 blocks) and then
+failed downstream, so it covers model + adapter residency but **not** peak sampling
+activation — the true peak will be somewhat higher. Even so, ~12 GB against 24 GB is far
+more headroom than expected, which suggests two things worth testing: 720p should fit
+comfortably, and `lynx_blocks_to_swap` (35, from Kijai's workflow — higher than our VACE
+path's 25) can probably come down, trading resident VRAM for speed.
+
+**Measurement caveat:** the daemon is a *separate process* from ComfyUI, so
+`torch.cuda.max_memory_allocated()` would report the daemon's own empty allocator. We poll
+device-level usage via `nvidia-smi` on a background thread (0.5 s) and report the peak.
+That figure includes anything else resident on the card — which is the number that
+actually matters for "does this fit in 24 GB", but is not directly comparable to a
+PyTorch allocator figure.
+
+### Loader configuration — three traps, all hit in the first live run
+
+The loader settings are the fiddliest part of this engine. All three of these produced
+confident-looking failures on a paid GPU:
+
+| Setting | Wrong value | Symptom |
 |---|---|---|
-| 832×480, 81f, fp8 + block swap 35 | — | pending |
-| 1280×720, 81f | — | pending |
+| `quantization` | `fp8_e4m3fn_scaled` | `self and mat2 must have the same dtype, but got Half and Float8_e4m3fn` at `WanVideoSampler` |
+| `base_precision` | `fp16_fast` | `allow_fp16_accumulation is not available in this version of torch` at `WanVideoModelLoader` |
+| `MODEL_PROFILE` vs validator | mismatched | `Model validation FAILED — cannot start`, daemon exits before registering |
 
-Budget sketch, for expectations only: 14.5 GB fp8 base (block-swapped, so resident share
-is well under that) + ~5 GB adapters + VAE + latents. `lynx_blocks_to_swap` is 35, from
-Kijai's reference workflow — higher than our VACE path's 25, because the adapters add
-resident weight on top of the base.
+1. **Do not re-quantize.** The base file is *already* scaled fp8 (`_scaled_KJ`).
+   `quantization: "disabled"` does **not** mean unquantized — the node autoselects from the
+   weights, which is what you want. Setting `fp8_e4m3fn_scaled` quantizes a second time and
+   leaves the fp16 adapters meeting fp8 base weights at matmul. (The VACE path *does* use
+   `fp8_e4m3fn_scaled`, correctly, because its checkpoints are unquantized fp16 — copying
+   that config across is what caused this.)
+2. **`fp16_fast` needs a torch 2.7 nightly.** Kijai's reference workflow uses it, but it
+   enables `torch.backends.cuda.matmul.allow_fp16_accumulation`, which our RunPod image's
+   torch lacks. Plain `fp16` is the same math without the fast-accumulate speedup.
+3. **The download profile and the validation profile must agree.** See §5.
+
+A unit test pins every loader enum we emit (`base_precision`, `quantization`,
+`load_device`, `attention_mode`) to the values `WanVideoModelLoader` actually declares, so
+an unsupported value fails locally rather than on a pod.
 
 **Measurement caveat:** the daemon is a *separate process* from ComfyUI, so
 `torch.cuda.max_memory_allocated()` would report the daemon's own empty allocator. We poll

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
     #   ref (Ref-adapter) dense VAE features of the reference face, cross-attended in DiT blocks
     # This is a T2V base conditioned on a subject image — NOT first-frame i2v, so the
     # subject image never appears as frame 0.
-    lynx_t2v_model: str = "Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors"
+    lynx_t2v_model: str = "wan2.1_t2v_14B_fp16.safetensors"
     # ip layers and resampler are a MATCHED PAIR (the resampler's proj_out dim must match
     # the ip layers). Default is Kijai's shipped combination — lite ip + full ref — because
     # his own workflow note reports the full ip adapter as "very weak". full ip + full ref
@@ -70,16 +70,22 @@ class Settings(BaseSettings):
     lynx_resampler: str = "lynx_lite_resampler_fp32.safetensors"
     lynx_ref_layers: str = "Wan2_1-T2V-14B-Lynx_full_ref_layers_fp16.safetensors"
     lynx_resampler_precision: str = "fp16"
-    # Loader precision pair. "disabled" does NOT mean unquantized — the node autoselects
-    # from the weights, which is what we want for an already-scaled fp8 checkpoint
-    # (_scaled_KJ). Quantizing it again leaves the fp16 Lynx adapters meeting fp8 base
-    # weights and the sampler dies with "self and mat2 must have the same dtype".
+    # Loader precision. Everything stays fp16: no fp8 anywhere in the graph.
     #
-    # Kijai's reference workflow pairs this with "fp16_fast", but that enables fp16
-    # accumulation via torch.backends.cuda.matmul.allow_fp16_accumulation, which needs a
-    # torch >= 2.7.0.dev2025-02-26 nightly. Our RunPod image ships an older torch, so
-    # fp16_fast fails at load. Plain fp16 is the same math without the fast-accumulate
-    # speedup. Valid values: fp32 | bf16 | fp16 | fp16_fast.
+    # An fp8 base does NOT work with Lynx on this stack. The adapters are plain
+    # nn.Linear (lynx/modules.py: to_k_ip, to_v_ip, to_k_ref, to_v_ref), so they are not
+    # wrapped by the wrapper's fp8-aware linear. With an fp8 base their weights get cast
+    # to fp8 while activations stay fp16, and WanVideoSampler dies with
+    # "self and mat2 must have the same dtype, but got Half and Float8_e4m3fn".
+    # Both fp8 settings fail identically (quantization=fp8_e4m3fn_scaled AND =disabled),
+    # so quantization is not the lever — the base checkpoint's dtype is.
+    #
+    # Kijai's reference workflow gets away with an fp8 base only via base_precision
+    # "fp16_fast", which needs torch >= 2.7.0.dev2025-02-26 (our image is older).
+    #
+    # Cost of fp16: a 28GB checkpoint instead of 14.5GB. Block swap carries it, exactly
+    # as the VACE path already runs 28GB fp16 models on a 24GB card.
+    # Valid base_precision: fp32 | bf16 | fp16 | fp16_fast.
     lynx_base_precision: str = "fp16"
     lynx_quantization: str = "disabled"
     # Wan2.1 T2V cfg-step-distill LoRA (the i2v lightx2v_* above are a different family and

--- a/tests/golden/lynx_832x480_81f.json
+++ b/tests/golden/lynx_832x480_81f.json
@@ -42,7 +42,7 @@
         "700",
         0
       ],
-      "model": "Wan2_1-T2V-14B_fp8_e4m3fn_scaled_KJ.safetensors",
+      "model": "wan2.1_t2v_14B_fp16.safetensors",
       "quantization": "disabled"
     }
   },

--- a/tests/test_lynx_workflow.py
+++ b/tests/test_lynx_workflow.py
@@ -166,15 +166,19 @@ class TestGraphTopology:
         assert wf["610"]["inputs"]["block_swap_args"] == ["600", 0]
         assert wf["600"]["inputs"]["blocks_to_swap"] == settings.lynx_blocks_to_swap
 
-    def test_does_not_requantise_an_already_scaled_fp8_checkpoint(self, segment):
-        """Regression: the base file is already _scaled_KJ fp8.
+    def test_no_fp8_anywhere_in_the_graph(self, segment):
+        """Regression: an fp8 base is incompatible with the Lynx adapters here.
 
-        Quantizing it again leaves the fp16 Lynx adapters meeting fp8 base weights and
-        WanVideoSampler dies with "self and mat2 must have the same dtype, but got Half
-        and Float8_e4m3fn". Kijai's reference workflow pairs fp16_fast with disabled.
+        The adapters are plain nn.Linear, so they are not wrapped by the wrapper's
+        fp8-aware linear. With an fp8 base their weights get cast to fp8 while
+        activations stay fp16 and WanVideoSampler dies with "self and mat2 must have the
+        same dtype, but got Half and Float8_e4m3fn" — identically for
+        quantization=fp8_e4m3fn_scaled and =disabled.
         """
         wf = build_lynx_workflow(segment, "subject.png", 81)
         assert wf["610"]["inputs"]["quantization"] == "disabled"
+        assert "fp8" not in wf["610"]["inputs"]["model"], (
+            "Lynx needs a non-fp8 base checkpoint")
 
     def test_base_precision_is_supported_by_the_pinned_torch(self, segment):
         """fp16_fast enables fp16 accumulation, which needs a torch 2.7 nightly the


### PR DESCRIPTION
Daemon half of the fp8→fp16 base switch. See [wanly-runpod#26](https://github.com/DavidJBarnes/wanly-runpod/pull/26) for the full root cause.

Short version: the Lynx adapters are plain `nn.Linear`, so they bypass the wrapper's fp8-aware linear. An fp8 base casts their weights to fp8 while activations stay fp16 → `self and mat2 must have the same dtype, but got Half and Float8_e4m3fn`. Both `fp8_e4m3fn_scaled` and `disabled` fail identically, so the loader flag was never the lever — the checkpoint dtype is.

Test asserts no fp8 anywhere in the loader inputs so this can't regress silently. 158 tests pass; ruff clean; golden regenerated.