### PR TITLE
test(seed-faceswap): pin face selection through the seed workflow

### DIFF
--- a/tests/test_seed_reanchor.py
+++ b/tests/test_seed_reanchor.py
@@ -191,6 +191,46 @@ class TestWorkflowShape:
         assert not any(n.get("class_type", "").startswith("VHS_") for n in wf.values())
 
 
+class TestFaceSelection:
+    """With two people in frame the seed swap must be told WHICH face to replace.
+
+    _add_faceswap defaults to faces_order="left-right", faces_index="0" — the leftmost
+    face. In a two-person scene that can be the wrong person entirely, so these values
+    have to survive from the console onto the seed workflow.
+    """
+
+    def test_faces_order_and_index_reach_the_seed_workflow(self):
+        seg = make_segment(
+            faceswap_enabled=False, seed_faceswap=True, faceswap_image="face.png",
+            faceswap_method="reactor",
+            faceswap_faces_order="right-left", faceswap_faces_index="1",
+        )
+        wf = build_seed_faceswap_workflow(seg, "seed.png")
+        opts = next(n for n in wf.values() if n["class_type"] == "ReActorOptions")
+        assert opts["inputs"]["input_faces_order"] == "right-left"
+        assert opts["inputs"]["input_faces_index"] == "1"
+
+    def test_defaults_pick_the_leftmost_face_when_unset(self):
+        """Documents the fallback: fine for one face, WRONG for two."""
+        seg = make_segment(
+            faceswap_enabled=False, seed_faceswap=True, faceswap_image="face.png",
+            faceswap_method="reactor",
+            faceswap_faces_order=None, faceswap_faces_index=None,
+        )
+        wf = build_seed_faceswap_workflow(seg, "seed.png")
+        opts = next(n for n in wf.values() if n["class_type"] == "ReActorOptions")
+        assert opts["inputs"]["input_faces_order"] == "left-right"
+        assert opts["inputs"]["input_faces_index"] == "0"
+
+    def test_method_reaches_the_seed_workflow(self):
+        seg = make_segment(
+            faceswap_enabled=False, seed_faceswap=True, faceswap_image="face.png",
+            faceswap_method="reactor",
+        )
+        wf = build_seed_faceswap_workflow(seg, "seed.png")
+        assert any(n["class_type"] == "ReActorOptions" for n in wf.values())
+
+
 class TestFlagPlumbing:
     def test_seed_faceswap_defaults_off(self):
         assert make_segment().seed_faceswap is False


### PR DESCRIPTION
## Why

`_add_faceswap` falls back to `faces_order="left-right"`, `faces_index="0"` — **the leftmost face in frame**.

```python
faces_order = segment.faceswap_faces_order or "left-right"
faces_index = segment.faceswap_faces_index or "0"
```

Fine for a single subject. In a **two-person scene it can swap the wrong person entirely** — pasting the character's face onto whoever happens to be left of frame. The console was sending `null` for both on a seed-only config, so every seed re-anchor would have silently used the leftmost face.

## Tests

- faces_order / faces_index survive onto the seed workflow's ReActorOptions
- method reaches the seed workflow
- the leftmost-face default is pinned explicitly, so it's documented behaviour rather than an accident

No production change here — the fix is console-side (exposing the controls for seed-only). These lock the daemon contract those controls depend on.

Pairs with the wanly-console PR on the same branch.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct