### PR TITLE
Fix seed re-anchor swapping the wrong face onto the wrong target

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -189,7 +189,11 @@ async def _reanchor_seed_frame(
     to a ComfyUI filename by this point (see _resolve_faceswap_image). It used to come from
     a hardcoded lora_id -> S3 face map, which limited the feature to two characters."""
     try:
-        face_fn = segment.faceswap_image
+        # Anchor to the SAME image identity is measured against — the job's starting image,
+        # which is segment 0's start frame. A separate faceswap portrait pulls the seed toward
+        # a different face than the one we score against, so even a perfect swap reads as a
+        # failure. Falls back to the configured faceswap face when no ground truth is set.
+        face_fn = segment.identity_ground_truth or segment.faceswap_image
         if not face_fn:
             logger.info("Seed re-anchor: segment %d has no faceswap face — kept raw seed", segment.index)
             await progress.log("[seed] No faceswap face configured — kept raw frame")
@@ -207,9 +211,16 @@ async def _reanchor_seed_frame(
 
         seed_fn = await comfyui.upload_image(last_frame_data, f"seed_{segment.id}.png")
 
+        # ALWAYS facefusion for a seed re-anchor, whatever the video's method is.
+        # ReActor selects the target face by POSITION (faces_index 0, left-right), so on a
+        # two-person frame it swaps the leftmost face — often the wrong person entirely. It
+        # still changes pixels, so the caller's diff reports success while her face is
+        # untouched. Measured cost of that on a real job: +0.014 cosine from a full swap.
+        # FaceFusion uses face_selector_mode="reference" and targets the face MATCHING the
+        # source, which is the only correct semantics for re-anchoring one specific identity.
         seg = segment.model_copy(update={
             "faceswap_image": face_fn,
-            "faceswap_method": segment.faceswap_method or "facefusion",
+            "faceswap_method": "facefusion",
         })
         workflow = build_seed_faceswap_workflow(seg, seed_fn)
         prompt_id, client_id = await comfyui.submit_workflow(workflow)

--- a/tests/test_seed_reanchor.py
+++ b/tests/test_seed_reanchor.py
@@ -134,6 +134,56 @@ class TestFaceSource:
         assert any(f.startswith("seedface_") for f in comfy.uploads)
 
 
+class TestAnchorsToTheScoredReference:
+    """Two bugs found on 2026-08-04 after a real re-anchor moved identity by +0.014.
+
+    The seed came out at 0.677 against ground truth where the raw frame was 0.663 — a full
+    face swap that accomplished nothing. Cause was a mismatch on BOTH ends: it swapped the
+    wrong face IN, onto the wrong face in the frame."""
+
+    @pytest.mark.asyncio
+    async def test_prefers_the_job_ground_truth_over_a_separate_portrait(self):
+        """Identity is scored against the job's starting image. Anchoring to a different
+        portrait pulls the seed toward a face nobody is measuring."""
+        seg = make_segment(
+            seed_faceswap=True, faceswap_enabled=True,
+            faceswap_image="Kelly_young_driveway.jpg",
+            identity_ground_truth="seg0_start.png",
+        )
+        comfy = FakeComfy()
+        out = await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), FakeProgress())
+        assert out == SWAPPED
+        assert comfy.submitted["188"]["inputs"]["image"] == "seg0_start.png"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_faceswap_face_without_ground_truth(self):
+        seg = make_segment(
+            seed_faceswap=True, faceswap_enabled=True,
+            faceswap_image="portrait.png", identity_ground_truth=None,
+        )
+        comfy = FakeComfy()
+        await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), FakeProgress())
+        assert comfy.submitted["188"]["inputs"]["image"] == "portrait.png"
+
+    @pytest.mark.asyncio
+    async def test_forces_facefusion_even_when_the_video_uses_reactor(self):
+        """ReActor picks the target face by POSITION (faces_index 0, left-right). On a
+        two-person frame that is the leftmost face — frequently the wrong person. It still
+        rewrites pixels, so the caller's diff reads success while her face is untouched.
+        FaceFusion selects by reference, matching the source face, which is the only correct
+        semantics here."""
+        seg = make_segment(
+            seed_faceswap=True, faceswap_enabled=True, faceswap_image="f.png",
+            faceswap_method="reactor", faceswap_faces_index="0",
+            faceswap_faces_order="left-right",
+        )
+        comfy = FakeComfy()
+        await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), FakeProgress())
+        node = comfy.submitted["183"]
+        assert node["class_type"] == "AdvancedSwapFaceImage", node["class_type"]
+        assert node["inputs"]["face_selector_mode"] == "reference"
+
+
 class TestDegradesToRawSeed:
     """A failed re-anchor must cost nothing: the raw frame still seeds the next segment."""
 


### PR DESCRIPTION
## The symptom

Seed re-anchor fired successfully on job `63d97c06` and moved identity by **+0.014**:

```
seg0 last frame (raw)      0.663  vs ground truth
re-anchored seed           0.677  vs ground truth
```

A full face swap that accomplished nothing. It logged `[seed] Re-anchored identity via faceswap` the whole time.

## Two causes, both real

**1. Wrong target face.** The segment carried `faceswap_method: reactor`, and ReActor selects the target by *position*:

```
input_faces_order  left-right
input_faces_index  "0"          -> the leftmost face in the frame
```

On a two-person scene that is frequently the wrong person. ReActor still rewrites pixels, so `_images_differ` returns True and the caller reports success while her face is untouched.

The seed swap now always uses FaceFusion, whose `face_selector_mode="reference"` targets the face **matching the source**. That is the only correct semantics for re-anchoring one specific identity, and it should not depend on which method the video-level faceswap happens to use.

**2. Wrong source face.** It anchored to `segment.faceswap_image` — `Kelly_young_driveway.jpg`, a separate portrait — while identity is scored against the job's starting image. Even a flawless swap pulls the seed toward a face nobody is measuring. Now prefers `segment.identity_ground_truth`, falling back to the configured face when unset.

## Tests

3 new cases in `test_seed_reanchor.py`: ground truth wins over a separate portrait, fallback when unset, and FaceFusion forced even when the segment says `reactor`. Full suite **83 passed**.

## Deploy

Daemon change — needs a restart on the 3090 to take effect.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct