### PR TITLE
fix(identity): score against segment 0's start frame only

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -651,7 +651,6 @@ async def _execute_smashcut_concat(segment: SegmentClaim, queue: QueueClient) ->
 async def _score_segment_identity(
     segment: SegmentClaim,
     video_data: bytes,
-    ref_bytes: "bytes | None",
     queue: QueueClient,
     progress: "ProgressLog",
 ) -> dict:
@@ -674,16 +673,19 @@ async def _score_segment_identity(
             except Exception as e:
                 logger.info("identity: could not fetch start frame (%s)", e)
 
-        # index 0 skips the reference download above, so fetch it here when scoring needs it
-        if ref_bytes is None and segment.initial_reference_image \
-                and segment.initial_reference_image.startswith("s3://"):
+        # Ground truth is segment 0's start frame - the job's starting image - and nothing
+        # else. Explicitly NOT initial_reference_image: that field is the PainterLongVideo
+        # anchor and can be overridden, which would silently change what "her" means
+        # partway through a measurement. "Her" is where the job began.
+        ref_bytes = None
+        truth = segment.identity_ground_truth
+        if truth and truth.startswith("s3://"):
             try:
                 ref_bytes = await _download_with_retry(
-                    lambda: queue.download_file(segment.initial_reference_image),
-                    "identity_reference",
+                    lambda: queue.download_file(truth), "identity_ground_truth",
                 )
             except Exception as e:
-                logger.info("identity: could not fetch reference (%s)", e)
+                logger.info("identity: could not fetch ground truth (%s)", e)
 
         score, reason = identity_score.score_video(video_data, start_bytes, ref_bytes)
         if score is None:
@@ -767,7 +769,6 @@ async def execute_segment(
 
         # Step 1b: Resolve initial reference image (identity anchor for PainterLongVideo)
         initial_ref_filename = None
-        identity_ref_bytes: bytes | None = None
         if segment.initial_reference_image and segment.index > 0:
             ref_image = segment.initial_reference_image
             if ref_image.startswith("s3://"):
@@ -776,7 +777,6 @@ async def execute_segment(
                     lambda: queue.download_file(ref_image), "initial_reference_image"
                 )
                 _validate_image_data(ref_data, "initial_reference_image")
-                identity_ref_bytes = ref_data
                 ext = os.path.splitext(ref_image)[1] or ".png"
                 ref_filename = f"initial_ref_{segment.id}{ext}"
                 initial_ref_filename = await comfyui.upload_image(ref_data, ref_filename)
@@ -898,7 +898,7 @@ async def execute_segment(
         # Identity scoring: same shape as motion magnitude - analyse the bytes we already
         # have, attach numbers to the segment. CPU only, and never raises.
         identity_fields = await _score_segment_identity(
-            segment, video_data, identity_ref_bytes, queue, progress,
+            segment, video_data, queue, progress,
         )
 
         segment_result = SegmentResult(

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -34,6 +34,9 @@ class SegmentClaim(BaseModel):
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
     initial_reference_image: Optional[str] = None
+    # Identity scoring ground truth: segment 0's start frame. NOT initial_reference_image -
+    # that is the PainterLongVideo anchor and is overridable.
+    identity_ground_truth: Optional[str] = None
     motion_keywords: Optional[list[str]] = None
     previous_motion_keywords: Optional[list[str]] = None
     previous_motion_magnitude: Optional[float] = None

--- a/tests/test_identity_score.py
+++ b/tests/test_identity_score.py
@@ -285,3 +285,52 @@ class TestTrajectory:
         patched(frame_faces=[[FakeFace(SUBJECT)]] * 3, ref_faces=[FakeFace(SUBJECT)])
         s, _ = score_video(b"video", start_frame_bytes=b"start")
         assert s.loss is None
+
+
+class TestGroundTruthIsSegmentZeroStartFrame:
+    """"Her" is defined by where the job began — segment 0's start frame — and by nothing
+    else. No external reference, no override, nothing hardcoded.
+
+    Scoring previously piggybacked on `initial_reference_image`, which resolves to
+    `job.identity_reference_image or job.starting_image`. That field exists for the
+    PainterLongVideo anchor and is overridable, so setting it would have silently changed
+    what the numbers were measured against, partway through a job.
+    """
+
+    def test_claim_carries_an_explicit_ground_truth_field(self):
+        from daemon.schemas import SegmentClaim
+        assert "identity_ground_truth" in SegmentClaim.model_fields
+
+    def test_ground_truth_is_independent_of_the_painter_anchor(self):
+        """The two fields must be separately settable, or one can shadow the other."""
+        from tests.conftest import make_segment
+        seg = make_segment(
+            identity_ground_truth="s3://bucket/seg0_start.png",
+            initial_reference_image="s3://bucket/some_other_anchor.png",
+        )
+        assert seg.identity_ground_truth != seg.initial_reference_image
+
+    def test_scoring_never_reads_the_painter_anchor(self):
+        """Source-level guard: the scoring helper must not reference the overridable field.
+        A future edit that reintroduces the coupling fails here rather than silently
+        changing what every number means."""
+        import ast as _ast, inspect
+        from daemon import executor
+        raw = inspect.getsource(executor._score_segment_identity)
+        # Strip comments and docstrings: the helper deliberately NAMES the anchor field in a
+        # comment explaining why it is not used, and that must not trip the guard.
+        tree = _ast.parse(raw.lstrip())
+        for node in _ast.walk(tree):
+            if isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef)) \
+                    and _ast.get_docstring(node):
+                node.body = node.body[1:]
+        src = _ast.unparse(tree)
+        assert "initial_reference_image" not in src, (
+            "identity scoring must use identity_ground_truth, not the overridable "
+            "PainterLongVideo anchor"
+        )
+        assert "identity_ground_truth" in src
+
+    def test_no_hardcoded_identity_face_map_remains(self):
+        from daemon import executor
+        assert not hasattr(executor, "_HARDCODE_IDENTITY_FACE")


### PR DESCRIPTION
## The problem

Scoring rode on `initial_reference_image`, which resolves to `job.identity_reference_image or job.starting_image`.

1. **Overridable** — setting `identity_reference_image` would silently make an external image the ground truth instead of segment 0's start frame, changing what every number means partway through a job, with no signal.
2. **Wrong field** — it exists for the PainterLongVideo anchor, not for measurement.

## Fix

Uses the new `identity_ground_truth` claim field (always `job.starting_image`). **"Her" is where the job began.** Also drops the piggybacked byte capture that implied the anchor fed scoring.

The helper now reads exactly two segment fields:

```
segment.identity_ground_truth   seg0's start frame  ("her")
segment.start_image             this segment's own first frame (local drift only)
```

## Audit

No hardcoded identity image exists anywhere in the daemon. `_HARDCODE_IDENTITY_FACE` was removed yesterday; remaining `.png` literals are file extensions and temp filenames.

## Guards — four, so this can't quietly return

- the claim carries an explicit field
- the two fields are independently settable
- **source-level check** that the helper never reads the overridable anchor, parsing the AST with comments and docstrings stripped — the helper deliberately *names* the field in a comment explaining why it isn't used, which would otherwise trip a naive grep
- no hardcoded identity face map exists

**80 daemon tests passing.** Requires wanly-api #142.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct