### PR TITLE
Loosen the seed re-anchor's reference-face threshold to 1.0

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -269,11 +269,22 @@ def _add_user_loras(workflow: dict, loras: list[dict]) -> None:
     workflow["102"]["inputs"]["model"] = [last_low_node, 0]
 
 
-def _add_faceswap(workflow: dict, segment: SegmentClaim, input_node: str = "87") -> None:
+def _add_faceswap(
+    workflow: dict,
+    segment: SegmentClaim,
+    input_node: str = "87",
+    reference_face_distance: float = 0.8,
+) -> None:
     """Add face swap nodes (188 LoadImage + 183 FaceSwap).
 
     input_node controls where frames come from: "87" (VAEDecode) for generation
     workflows, or "400" (VHS_LoadVideo) for faceswap-only reprocessing.
+
+    reference_face_distance is the threshold FaceFusion uses in face_selector_mode
+    "reference": a target face is swapped only when its embedding is within this
+    distance of the source. That is how the RIGHT person gets picked in a two-person
+    frame — by identity, not by position. The seed re-anchor overrides it upward; see
+    build_seed_faceswap_workflow for why.
     """
     workflow["188"] = {
         "class_type": "LoadImage",
@@ -339,7 +350,7 @@ def _add_faceswap(workflow: dict, segment: SegmentClaim, input_node: str = "87")
             "face_mask_regions": "skin,nose,mouth,upper-lip,lower-lip",
             "face_mask_padding": "0,0,0,0",
             "reference_image": ["188", 0],
-            "reference_face_distance": 0.8,
+            "reference_face_distance": reference_face_distance,
         }
         workflow["183"] = {
             "class_type": "AdvancedSwapFaceImage",
@@ -430,7 +441,14 @@ def build_seed_faceswap_workflow(segment: SegmentClaim, seed_filename: str) -> d
         "inputs": {"image": seed_filename},
         "_meta": {"title": "Seed frame (last frame)"},
     }
-    _add_faceswap(workflow, segment, input_node="400")
+    # Looser reference threshold than the video path (0.8), and deliberately so.
+    # In a two-person frame the right face is chosen by matching the SOURCE identity, but
+    # the seed frame is by definition the drifted one — that is the reason to re-anchor it.
+    # A face measured at 0.663 cosine against the reference can fall outside a 0.8 threshold,
+    # in which case FaceFusion swaps nothing and the fix silently no-ops exactly when it is
+    # needed most. 1.0 is the value validated on the NSFW face-swap work. It still excludes
+    # the male partner, whose embedding distance from her is far larger than either bound.
+    _add_faceswap(workflow, segment, input_node="400", reference_face_distance=1.0)
     workflow["186"] = {
         "class_type": "SaveImage",
         "inputs": {"filename_prefix": "seed_swap", "images": ["183", 0]},

--- a/tests/test_seed_reanchor.py
+++ b/tests/test_seed_reanchor.py
@@ -183,6 +183,26 @@ class TestAnchorsToTheScoredReference:
         assert node["class_type"] == "AdvancedSwapFaceImage", node["class_type"]
         assert node["inputs"]["face_selector_mode"] == "reference"
 
+    @pytest.mark.asyncio
+    async def test_seed_uses_a_looser_reference_threshold_than_video(self):
+        """The seed frame is the DRIFTED one — that is why it is being re-anchored. A face
+        at 0.663 cosine can fall outside the video path's 0.8 threshold, in which case
+        FaceFusion swaps nothing and the fix no-ops precisely when it matters."""
+        seg = make_segment(seed_faceswap=True, faceswap_enabled=True, faceswap_image="f.png")
+        comfy = FakeComfy()
+        await _reanchor_seed_frame(seg, RAW_SEED, comfy, FakeQueue(), FakeProgress())
+        assert comfy.submitted["183"]["inputs"]["reference_face_distance"] == 1.0
+
+    def test_video_faceswap_keeps_the_validated_08_threshold(self):
+        """Scoped change: the seed path loosens, the video path David has already validated
+        must not move."""
+        from daemon.workflow_builder import _add_faceswap
+        wf: dict = {}
+        seg = make_segment(faceswap_enabled=True, faceswap_image="f.png",
+                           faceswap_method="facefusion")
+        _add_faceswap(wf, seg)
+        assert wf["183"]["inputs"]["reference_face_distance"] == 0.8
+
 
 class TestDegradesToRawSeed:
     """A failed re-anchor must cost nothing: the raw frame still seeds the next segment."""


### PR DESCRIPTION
Follow-up to #98, prompted by David asking the right question: *"for re-anchor, there may be two faces... how will it select the correct one?"*

**Selection is by identity, not position** — that part #98 fixed. FaceFusion's `face_selector_mode="reference"` swaps a target face only when its embedding is within `reference_face_distance` of the source.

**But the threshold was too tight for this job.** It was 0.8, and the seed frame is *the drifted one* — drift is the entire reason to re-anchor. A seed at 0.663 cosine against ground truth can fall outside 0.8, FaceFusion then matches nothing, passes the frame through unchanged, and the re-anchor no-ops precisely when it matters. The worse the drift, the less likely the fix fires.

1.0 is the value validated on the NSFW face-swap work, and still excludes the male partner — a cross-sex embedding distance is far larger than either bound.

**Scoped:** `_add_faceswap` takes `reference_face_distance` defaulting to 0.8, and only the seed path passes 1.0. The video faceswap David has validated does not move. Both pinned by tests.

85 passed.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct