### PR TITLE
fix(seed-faceswap): source the re-anchor face from the segment, not a hardcoded map

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -54,13 +54,6 @@ from daemon.hologram import (
 )
 from daemon.depth import ensure_depth_model, estimate_depth, normalize_depth_clip
 
-# HACK (temp): known-good canonical face per character LoRA, keyed by char lora_id. Feeds the
-# seed re-anchor faceswap, which re-asserts identity on the frame that seeds the next segment.
-_HARDCODE_IDENTITY_FACE = {
-    "b86c19a9-20aa-44de-85e9-aab2a4ca4809": "s3://wanly-loras/hardcode/k3lly2026_face.png",
-    "5427b202-76da-4a15-aa8a-75e375c4d7d0": "s3://wanly-loras/hardcode/k3llydw_face.png",
-}
-
 logger = logging.getLogger(__name__)
 
 
@@ -186,24 +179,31 @@ async def _reanchor_seed_frame(
     queue: QueueClient,
     progress: "ProgressLog",
 ) -> bytes:
-    """Re-anchor the continuation seed (last frame) to the canonical identity face before
-    it seeds the next i2v segment. FaceFusion passes the frame through unchanged when no
-    face is detected, so we diff the result and fall back to the raw seed on no-op/error.
-    NEVER raises — always returns a usable seed frame (swapped or raw), and logs which."""
+    """Re-anchor the continuation seed (last frame) to the segment's own faceswap face
+    before it seeds the next i2v segment. FaceFusion passes the frame through unchanged when
+    no face is detected, so we diff the result and fall back to the raw seed on no-op/error.
+    NEVER raises — always returns a usable seed frame (swapped or raw), and logs which.
+
+    The face comes from segment.faceswap_image, which execute_segment has already resolved
+    to a ComfyUI filename by this point (see _resolve_faceswap_image). It used to come from
+    a hardcoded lora_id -> S3 face map, which limited the feature to two characters."""
     try:
-        source_s3 = next(
-            (_HARDCODE_IDENTITY_FACE[item.lora_id] for item in (segment.loras or [])
-             if item.lora_id in _HARDCODE_IDENTITY_FACE),
-            None,
-        )
-        if not source_s3:
-            logger.info("Seed re-anchor: no canonical face for segment %d LoRAs — kept raw seed", segment.index)
-            await progress.log("[seed] No canonical face for these LoRAs — kept raw frame")
+        face_fn = segment.faceswap_image
+        if not face_fn:
+            logger.info("Seed re-anchor: segment %d has no faceswap face — kept raw seed", segment.index)
+            await progress.log("[seed] No faceswap face configured — kept raw frame")
             return last_frame_data
 
-        face_data = await _download_with_retry(lambda: queue.download_file(source_s3), "seed_face")
-        _validate_image_data(face_data, "seed_face")
-        face_fn = await comfyui.upload_image(face_data, f"seedface_{segment.id}.png")
+        # Normally already a ComfyUI filename. If the segment carries an unresolved S3 URI
+        # (faceswap disabled for the video but a face still selected), resolve it here.
+        if face_fn.startswith("s3://"):
+            face_data = await _download_with_retry(
+                lambda: queue.download_file(face_fn), "seed_face"
+            )
+            _validate_image_data(face_data, "seed_face")
+            ext = os.path.splitext(face_fn)[1] or ".png"
+            face_fn = await comfyui.upload_image(face_data, f"seedface_{segment.id}{ext}")
+
         seed_fn = await comfyui.upload_image(last_frame_data, f"seed_{segment.id}.png")
 
         seg = segment.model_copy(update={

--- a/tests/test_seed_reanchor.py
+++ b/tests/test_seed_reanchor.py
@@ -1,0 +1,204 @@
+"""Tests for the continuation seed re-anchor.
+
+This path shipped non-functional and stayed that way through 26 multi-segment jobs, because
+the API gated it on "a later segment already exists at claim time" — which a job created
+with segment 0 and continued afterwards can never satisfy. It had zero test coverage, which
+is why nobody noticed. These tests pin the behaviour that matters:
+
+  - the face comes from the SEGMENT (not a hardcoded per-character map)
+  - a missing face degrades to the raw frame instead of raising
+  - FaceFusion's "no face found" no-op is detected and falls back
+  - nothing in here may ever raise: a failed re-anchor must not fail the segment
+"""
+
+import io
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from daemon.executor import _images_differ, _reanchor_seed_frame
+from daemon.workflow_builder import build_seed_faceswap_workflow
+from tests.conftest import make_segment
+
+
+def png_bytes(seed: int, size: tuple[int, int] = (128, 128)) -> bytes:
+    """Deterministic noise, not a flat colour.
+
+    _validate_image_data rejects anything under 1 KB, and a solid-colour PNG of this size
+    compresses to ~0.2 KB — so flat fixtures get rejected as corrupt before the code under
+    test is reached. Noise keeps the encoded size realistic.
+    """
+    rng = np.random.default_rng(seed)
+    arr = rng.integers(0, 256, size=(size[1], size[0], 3), dtype=np.uint8)
+    buf = io.BytesIO()
+    Image.fromarray(arr, "RGB").save(buf, format="PNG")
+    return buf.getvalue()
+
+
+RAW_SEED = png_bytes(1)
+SWAPPED = png_bytes(2)
+
+
+class FakeProgress:
+    def __init__(self):
+        self.lines: list[str] = []
+
+    async def log(self, msg: str) -> None:
+        self.lines.append(msg)
+
+
+class FakeComfy:
+    """Records uploads and returns a canned swapped image."""
+
+    def __init__(self, output: bytes | None = SWAPPED, raise_on_submit: bool = False):
+        self.uploads: list[str] = []
+        self.submitted: dict | None = None
+        self.output = output
+        self.raise_on_submit = raise_on_submit
+
+    async def upload_image(self, data: bytes, filename: str) -> str:
+        self.uploads.append(filename)
+        return filename
+
+    async def submit_workflow(self, workflow: dict):
+        if self.raise_on_submit:
+            raise RuntimeError("comfy exploded")
+        self.submitted = workflow
+        return "prompt-1", "client-1"
+
+    async def monitor_execution(self, prompt_id, client_id, progress=None):
+        return None
+
+    async def get_history(self, prompt_id):
+        return {"outputs": {"186": {"images": [{"filename": "seed_swap_0001.png"}]}}}
+
+    async def download_output(self, filename, subfolder="", type_="output"):
+        return self.output
+
+
+class FakeQueue:
+    def __init__(self, file_bytes: bytes = png_bytes(3)):
+        self.downloaded: list[str] = []
+        self.file_bytes = file_bytes
+
+    async def download_file(self, uri: str) -> bytes:
+        self.downloaded.append(uri)
+        return self.file_bytes
+
+
+class TestFaceSource:
+    """The whole point of the rework: the face is per-segment, not per-character."""
+
+    @pytest.mark.asyncio
+    async def test_uses_the_segments_own_faceswap_face(self):
+        seg = make_segment(
+            index=0, seed_faceswap=True,
+            faceswap_enabled=True, faceswap_image="faceswap_abc.png",
+        )
+        comfy, queue, prog = FakeComfy(), FakeQueue(), FakeProgress()
+        out = await _reanchor_seed_frame(seg, RAW_SEED, comfy, queue, prog)
+
+        assert out == SWAPPED
+        # node 188 is the swap SOURCE image; it must be the segment's face
+        assert comfy.submitted["188"]["inputs"]["image"] == "faceswap_abc.png"
+        assert any("Re-anchored" in line for line in prog.lines)
+
+    @pytest.mark.asyncio
+    async def test_any_character_works_not_just_the_two_hardcoded_ones(self):
+        """Previously the face came from a lora_id -> S3 map with exactly two entries, so an
+        unknown LoRA silently did nothing. Identity now travels with the segment."""
+        seg = make_segment(
+            seed_faceswap=True, loras=None,
+            faceswap_enabled=True, faceswap_image="someone_else.png",
+        )
+        comfy = FakeComfy()
+        out = await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), FakeProgress())
+        assert out == SWAPPED
+        assert comfy.submitted["188"]["inputs"]["image"] == "someone_else.png"
+
+    @pytest.mark.asyncio
+    async def test_unresolved_s3_uri_is_downloaded_and_uploaded(self):
+        """Covers a face selected while video faceswap is off, so _resolve_faceswap_image
+        never converted it to a ComfyUI filename."""
+        seg = make_segment(
+            seed_faceswap=True, faceswap_enabled=False,
+            faceswap_image="s3://wanly-loras/faces/kelly.png",
+        )
+        comfy, queue = FakeComfy(), FakeQueue()
+        out = await _reanchor_seed_frame(seg, RAW_SEED, comfy, queue, FakeProgress())
+
+        assert out == SWAPPED
+        assert queue.downloaded == ["s3://wanly-loras/faces/kelly.png"]
+        assert any(f.startswith("seedface_") for f in comfy.uploads)
+
+
+class TestDegradesToRawSeed:
+    """A failed re-anchor must cost nothing: the raw frame still seeds the next segment."""
+
+    @pytest.mark.asyncio
+    async def test_no_face_configured_keeps_raw_frame(self):
+        seg = make_segment(seed_faceswap=True, faceswap_enabled=False, faceswap_image=None)
+        comfy, prog = FakeComfy(), FakeProgress()
+        out = await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), prog)
+
+        assert out == RAW_SEED
+        assert comfy.submitted is None, "must not submit a workflow with no source face"
+        assert any("No faceswap face" in line for line in prog.lines)
+
+    @pytest.mark.asyncio
+    async def test_facefusion_noop_is_detected_and_falls_back(self):
+        """FaceFusion re-saves identical pixels when it finds no face in the frame. That is
+        indistinguishable from success unless the result is diffed."""
+        seg = make_segment(seed_faceswap=True, faceswap_enabled=True, faceswap_image="f.png")
+        comfy = FakeComfy(output=RAW_SEED)   # same pixels back
+        prog = FakeProgress()
+        out = await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), prog)
+
+        assert out == RAW_SEED
+        assert any("No face detected" in line for line in prog.lines)
+
+    @pytest.mark.asyncio
+    async def test_never_raises_when_comfyui_fails(self):
+        """A broken re-anchor must not fail an otherwise-good 30-minute generation."""
+        seg = make_segment(seed_faceswap=True, faceswap_enabled=True, faceswap_image="f.png")
+        comfy = FakeComfy(raise_on_submit=True)
+        out = await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), FakeProgress())
+        assert out == RAW_SEED
+
+
+class TestNoopDetection:
+    def test_identical_images_do_not_differ(self):
+        assert _images_differ(RAW_SEED, RAW_SEED) is False
+
+    def test_different_images_differ(self):
+        assert _images_differ(RAW_SEED, SWAPPED) is True
+
+    def test_mismatched_shapes_count_as_different(self):
+        assert _images_differ(RAW_SEED, png_bytes(1, size=(64, 64))) is True
+
+
+class TestWorkflowShape:
+    def test_seed_workflow_loads_the_frame_and_saves_one_image(self):
+        seg = make_segment(faceswap_enabled=True, faceswap_image="face.png",
+                           faceswap_method="facefusion")
+        wf = build_seed_faceswap_workflow(seg, "seed_frame.png")
+        assert wf["400"]["class_type"] == "LoadImage"
+        assert wf["400"]["inputs"]["image"] == "seed_frame.png"
+        assert wf["186"]["class_type"] == "SaveImage"
+        # single still, not a video: no VHS combine anywhere in the graph
+        assert not any(n.get("class_type", "").startswith("VHS_") for n in wf.values())
+
+
+class TestFlagPlumbing:
+    def test_seed_faceswap_defaults_off(self):
+        assert make_segment().seed_faceswap is False
+
+    def test_flag_round_trips_from_the_claim(self):
+        assert make_segment(seed_faceswap=True).seed_faceswap is True
+
+    def test_flag_is_independent_of_video_faceswap(self):
+        """The seed re-anchor is a separate decision from swapping the whole clip."""
+        seg = make_segment(seed_faceswap=True, faceswap_enabled=False)
+        assert seg.seed_faceswap is True and seg.faceswap_enabled is False


### PR DESCRIPTION
## Change

The seed re-anchor took its face from a hardcoded map:

```python
_HARDCODE_IDENTITY_FACE = {
    "b86c19a9-...": "s3://wanly-loras/hardcode/k3lly2026_face.png",
    "5427b202-...": "s3://wanly-loras/hardcode/k3llydw_face.png",
}
```

Exactly two characters. Any other LoRA logged *"no canonical face — kept raw seed"* and did nothing.

It now uses **`segment.faceswap_image`** — whichever face that segment already selected in the console. By the time the re-anchor runs, `execute_segment` has already replaced that field with a resolved ComfyUI filename (`_resolve_faceswap_image`), so there's no extra download. An unresolved `s3://` URI is handled inline as a fallback, covering a face selected while video faceswap is off.

Map removed.

## Tests

This path had **no coverage at all** — it shipped non-functional and stayed that way through 26 multi-segment jobs. 13 new tests (49 total, no regressions):

- **face source** — uses the segment's face; works for any character, not just the two hardcoded ones; resolves an unresolved S3 URI
- **degradation** — no face configured keeps the raw frame and never submits a workflow; FaceFusion's no-op re-save is detected via pixel diff and falls back; a ComfyUI failure never propagates (a broken re-anchor must not fail a 30-minute generation)
- **no-op detection** — `_images_differ` on identical / different / mismatched-shape inputs
- **workflow shape** — single still, no VHS video nodes
- **flag plumbing** — defaults off, round-trips, independent of video faceswap

One thing the tests caught: `_validate_image_data` rejects anything under 1 KB, so flat-colour PNG fixtures were being rejected as corrupt before reaching the code under test. Fixtures use deterministic noise instead.

Requires wanly-api PR (per-segment flag) — same branch name.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct