### PR TITLE
fix(identity): report WHY scoring was skipped, not a guess

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -685,9 +685,10 @@ async def _score_segment_identity(
             except Exception as e:
                 logger.info("identity: could not fetch reference (%s)", e)
 
-        score = identity_score.score_video(video_data, start_bytes, ref_bytes)
+        score, reason = identity_score.score_video(video_data, start_bytes, ref_bytes)
         if score is None:
-            await progress.log("[7/7] Identity: not scored (no usable reference)")
+            await progress.log(f"[7/7] Identity: not scored ({reason})")
+            logger.info("Identity not scored for segment %d: %s", segment.index, reason)
             return {}
         await progress.log(f"[7/7] Identity: {score.summary()}")
         logger.info("Identity score for segment %d: %s", segment.index, score.summary())

--- a/daemon/identity_score.py
+++ b/daemon/identity_score.py
@@ -56,6 +56,12 @@ def prewarm() -> bool:
     try:
         _get_app()
         return True
+    except ModuleNotFoundError as e:
+        logger.warning(
+            "identity: %s is not installed in the daemon venv - scoring will be SKIPPED for "
+            "every segment. Fix: venv/bin/pip install insightface==0.7.3", e.name,
+        )
+        return False
     except Exception as e:
         logger.warning("identity: prewarm failed (%s) - scoring will be skipped", e)
         return False
@@ -118,16 +124,21 @@ def score_video(
     video_bytes: bytes,
     start_frame_bytes: Optional[bytes] = None,
     reference_bytes: Optional[bytes] = None,
-) -> Optional[IdentityScore]:
-    """Score a segment. Returns None if scoring could not run at all.
+) -> tuple[Optional[IdentityScore], str]:
+    """Score a segment.
+
+    Returns (score, reason). `reason` is "" on success and otherwise says WHY scoring did
+    not run - a missing dependency, an unreadable reference and an empty video are very
+    different problems, and collapsing them into a single "not scored" message sent us
+    looking for a missing reference when insightface simply was not installed.
 
     Never raises.
     """
     if not video_bytes:
-        return None
+        return None, "no video data"
     if not start_frame_bytes and not reference_bytes:
         logger.info("identity: no reference available - skipping")
-        return None
+        return None, "no reference image on the segment"
 
     tmp = None
     try:
@@ -138,7 +149,7 @@ def score_video(
         emb_ref = _pick_reference_face(app, reference_bytes, "identity reference") if reference_bytes else None
         if emb_start is None and emb_ref is None:
             logger.info("identity: no usable reference face - skipping")
-            return None
+            return None, "no face detected in the reference image"
         # the embedding used to disambiguate WHICH face is the subject on multi-face frames
         anchor = emb_ref if emb_ref is not None else emb_start
 
@@ -198,7 +209,7 @@ def score_video(
                 mean_cos_start=None, mean_cos_ref=None, min_cos_start=None,
                 slope=None, face_px_p50=None, yaw_max=None,
                 metrics={"stride": stride, "total_frames": total},
-            )
+            ), ""
 
         slope = None
         if len(slope_x) >= 3:
@@ -234,10 +245,15 @@ def score_video(
                 "yaw_bands": bands,
                 "series": [round(v, 4) for v in slope_y[:600]],
             },
-        )
+        ), ""
+    except ModuleNotFoundError as e:
+        # The one that actually bit: insightface missing from the daemon venv. Say so
+        # plainly instead of blaming the reference image.
+        logger.warning("identity: dependency missing (%s) - scoring skipped", e)
+        return None, f"dependency missing: {e.name}"
     except Exception as e:
         logger.warning("identity: scoring failed (%s) - segment unaffected", e, exc_info=True)
-        return None
+        return None, f"error: {type(e).__name__}: {e}"
     finally:
         if tmp and os.path.exists(tmp):
             try:

--- a/tests/test_identity_score.py
+++ b/tests/test_identity_score.py
@@ -90,14 +90,14 @@ class TestPicksTheSubjectNotTheLargestFace:
         patched(frame_faces=[[big_other, small_subject]] * 4,
                 ref_faces=[FakeFace(SUBJECT, x0=0, x1=200)])
 
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s is not None
         assert s.mean_cos_ref == pytest.approx(1.0, abs=1e-4)
         assert s.metrics["multi_face_frames"] == 4
 
     def test_single_face_frames_still_work(self, patched):
         patched(frame_faces=[[FakeFace(SUBJECT)]] * 3, ref_faces=[FakeFace(SUBJECT)])
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s.mean_cos_ref == pytest.approx(1.0, abs=1e-4)
         assert s.metrics["multi_face_frames"] == 0
 
@@ -106,7 +106,7 @@ class TestUndetectedFramesAreCounted:
     def test_no_face_frames_are_reported_not_dropped(self, patched):
         patched(frame_faces=[[FakeFace(SUBJECT)], [], [FakeFace(SUBJECT)], []],
                 ref_faces=[FakeFace(SUBJECT)])
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s.frames == 4
         assert s.faces_detected == 2
         assert s.no_face == 2
@@ -115,7 +115,7 @@ class TestUndetectedFramesAreCounted:
         """'No face anywhere' is a real result about the clip, distinct from 'scoring
         could not run'. Returning None for both would conflate them."""
         patched(frame_faces=[[], [], []], ref_faces=[FakeFace(SUBJECT)])
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s is not None
         assert s.faces_detected == 0 and s.no_face == 3
         assert s.mean_cos_ref is None
@@ -128,17 +128,19 @@ class TestTwoReferences:
         patched(frame_faces=[[FakeFace(DRIFTED)]] * 4,
                 ref_faces=[FakeFace(DRIFTED)])   # reference-face lookup returns this for both
 
-        s = score_video(b"video", start_frame_bytes=b"start", reference_bytes=b"ref")
+        s, _ = score_video(b"video", start_frame_bytes=b"start", reference_bytes=b"ref")
         assert s.mean_cos_start is not None
         assert s.mean_cos_ref is not None
 
     def test_reference_only_still_scores(self, patched):
         patched(frame_faces=[[FakeFace(SUBJECT)]] * 3, ref_faces=[FakeFace(SUBJECT)])
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s.mean_cos_ref is not None and s.mean_cos_start is None
 
     def test_no_reference_at_all_returns_none(self):
-        assert score_video(b"video") is None
+        score, reason = score_video(b"video")
+        assert score is None
+        assert "no reference" in reason
 
 
 class TestSlope:
@@ -147,29 +149,35 @@ class TestSlope:
         drift, which needs a different fix than a uniformly low mean."""
         decaying = [[FakeFace(unit(1, t * 0.25, 0))] for t in range(8)]
         patched(frame_faces=decaying, ref_faces=[FakeFace(SUBJECT)])
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s.slope is not None and s.slope < 0
 
     def test_stable_identity_gives_a_flat_slope(self, patched):
         patched(frame_faces=[[FakeFace(SUBJECT)]] * 8, ref_faces=[FakeFace(SUBJECT)])
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s.slope == pytest.approx(0.0, abs=1e-6)
 
 
 class TestNeverRaises:
     def test_empty_video_returns_none(self):
-        assert score_video(b"", reference_bytes=b"ref") is None
+        score, reason = score_video(b"", reference_bytes=b"ref")
+        assert score is None
+        assert reason == "no video data"
 
     def test_model_load_failure_returns_none(self, monkeypatch):
         def boom(): raise RuntimeError("onnxruntime exploded")
         monkeypatch.setattr(identity_score, "_get_app", boom)
-        assert score_video(b"video", reference_bytes=b"ref") is None
+        score, reason = score_video(b"video", reference_bytes=b"ref")
+        assert score is None
+        assert "error:" in reason or "dependency missing" in reason
 
     def test_unreadable_reference_returns_none(self, monkeypatch):
         monkeypatch.setattr(identity_score, "_get_app", lambda: FakeApp([[]]))
         import cv2
         monkeypatch.setattr(cv2, "imdecode", lambda *a, **k: None)
-        assert score_video(b"video", reference_bytes=b"notanimage") is None
+        score, reason = score_video(b"video", reference_bytes=b"notanimage")
+        assert score is None
+        assert "reference" in reason
 
     def test_prewarm_failure_is_survivable(self, monkeypatch):
         def boom(): raise RuntimeError("no model")
@@ -199,6 +207,34 @@ class TestStride:
         """Bounds the cost so a long stitched segment cannot add minutes to every job."""
         n = identity_score.MAX_FRAMES_DENSE * 3
         patched(frame_faces=[[FakeFace(SUBJECT)]] * 30, ref_faces=[FakeFace(SUBJECT)], n_frames=n)
-        s = score_video(b"video", reference_bytes=b"ref")
+        s, _ = score_video(b"video", reference_bytes=b"ref")
         assert s.metrics["stride"] > 1
         assert s.metrics["total_frames"] == n
+
+
+class TestFailureReasonIsSpecific:
+    """The bug this class exists for: a missing insightface reported as
+    "not scored (no usable reference)", which sent us looking for a missing reference image
+    when the real cause was a dependency that was never installed. Six different failures
+    were collapsing into one message."""
+
+    def test_missing_dependency_says_so_by_name(self, monkeypatch):
+        def boom():
+            raise ModuleNotFoundError("No module named 'insightface'", name="insightface")
+        monkeypatch.setattr(identity_score, "_get_app", boom)
+        score, reason = score_video(b"video", reference_bytes=b"ref")
+        assert score is None
+        assert "dependency missing" in reason and "insightface" in reason
+
+    def test_no_reference_is_distinguishable_from_a_bad_one(self, monkeypatch):
+        _, none_at_all = score_video(b"video")
+        monkeypatch.setattr(identity_score, "_get_app", lambda: FakeApp([[]]))
+        import cv2
+        monkeypatch.setattr(cv2, "imdecode", lambda *a, **k: None)
+        _, unreadable = score_video(b"video", reference_bytes=b"junk")
+        assert none_at_all != unreadable, "distinct failures must not share a message"
+
+    def test_success_has_an_empty_reason(self, patched):
+        patched(frame_faces=[[FakeFace(SUBJECT)]] * 3, ref_faces=[FakeFace(SUBJECT)])
+        score, reason = score_video(b"video", reference_bytes=b"ref")
+        assert score is not None and reason == ""


### PR DESCRIPTION
## The bug

First post-deploy job produced no scores, and the log said:

```
[7/7] Identity: not scored (no usable reference)
```

The reference was fine. The real cause:

```
WARNING identity: prewarm failed (No module named 'insightface') - scoring will be skipped
WARNING identity: scoring failed (No module named 'insightface') - segment unaffected
```

`score_video` returned a bare `None` for **six distinct outcomes**, and the caller printed one hardcoded message. So a missing dependency read as a missing reference image, and the first place I looked was the wrong one.

## Fix

`score_video` now returns `(score, reason)`. `reason` is `""` on success and otherwise says what actually happened:

- `dependency missing: insightface`
- `no video data`
- `no reference image on the segment`
- `no face detected in the reference image`
- `error: <Type>: <detail>`

Prewarm additionally names the package **and the fix command**, because a failed prewarm means *every* segment silently goes unscored — the failure is total but presents as nothing at all:

```
identity: insightface is not installed in the daemon venv - scoring will be SKIPPED for
every segment. Fix: venv/bin/pip install insightface==0.7.3
```

## Tests

The existing 16 caught the signature change immediately and were updated to unpack and assert on the reason. Three new cases pin the actual bug:

- a missing dependency is reported **by name**, not as a reference problem
- "no reference at all" and "unreadable reference" produce **different** messages
- success carries an empty reason

**19 identity tests, 71 total, no regressions.**

Note the degradation itself was correct throughout — the segment generated fine and was never at risk. Only the diagnosis was wrong.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct