### PR TITLE
feat(smashcut): retime clips to per-clip playback speeds

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -519,6 +519,38 @@ async def _execute_ar_hologram(
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
+SMASHCUT_MAX_FPS = 60
+
+
+def smashcut_output_fps(base_fps: int, speeds: list[float]) -> int:
+    """The single fps every retimed clip is encoded at before concatenation.
+
+    The concat demuxer needs uniform streams, so one rate has to cover clips running at
+    different speeds. Speeding up raises the rate rather than dropping frames: sources come
+    out of RIFE interpolation, so up to ~2x every original frame still fits. Slowing down
+    holds frames longer instead of lowering the rate, which would make slow-motion choppier
+    than the clip it came from. Capped so 4x on a 30fps source cannot emit a 120fps file.
+    """
+    fastest = max([*speeds, 1.0])
+    return min(round(base_fps * fastest), SMASHCUT_MAX_FPS)
+
+
+async def _retime_clip(src: str, dst: str, speed: float, fps: int) -> None:
+    """Re-encode one clip at a new playback speed, normalised to the montage's fps.
+
+    setpts rescales presentation timestamps — <1 stretches (slow-motion), >1 compresses.
+    -an because generated clips carry no audio; without it a stray stream would survive
+    retiming untouched and drift against the video.
+    """
+    await _run_ffmpeg([
+        "-i", src,
+        "-filter:v", f"setpts=PTS/{speed}",
+        "-r", str(fps),
+        "-an",
+        "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18", dst,
+    ])
+
+
 async def _generate_black(path: str, duration: float, width: int, height: int, fps: int) -> None:
     """Generate a black mp4 clip for dip-to-black smashcut transitions."""
     await _run_ffmpeg([
@@ -534,8 +566,20 @@ async def _execute_smashcut_concat(segment: SegmentClaim, queue: QueueClient) ->
     """
     paths = segment.smashcut_clip_paths or []
     black = segment.smashcut_transition == "black"
-    logger.info("=== Smashcut concat %s: %d clips, transition=%s ===",
-                str(segment.id)[:8], len(paths), segment.smashcut_transition)
+    # Speeds ride in a list parallel to the paths. A shorter list would silently misalign
+    # every clip after the gap, so treat any mismatch as "no retiming" rather than guessing.
+    speeds = segment.smashcut_clip_speeds or []
+    if speeds and len(speeds) != len(paths):
+        logger.warning(
+            "Smashcut %s: %d clip speeds for %d clips — ignoring the speeds and building at 1x",
+            str(segment.id)[:8], len(speeds), len(paths),
+        )
+        speeds = []
+    retime = any(s != 1.0 for s in speeds)
+    out_fps = smashcut_output_fps(segment.fps, speeds) if retime else segment.fps
+    logger.info("=== Smashcut concat %s: %d clips, transition=%s, speeds=%s, fps=%d ===",
+                str(segment.id)[:8], len(paths), segment.smashcut_transition,
+                speeds if retime else "1x", out_fps)
     progress = ProgressLog(segment.id, queue)
     start = time.monotonic()
     try:
@@ -543,7 +587,8 @@ async def _execute_smashcut_concat(segment: SegmentClaim, queue: QueueClient) ->
             raise RuntimeError("smashcut needs at least 2 clips")
 
         with tempfile.TemporaryDirectory() as tmp:
-            await progress.log(f"[1/3] Downloading {len(paths)} clips...")
+            steps = 4 if retime else 3  # download, [retime], concat, upload
+            await progress.log(f"[1/{steps}] Downloading {len(paths)} clips...")
             local = []
             for i, p in enumerate(paths):
                 data = await _download_with_retry(lambda p=p: queue.download_file(p), "smashcut_clip")
@@ -552,13 +597,26 @@ async def _execute_smashcut_concat(segment: SegmentClaim, queue: QueueClient) ->
                     f.write(data)
                 local.append(fn)
 
-            await progress.log("[2/3] Concatenating...")
+            if retime:
+                await progress.log(f"[2/{steps}] Retiming {len(local)} clips to {out_fps}fps...")
+                retimed = []
+                for i, (fn, speed) in enumerate(zip(local, speeds)):
+                    rp = os.path.join(tmp, f"retimed_{i:03d}.mp4")
+                    # Every clip goes through this, including the 1.0x ones: the concat
+                    # demuxer needs them all at out_fps, which differs from the source rate.
+                    await _retime_clip(fn, rp, speed, out_fps)
+                    retimed.append(rp)
+                local = retimed
+
+            await progress.log(f"[{steps - 1}/{steps}] Concatenating...")
             items = []
             for i, fn in enumerate(local):
                 items.append(fn)
                 if black and i < len(local) - 1:
                     bp = os.path.join(tmp, f"black_{i:03d}.mp4")
-                    await _generate_black(bp, 0.4, segment.width, segment.height, segment.fps)
+                    # Generated after retiming and never passed through it, so the dip stays
+                    # a real 0.4s beat no matter how fast the clips around it run.
+                    await _generate_black(bp, 0.4, segment.width, segment.height, out_fps)
                     items.append(bp)
 
             # concat demuxer resolves relative paths against the list file's dir → basenames in tmp.
@@ -577,7 +635,7 @@ async def _execute_smashcut_concat(segment: SegmentClaim, queue: QueueClient) ->
             with open(out, "rb") as f:
                 result = f.read()
 
-            await progress.log("[3/3] Uploading...")
+            await progress.log(f"[{steps}/{steps}] Uploading...")
             await queue.upload_smashcut_output(segment.id, result)
         logger.info("Smashcut %s complete in %.1fs", str(segment.id)[:8], time.monotonic() - start)
     except Exception as e:

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -68,6 +68,8 @@ class SegmentClaim(BaseModel):
     # Foundry smashcut (reprocess_type="smashcut_concat"): ordered clip paths + transition.
     smashcut_clip_paths: Optional[list[str]] = None
     smashcut_transition: Optional[str] = None
+    # Per-clip playback speed, aligned 1:1 with smashcut_clip_paths. None = no retiming.
+    smashcut_clip_speeds: Optional[list[float]] = None
     width: int
     height: int
     fps: int

--- a/tests/test_smashcut_speed.py
+++ b/tests/test_smashcut_speed.py
@@ -1,0 +1,80 @@
+"""Tests for per-clip smashcut retiming.
+
+The fps choice is the load-bearing decision here. Every clip must be encoded at one rate
+before the concat demuxer will splice them, so a montage mixing 0.5x and 2x still has to
+resolve to a single number — and the naive choice (scale by each clip's own speed) produces
+streams that will not concatenate at all.
+"""
+
+import pytest
+
+from daemon.executor import SMASHCUT_MAX_FPS, _retime_clip, smashcut_output_fps
+
+
+class TestOutputFps:
+    def test_no_retiming_keeps_the_source_rate(self):
+        assert smashcut_output_fps(30, []) == 30
+        assert smashcut_output_fps(30, [1.0, 1.0]) == 30
+
+    def test_speeding_up_raises_the_rate_instead_of_dropping_frames(self):
+        """Sources are RIFE-interpolated, so 2x on 30fps still fits every original frame."""
+        assert smashcut_output_fps(30, [2.0]) == 60
+
+    def test_slowing_down_never_drops_below_the_source_rate(self):
+        """The regression this guards: base*0.5 would emit 15fps and make slow-motion
+        choppier than the clip it was made from. Frames are held longer instead."""
+        assert smashcut_output_fps(30, [0.5]) == 30
+        assert smashcut_output_fps(30, [0.25, 0.5]) == 30
+
+    def test_the_fastest_clip_sets_the_rate(self):
+        """A mixed montage resolves to one rate; the slow clips just repeat frames."""
+        assert smashcut_output_fps(30, [0.5, 2.0, 1.0]) == 60
+
+    def test_rate_is_capped(self):
+        """4x on 30fps would be 120fps — past what the cap allows for a montage."""
+        assert smashcut_output_fps(30, [4.0]) == SMASHCUT_MAX_FPS
+        assert smashcut_output_fps(60, [2.0]) == SMASHCUT_MAX_FPS
+
+    def test_fractional_rates_are_rounded_to_an_integer(self):
+        """-r takes an int here; 24 * 1.5 must not reach ffmpeg as 36.0."""
+        result = smashcut_output_fps(24, [1.5])
+        assert result == 36
+        assert isinstance(result, int)
+
+
+class TestRetimeCommand:
+    @pytest.fixture
+    def captured(self, monkeypatch):
+        calls = []
+
+        async def fake(args):
+            calls.append(args)
+
+        monkeypatch.setattr("daemon.executor._run_ffmpeg", fake)
+        return calls
+
+    async def test_setpts_divides_by_the_speed(self, captured):
+        """setpts=PTS/2 halves the duration. Inverting this silently reverses the control."""
+        await _retime_clip("in.mp4", "out.mp4", 2.0, 60)
+        assert "setpts=PTS/2.0" in captured[0]
+
+    async def test_slow_motion_stretches(self, captured):
+        await _retime_clip("in.mp4", "out.mp4", 0.5, 30)
+        assert "setpts=PTS/0.5" in captured[0]
+
+    async def test_output_rate_is_forced(self, captured):
+        """Without -r the clips keep their source rates and the concat demuxer rejects them."""
+        await _retime_clip("in.mp4", "out.mp4", 2.0, 60)
+        args = captured[0]
+        assert args[args.index("-r") + 1] == "60"
+
+    async def test_audio_is_dropped(self, captured):
+        """Generated clips have no audio; a stray stream would survive setpts and drift."""
+        await _retime_clip("in.mp4", "out.mp4", 2.0, 60)
+        assert "-an" in captured[0]
+
+    async def test_source_and_destination_are_not_swapped(self, captured):
+        await _retime_clip("src.mp4", "dst.mp4", 1.5, 45)
+        args = captured[0]
+        assert args[args.index("-i") + 1] == "src.mp4"
+        assert args[-1] == "dst.mp4"


### PR DESCRIPTION
Applies the per-clip speeds wanly-api#134 now sends. Each clip is re-encoded with `setpts` **before** concatenation.

### Why per-clip retiming makes the dips fall out for free
Because retiming happens per clip rather than on the finished montage, the black dips are generated afterwards and never passed through it — so a dip stays a real 0.4s beat no matter how fast the clips around it run. No compensation math needed.

### The output fps is the load-bearing decision
Every clip must share one rate before the concat demuxer will splice them, so a montage mixing 0.5x and 2x still has to resolve to a single number:

| case | behaviour | why |
|---|---|---|
| speed up | raise the rate | sources are RIFE-interpolated, so up to ~2x every original frame still fits — no dropping |
| slow down | hold the source rate | scaling down would emit 15fps for a 0.5x clip, making slow-motion choppier than its source |
| extreme | cap at 60fps | 4x on 30fps would otherwise be a 120fps file |

A speeds list whose length doesn't match the clips is **ignored with a warning** rather than applied — it would misalign every clip after the gap and retime the wrong ones.

### Verification
- 36 tests pass (25 baseline + 11 new). Proved non-vacuous: mutating the slow-motion guard to `max([*speeds, 0.0])` fails exactly the 2 tests that cover it.
- **Validated against real ffmpeg**, not just mocks — generated clips, ran the actual `_retime_clip` / `_generate_black` code, probed the results:

```
source clips:      (2.0s, 30fps, 60 frames)
chosen output fps: 60  (fastest clip is 2.0x)

OK  2.0x: 1.02s (expected ~1.0s), 60fps, 61 frames   <- all 60 source frames kept
OK  0.5x: 3.98s (expected ~4.0s), 60fps, 239 frames
OK  dip: 0.4s at 60fps (must stay 0.4s)

OK  montage: 5.4s (expected ~5.4s), 60fps, 324 frames
```

The final concat used `-c copy`, which proves the retimed clips come out uniform enough for the demuxer to splice without re-encoding.

Caveat on that run: this box's ffmpeg is Fedora's stripped build with no libx264, so the harness swapped **only** the encoder for `libopenh264`. Everything under test — `setpts`, `-r`, `-an`, concat uniformity — is encoder-independent, but the exact libx264 invocation has not been exercised outside the pod.