### PR TITLE
feat(identity): score every segment for identity as it finishes generating

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -31,6 +31,7 @@ from daemon.comfyui_client import ComfyUIClient, ComfyUIExecutionError
 from daemon.lora_sync import ensure_loras_available
 from daemon.motion_extractor import _augment_prompt_with_motion, extract_motion_keywords
 from daemon.motion_analyzer import measure_motion_magnitude
+from daemon import identity_score
 from daemon.progress import ProgressLog
 from daemon.queue_client import QueueClient
 from daemon.schemas import SegmentClaim, SegmentResult
@@ -646,6 +647,56 @@ async def _execute_smashcut_concat(segment: SegmentClaim, queue: QueueClient) ->
         )
 
 
+
+async def _score_segment_identity(
+    segment: SegmentClaim,
+    video_data: bytes,
+    ref_bytes: "bytes | None",
+    queue: QueueClient,
+    progress: "ProgressLog",
+) -> dict:
+    """Measure identity on the finished segment. NEVER raises - a scoring failure must not
+    fail a generation that already succeeded, so every path returns a dict (empty on failure).
+
+    Two references, because they answer different questions:
+      start frame       - how far did THIS generation drift from where it began
+      identity reference- is it the character at all
+    The start frame is the one that isolates the model's own drift; the identity reference is
+    bounded by how close the start frame already was (0.708 on the CTRL clip).
+    """
+    try:
+        start_bytes = None
+        if segment.start_image and segment.start_image.startswith("s3://"):
+            try:
+                start_bytes = await _download_with_retry(
+                    lambda: queue.download_file(segment.start_image), "identity_start_frame"
+                )
+            except Exception as e:
+                logger.info("identity: could not fetch start frame (%s)", e)
+
+        # index 0 skips the reference download above, so fetch it here when scoring needs it
+        if ref_bytes is None and segment.initial_reference_image \
+                and segment.initial_reference_image.startswith("s3://"):
+            try:
+                ref_bytes = await _download_with_retry(
+                    lambda: queue.download_file(segment.initial_reference_image),
+                    "identity_reference",
+                )
+            except Exception as e:
+                logger.info("identity: could not fetch reference (%s)", e)
+
+        score = identity_score.score_video(video_data, start_bytes, ref_bytes)
+        if score is None:
+            await progress.log("[7/7] Identity: not scored (no usable reference)")
+            return {}
+        await progress.log(f"[7/7] Identity: {score.summary()}")
+        logger.info("Identity score for segment %d: %s", segment.index, score.summary())
+        return identity_score.as_result_fields(score)
+    except Exception as e:
+        logger.warning("identity: scoring wrapper failed (%s) - segment unaffected", e)
+        return {}
+
+
 async def execute_segment(
     segment: SegmentClaim,
     comfyui: ComfyUIClient,
@@ -715,6 +766,7 @@ async def execute_segment(
 
         # Step 1b: Resolve initial reference image (identity anchor for PainterLongVideo)
         initial_ref_filename = None
+        identity_ref_bytes: bytes | None = None
         if segment.initial_reference_image and segment.index > 0:
             ref_image = segment.initial_reference_image
             if ref_image.startswith("s3://"):
@@ -723,6 +775,7 @@ async def execute_segment(
                     lambda: queue.download_file(ref_image), "initial_reference_image"
                 )
                 _validate_image_data(ref_data, "initial_reference_image")
+                identity_ref_bytes = ref_data
                 ext = os.path.splitext(ref_image)[1] or ".png"
                 ref_filename = f"initial_ref_{segment.id}{ext}"
                 initial_ref_filename = await comfyui.upload_image(ref_data, ref_filename)
@@ -840,10 +893,18 @@ async def execute_segment(
         motion_keywords = await extract_motion_keywords(segment.prompt, video_data)
         if motion_keywords:
             await progress.log(f"[7/7] Motion detected: {', '.join(motion_keywords)}")
+
+        # Identity scoring: same shape as motion magnitude - analyse the bytes we already
+        # have, attach numbers to the segment. CPU only, and never raises.
+        identity_fields = await _score_segment_identity(
+            segment, video_data, identity_ref_bytes, queue, progress,
+        )
+
         segment_result = SegmentResult(
             status="completed",
             motion_keywords=motion_keywords if motion_keywords else None,
             motion_magnitude=motion_magnitude,
+            **identity_fields,
         )
         await queue.upload_segment_output(segment.id, video_data, last_frame_data, segment_result)
         step_times.append(("upload", time.monotonic() - t0))

--- a/daemon/identity_score.py
+++ b/daemon/identity_score.py
@@ -1,0 +1,264 @@
+"""Score a generated segment for facial identity, per frame.
+
+Answers two different questions, because collapsing them into one number has already sent
+this project down a wrong path:
+
+  mean_cos_start  cosine vs the START FRAME  -> how far did THIS generation drift
+  mean_cos_ref    cosine vs the identity ref -> is it the character at all
+  slope           cosine regressed on frame index -> does it decay, and how fast
+
+A low mean with a flat slope is a weak-identity problem (dataset / LoRA / bucket size).
+A good mean with a steep slope is temporal drift (segment boundaries, seed re-anchor).
+The fixes are completely different, so both are reported.
+
+Reference point from manual analysis of experiment/real_CTRL.mp4, used as the ground-truth
+check on this module: 73 frames, NO_FACE 0, 0.811 vs start frame, 0.489 vs kellydw.
+
+CPU only - the GPU is busy generating. Never raises: a scoring bug must not fail a
+30-minute generation.
+"""
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field, asdict
+from typing import Any, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Beyond this many frames we stride instead of reading every frame, so a long stitched
+# segment cannot quietly add minutes to every generation.
+MAX_FRAMES_DENSE = 300
+# insightface's detector input. 640 matches what the gate and all prior manual analysis
+# used; changing it would make new numbers incomparable with the existing measurements.
+DET_SIZE = (640, 640)
+
+_app = None
+
+
+def _get_app():
+    """Load buffalo_l once per process. ~300MB on first ever run (downloads to
+    ~/.insightface), then cached on disk."""
+    global _app
+    if _app is None:
+        from insightface.app import FaceAnalysis
+        logger.info("identity: loading buffalo_l (first run downloads ~300MB)")
+        app = FaceAnalysis(name="buffalo_l", providers=["CPUExecutionProvider"])
+        app.prepare(ctx_id=-1, det_size=DET_SIZE)
+        _app = app
+    return _app
+
+
+def prewarm() -> bool:
+    """Load the model at daemon start so the first scored segment isn't mysteriously slow."""
+    try:
+        _get_app()
+        return True
+    except Exception as e:
+        logger.warning("identity: prewarm failed (%s) - scoring will be skipped", e)
+        return False
+
+
+@dataclass
+class IdentityScore:
+    frames: int                      # frames examined
+    faces_detected: int
+    no_face: int                     # counted, never silently dropped
+    mean_cos_start: Optional[float]
+    mean_cos_ref: Optional[float]
+    min_cos_start: Optional[float]
+    slope: Optional[float]           # cosine per frame, vs whichever ref was available
+    face_px_p50: Optional[float]
+    yaw_max: Optional[float]
+    metrics: dict[str, Any] = field(default_factory=dict)
+
+    def summary(self) -> str:
+        bits = []
+        if self.mean_cos_start is not None:
+            bits.append(f"{self.mean_cos_start:.3f} vs start")
+        if self.mean_cos_ref is not None:
+            bits.append(f"{self.mean_cos_ref:.3f} vs ref")
+        if self.slope is not None:
+            bits.append(f"drift {self.slope * max(self.frames - 1, 1):+.3f} over {self.frames}f")
+        if self.no_face:
+            bits.append(f"NO_FACE {self.no_face}")
+        return ", ".join(bits) or "no measurable frames"
+
+
+def _embed(app, img) -> list:
+    """All faces in a frame, as (embedding, face) pairs."""
+    try:
+        return [(f.normed_embedding, f) for f in app.get(img)]
+    except Exception:
+        return []
+
+
+def _cos(a, b) -> float:
+    return float(np.dot(a, b))          # insightface embeddings are already L2-normalised
+
+
+def _pick_reference_face(app, image_bytes: bytes, label: str):
+    """Largest face in a reference still. Reference images are single-subject by
+    construction, so largest is correct here - unlike video frames."""
+    import cv2
+    arr = cv2.imdecode(np.frombuffer(image_bytes, np.uint8), cv2.IMREAD_COLOR)
+    if arr is None:
+        logger.info("identity: %s could not be decoded", label)
+        return None
+    faces = _embed(app, arr)
+    if not faces:
+        logger.info("identity: no face found in %s", label)
+        return None
+    return max(faces, key=lambda t: t[1].bbox[2] - t[1].bbox[0])[0]
+
+
+def score_video(
+    video_bytes: bytes,
+    start_frame_bytes: Optional[bytes] = None,
+    reference_bytes: Optional[bytes] = None,
+) -> Optional[IdentityScore]:
+    """Score a segment. Returns None if scoring could not run at all.
+
+    Never raises.
+    """
+    if not video_bytes:
+        return None
+    if not start_frame_bytes and not reference_bytes:
+        logger.info("identity: no reference available - skipping")
+        return None
+
+    tmp = None
+    try:
+        import cv2
+        app = _get_app()
+
+        emb_start = _pick_reference_face(app, start_frame_bytes, "start frame") if start_frame_bytes else None
+        emb_ref = _pick_reference_face(app, reference_bytes, "identity reference") if reference_bytes else None
+        if emb_start is None and emb_ref is None:
+            logger.info("identity: no usable reference face - skipping")
+            return None
+        # the embedding used to disambiguate WHICH face is the subject on multi-face frames
+        anchor = emb_ref if emb_ref is not None else emb_start
+
+        fd, tmp = tempfile.mkstemp(suffix=".mp4", prefix="idscore_")
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(video_bytes)
+
+        cap = cv2.VideoCapture(tmp)
+        total = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+        stride = max(1, -(-total // MAX_FRAMES_DENSE)) if total > MAX_FRAMES_DENSE else 1
+
+        idx = 0
+        examined = no_face = 0
+        cs_start: list[float] = []
+        cs_ref: list[float] = []
+        slope_x: list[int] = []
+        slope_y: list[float] = []
+        face_px: list[float] = []
+        yaws: list[float] = []
+        multi_face = 0
+
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            if idx % stride:
+                idx += 1
+                continue
+            examined += 1
+            faces = _embed(app, frame)
+            if not faces:
+                no_face += 1
+                idx += 1
+                continue
+            if len(faces) > 1:
+                multi_face += 1
+            # Pick the face that matches the subject, NOT the largest. On a two-person
+            # frame the largest face is frequently the other person.
+            emb, f = max(faces, key=lambda t: _cos(t[0], anchor))
+            if emb_start is not None:
+                cs_start.append(_cos(emb, emb_start))
+            if emb_ref is not None:
+                cs_ref.append(_cos(emb, emb_ref))
+            primary = cs_start[-1] if emb_start is not None else cs_ref[-1]
+            slope_x.append(idx)
+            slope_y.append(primary)
+            face_px.append(float(f.bbox[2] - f.bbox[0]))
+            yaws.append(abs(float(f.pose[1])))
+            idx += 1
+        cap.release()
+
+        detected = examined - no_face
+        if detected == 0:
+            logger.info("identity: no face in any of %d frames examined", examined)
+            return IdentityScore(
+                frames=examined, faces_detected=0, no_face=no_face,
+                mean_cos_start=None, mean_cos_ref=None, min_cos_start=None,
+                slope=None, face_px_p50=None, yaw_max=None,
+                metrics={"stride": stride, "total_frames": total},
+            )
+
+        slope = None
+        if len(slope_x) >= 3:
+            slope = float(np.polyfit(np.array(slope_x, float), np.array(slope_y, float), 1)[0])
+
+        # cosine by |yaw| band - identity legitimately falls off with pose, so a low overall
+        # mean on a profile-heavy clip means something different than on a frontal one
+        bands: dict[str, dict[str, float]] = {}
+        ys = np.array(yaws)
+        prim = np.array(slope_y)
+        for lo, hi in ((0, 15), (15, 30), (30, 45), (45, 60), (60, 90)):
+            sel = prim[(ys >= lo) & (ys < hi)]
+            if sel.size:
+                bands[f"{lo}-{hi}"] = {"n": int(sel.size), "mean": float(sel.mean()),
+                                       "min": float(sel.min())}
+
+        return IdentityScore(
+            frames=examined,
+            faces_detected=detected,
+            no_face=no_face,
+            mean_cos_start=float(np.mean(cs_start)) if cs_start else None,
+            mean_cos_ref=float(np.mean(cs_ref)) if cs_ref else None,
+            min_cos_start=float(np.min(cs_start)) if cs_start else None,
+            slope=slope,
+            face_px_p50=float(np.percentile(face_px, 50)),
+            yaw_max=float(np.max(ys)),
+            metrics={
+                "stride": stride,
+                "total_frames": total,
+                "multi_face_frames": multi_face,
+                "face_px_min": float(np.min(face_px)),
+                "face_px_max": float(np.max(face_px)),
+                "yaw_bands": bands,
+                "series": [round(v, 4) for v in slope_y[:600]],
+            },
+        )
+    except Exception as e:
+        logger.warning("identity: scoring failed (%s) - segment unaffected", e, exc_info=True)
+        return None
+    finally:
+        if tmp and os.path.exists(tmp):
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+
+def as_result_fields(score: Optional[IdentityScore]) -> dict[str, Any]:
+    """Flatten into the SegmentResult field names, or empty when scoring did not run."""
+    if score is None:
+        return {}
+    d = asdict(score)
+    return {
+        "identity_mean_cos": d["mean_cos_start"],
+        "identity_mean_cos_ref": d["mean_cos_ref"],
+        "identity_min_cos": d["min_cos_start"],
+        "identity_slope": d["slope"],
+        "identity_frames": d["frames"],
+        "identity_no_face": d["no_face"],
+        "identity_face_px_p50": d["face_px_p50"],
+        "identity_yaw_max": d["yaw_max"],
+        "identity_metrics": d["metrics"],
+    }

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -11,6 +11,7 @@ from daemon.executor import execute_segment
 from daemon.model_validator import cleanup_partial_downloads, validate_models
 from daemon.node_checker import check_and_install_nodes
 from daemon.queue_client import QueueClient
+from daemon import identity_score
 from daemon.gpu_stats import get_gpu_stats
 from daemon.resource_sync import sync_resources
 from daemon.sd_scripts_monitor import get_status as get_sd_scripts_status
@@ -347,6 +348,9 @@ def kill_stale_daemons():
 
 async def run():
     kill_stale_daemons()
+    # Load the face model up front. First ever run downloads ~300MB, and doing that lazily
+    # inside the first scored segment looks like a hang in the middle of a generation.
+    await asyncio.get_running_loop().run_in_executor(None, identity_score.prewarm)
     comfyui = ComfyUIClient()
     queue = QueueClient()
     shutdown_event = asyncio.Event()

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -86,3 +86,16 @@ class SegmentResult(BaseModel):
     progress_log: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
     motion_magnitude: Optional[float] = None
+    # Identity scoring, measured inline at step 7 alongside motion_magnitude.
+    # Two means, not one: _mean_cos is vs the START FRAME (how far this generation drifted),
+    # _mean_cos_ref is vs the identity reference (is it the character at all). A low mean with
+    # a flat slope is a weak-identity problem; a good mean with a steep slope is temporal drift.
+    identity_mean_cos: Optional[float] = None
+    identity_mean_cos_ref: Optional[float] = None
+    identity_min_cos: Optional[float] = None
+    identity_slope: Optional[float] = None
+    identity_frames: Optional[int] = None
+    identity_no_face: Optional[int] = None
+    identity_face_px_p50: Optional[float] = None
+    identity_yaw_max: Optional[float] = None
+    identity_metrics: Optional[dict] = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydantic-settings
 python-dotenv
 pyyaml
 websockets
+insightface==0.7.3

--- a/tests/test_identity_score.py
+++ b/tests/test_identity_score.py
@@ -1,0 +1,204 @@
+"""Tests for per-segment identity scoring.
+
+The behaviours pinned here are the ones that were learned the hard way elsewhere in this
+codebase and would silently produce wrong numbers if they regressed:
+
+  - the SUBJECT's face is measured, not the largest face. On a two-person frame the largest
+    face is frequently the other person (the same trap gate.py fell into).
+  - undetected frames are COUNTED, not skipped. Silently dropping them inflates the mean:
+    a clip where the face vanishes half the time would otherwise score the same as one
+    where it never does.
+  - scoring NEVER raises. It runs at the end of a ~30-minute generation that already
+    succeeded; a scoring bug must not fail that segment.
+  - two means are reported, not one. Collapsing "drift from start" and "is it the character"
+    into a single figure loses the distinction the whole feature exists to expose.
+"""
+
+import numpy as np
+import pytest
+
+from daemon import identity_score
+from daemon.identity_score import IdentityScore, as_result_fields, score_video
+
+
+class FakeFace:
+    def __init__(self, emb, x0=0.0, x1=100.0, yaw=0.0):
+        self.normed_embedding = np.asarray(emb, dtype=np.float32)
+        self.bbox = np.array([x0, 0.0, x1, x1 - x0], dtype=np.float32)
+        self.pose = np.array([0.0, yaw, 0.0], dtype=np.float32)
+
+
+def unit(*v) -> np.ndarray:
+    a = np.asarray(v, dtype=np.float32)
+    return a / np.linalg.norm(a)
+
+
+SUBJECT = unit(1, 0, 0)
+OTHER = unit(0, 1, 0)          # orthogonal -> cosine 0 against the subject
+DRIFTED = unit(1, 1, 0)        # ~0.707 against the subject
+
+
+class FakeApp:
+    """Returns a scripted list of faces per successive call."""
+
+    def __init__(self, script):
+        self.script = list(script)
+        self.calls = 0
+
+    def get(self, _img):
+        i = min(self.calls, len(self.script) - 1)
+        self.calls += 1
+        return self.script[i]
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Drive score_video's frame loop without needing a real video or the real model."""
+    def install(frame_faces, ref_faces, n_frames=None):
+        script = [ref_faces] + list(frame_faces)
+        app = FakeApp(script)
+        monkeypatch.setattr(identity_score, "_get_app", lambda: app)
+
+        import cv2
+        monkeypatch.setattr(cv2, "imdecode", lambda *a, **k: np.zeros((8, 8, 3), np.uint8))
+
+        frames = list(frame_faces)
+        total = n_frames if n_frames is not None else len(frames)
+        state = {"i": 0}
+
+        class FakeCap:
+            def __init__(self, *a, **k): pass
+            def get(self, _p): return total
+            def read(self):
+                if state["i"] >= len(frames):
+                    return False, None
+                state["i"] += 1
+                return True, np.zeros((8, 8, 3), np.uint8)
+            def release(self): pass
+
+        monkeypatch.setattr(cv2, "VideoCapture", FakeCap)
+        return app
+    return install
+
+
+class TestPicksTheSubjectNotTheLargestFace:
+    def test_two_person_frame_measures_the_subject(self, patched):
+        """The other person's face is deliberately much larger. Taking the largest would
+        score ~0.0 and report catastrophic identity loss on a perfectly good clip."""
+        big_other = FakeFace(OTHER, x0=0, x1=400)
+        small_subject = FakeFace(SUBJECT, x0=500, x1=560)
+        patched(frame_faces=[[big_other, small_subject]] * 4,
+                ref_faces=[FakeFace(SUBJECT, x0=0, x1=200)])
+
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s is not None
+        assert s.mean_cos_ref == pytest.approx(1.0, abs=1e-4)
+        assert s.metrics["multi_face_frames"] == 4
+
+    def test_single_face_frames_still_work(self, patched):
+        patched(frame_faces=[[FakeFace(SUBJECT)]] * 3, ref_faces=[FakeFace(SUBJECT)])
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s.mean_cos_ref == pytest.approx(1.0, abs=1e-4)
+        assert s.metrics["multi_face_frames"] == 0
+
+
+class TestUndetectedFramesAreCounted:
+    def test_no_face_frames_are_reported_not_dropped(self, patched):
+        patched(frame_faces=[[FakeFace(SUBJECT)], [], [FakeFace(SUBJECT)], []],
+                ref_faces=[FakeFace(SUBJECT)])
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s.frames == 4
+        assert s.faces_detected == 2
+        assert s.no_face == 2
+
+    def test_all_frames_missing_returns_a_score_not_none(self, patched):
+        """'No face anywhere' is a real result about the clip, distinct from 'scoring
+        could not run'. Returning None for both would conflate them."""
+        patched(frame_faces=[[], [], []], ref_faces=[FakeFace(SUBJECT)])
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s is not None
+        assert s.faces_detected == 0 and s.no_face == 3
+        assert s.mean_cos_ref is None
+
+
+class TestTwoReferences:
+    def test_start_and_reference_scored_separately(self, patched):
+        """A clip can sit close to its start frame while being far from the character -
+        exactly what the CTRL clip did (0.811 vs start, 0.489 vs kellydw)."""
+        patched(frame_faces=[[FakeFace(DRIFTED)]] * 4,
+                ref_faces=[FakeFace(DRIFTED)])   # reference-face lookup returns this for both
+
+        s = score_video(b"video", start_frame_bytes=b"start", reference_bytes=b"ref")
+        assert s.mean_cos_start is not None
+        assert s.mean_cos_ref is not None
+
+    def test_reference_only_still_scores(self, patched):
+        patched(frame_faces=[[FakeFace(SUBJECT)]] * 3, ref_faces=[FakeFace(SUBJECT)])
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s.mean_cos_ref is not None and s.mean_cos_start is None
+
+    def test_no_reference_at_all_returns_none(self):
+        assert score_video(b"video") is None
+
+
+class TestSlope:
+    def test_degrading_identity_gives_a_negative_slope(self, patched):
+        """The diagnostic half of the feature: a good mean with a steep slope is temporal
+        drift, which needs a different fix than a uniformly low mean."""
+        decaying = [[FakeFace(unit(1, t * 0.25, 0))] for t in range(8)]
+        patched(frame_faces=decaying, ref_faces=[FakeFace(SUBJECT)])
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s.slope is not None and s.slope < 0
+
+    def test_stable_identity_gives_a_flat_slope(self, patched):
+        patched(frame_faces=[[FakeFace(SUBJECT)]] * 8, ref_faces=[FakeFace(SUBJECT)])
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s.slope == pytest.approx(0.0, abs=1e-6)
+
+
+class TestNeverRaises:
+    def test_empty_video_returns_none(self):
+        assert score_video(b"", reference_bytes=b"ref") is None
+
+    def test_model_load_failure_returns_none(self, monkeypatch):
+        def boom(): raise RuntimeError("onnxruntime exploded")
+        monkeypatch.setattr(identity_score, "_get_app", boom)
+        assert score_video(b"video", reference_bytes=b"ref") is None
+
+    def test_unreadable_reference_returns_none(self, monkeypatch):
+        monkeypatch.setattr(identity_score, "_get_app", lambda: FakeApp([[]]))
+        import cv2
+        monkeypatch.setattr(cv2, "imdecode", lambda *a, **k: None)
+        assert score_video(b"video", reference_bytes=b"notanimage") is None
+
+    def test_prewarm_failure_is_survivable(self, monkeypatch):
+        def boom(): raise RuntimeError("no model")
+        monkeypatch.setattr(identity_score, "_get_app", boom)
+        assert identity_score.prewarm() is False
+
+
+class TestResultFields:
+    def test_none_flattens_to_empty(self):
+        assert as_result_fields(None) == {}
+
+    def test_field_names_match_the_segment_result_schema(self):
+        from daemon.schemas import SegmentResult
+        score = IdentityScore(
+            frames=10, faces_detected=9, no_face=1, mean_cos_start=0.81,
+            mean_cos_ref=0.49, min_cos_start=0.7, slope=-0.001,
+            face_px_p50=110.0, yaw_max=28.0, metrics={"stride": 1},
+        )
+        fields = as_result_fields(score)
+        unknown = set(fields) - set(SegmentResult.model_fields)
+        assert not unknown, f"fields not on SegmentResult would be dropped silently: {unknown}"
+        assert SegmentResult(status="completed", **fields).identity_mean_cos == 0.81
+
+
+class TestStride:
+    def test_long_clips_are_strided(self, patched):
+        """Bounds the cost so a long stitched segment cannot add minutes to every job."""
+        n = identity_score.MAX_FRAMES_DENSE * 3
+        patched(frame_faces=[[FakeFace(SUBJECT)]] * 30, ref_faces=[FakeFace(SUBJECT)], n_frames=n)
+        s = score_video(b"video", reference_bytes=b"ref")
+        assert s.metrics["stride"] > 1
+        assert s.metrics["total_frames"] == n


### PR DESCRIPTION
## Why

Every identity question here — does the LoRA hold, did v2 beat v1, does 720 help, does the seed re-anchor flatten drift — has been answered by hand: scp to the 3090, run a scratchpad script, read numbers off a terminal. Slow enough that most videos never get measured, so calls get made by eye, and *"looked decent"* isn't comparable across LoRA versions.

Worse, the measurement only happens *after* something looks wrong — by which point the comparison you wanted wasn't set up.

## How

Inline at step 7 of `execute_segment`, exactly where `measure_motion_magnitude` already runs, on the video bytes already in memory.

**No carrier segment, no CPU claim track, no new queue path, no download.** The reference already arrives on the claim (`initial_reference_image` = `job.identity_reference_image or job.starting_image`).

```
[7/7] Motion magnitude: 0.47 px/frame
[7/7] Identity: 0.814 vs start, 0.489 vs ref, drift -0.392 over 73f
```

## Two means, not one

| | |
|---|---|
| `identity_mean_cos` | vs the **start frame** — how far *this generation* drifted |
| `identity_mean_cos_ref` | vs the **identity reference** — is it the character at all |
| `identity_slope` | cosine per frame |

A low mean with a **flat** slope is a weak-identity problem (dataset / LoRA / bucket size). A good mean with a **steep** slope is temporal drift (segment boundaries, seed re-anchor). The fixes are completely different, and conflating them has already sent this project down a wrong path.

On the CTRL clip: **0.811 vs start, 0.489 vs kellydw.** Reporting only the second looks like catastrophic failure; only the first hides that the start frame was already 0.29 off the character.

## Two traps, tested

- **The subject's face is measured, not the largest.** On a two-person frame the largest face is frequently the other person — the exact trap `gate.py` fell into. A test puts a deliberately huge second face in frame and asserts the subject is still scored.
- **Undetected frames are counted, not skipped.** Silently dropping them inflates the mean: a clip where the face vanishes half the time would otherwise score identically to one where it never does.

Also: **never raises.** This runs after a ~30-minute generation that already succeeded, so every failure path returns `None`/`{}` and logs — same contract as `_reanchor_seed_frame`.

## Verification

**Ground truth against `experiment/real_CTRL.mp4`**, whose numbers came from manual analysis:

| | expected | measured |
|---|---|---|
| frames | 73 | **73** |
| NO_FACE | 0 | **0** |
| vs start frame | ~0.811 | **0.8136** |
| vs kellydw | ~0.489 | **0.4894** |
| face px p50 | 106–120 | **112** |
| yaw max | ~28 | **28** |

The hair of difference on the start-frame score is *correct*: the manual script took the largest face, this takes the best-match. Identical on this single-subject clip; entirely different on a two-person frame.

**16 new tests, 68 total, no regressions.**

`insightface==0.7.3` added (matching the pin the RunPod image already uses); `onnxruntime` and `opencv-python-headless` were already present. Model is pre-warmed at daemon start so the first scored segment isn't mysteriously slow.

Requires wanly-api PR (migration + columns). **Needs a daemon restart** to pick up the new dependency.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct