### PR TITLE
Make face swapper model and pixel boost tunable per segment

### DIFF
--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -31,6 +31,8 @@ class SegmentClaim(BaseModel):
     faceswap_method: Optional[str] = None
     faceswap_source_type: Optional[str] = None
     faceswap_image: Optional[str] = None
+    faceswap_model: Optional[str] = None
+    faceswap_pixel_boost: Optional[str] = None
     faceswap_faces_order: Optional[str] = None
     faceswap_faces_index: Optional[str] = None
     initial_reference_image: Optional[str] = None

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -332,9 +332,14 @@ def _add_faceswap(
             "source_images": ["188", 0],
             "target_image": [input_node, 0],
             "api_token": "-1",
-            "face_swapper_model": "inswapper_128",
+            # inswapper_128 is 128px native, so a 256/512 model stretches the crop
+            # half as far or not at all. The node's own default is hyperswap_1c_256.
+            "face_swapper_model": segment.faceswap_model or "inswapper_128",
             "face_detector_model": "retinaface",
-            "pixel_boost": "512x512",
+            # 512x512 on a ~100px face interpolates 5x then pixel-unshuffles into 16
+            # strided sub-images carrying no extra real signal - ~16x compute for nothing.
+            # Only worth raising when the face genuinely has >128px of detail.
+            "pixel_boost": segment.faceswap_pixel_boost or "512x512",
             "face_occluder_model": "xseg_1",
             "face_parser_model": "bisenet_resnet_34",
             "face_mask_blur": 0.3,

--- a/tests/test_seed_reanchor.py
+++ b/tests/test_seed_reanchor.py
@@ -312,3 +312,29 @@ class TestFlagPlumbing:
         """The seed re-anchor is a separate decision from swapping the whole clip."""
         seg = make_segment(seed_faceswap=True, faceswap_enabled=False)
         assert seg.seed_faceswap is True and seg.faceswap_enabled is False
+
+
+class TestSwapperTunables:
+    """face_swapper_model and pixel_boost were hardcoded, which made the swap stage
+    untunable - and a controlled sweep put the remaining headroom there, not in generation
+    (no LoRA at all scores mean 0.695, same as a purpose-trained one)."""
+
+    def test_defaults_preserve_the_validated_recipe(self):
+        from daemon.workflow_builder import _add_faceswap
+        wf: dict = {}
+        seg = make_segment(faceswap_enabled=True, faceswap_image="f.png",
+                           faceswap_method="facefusion")
+        _add_faceswap(wf, seg)
+        assert wf["183"]["inputs"]["face_swapper_model"] == "inswapper_128"
+        assert wf["183"]["inputs"]["pixel_boost"] == "512x512"
+
+    def test_segment_can_override_both(self):
+        from daemon.workflow_builder import _add_faceswap
+        wf: dict = {}
+        seg = make_segment(faceswap_enabled=True, faceswap_image="f.png",
+                           faceswap_method="facefusion",
+                           faceswap_model="hyperswap_1c_256",
+                           faceswap_pixel_boost="256x256")
+        _add_faceswap(wf, seg)
+        assert wf["183"]["inputs"]["face_swapper_model"] == "hyperswap_1c_256"
+        assert wf["183"]["inputs"]["pixel_boost"] == "256x256"


### PR DESCRIPTION
## Why

A controlled sweep this week moved the problem: **nothing on the generation side affects identity.** With no LoRA at all a clip scores mean 0.695 — identical to one with a purpose-trained character LoRA. Sampler variations were all worse. Identity has to be *injected* by the swap, so the swap needs knobs, and both of the ones that matter were hardcoded.

```
face_swapper_model   inswapper_128   ← 128px native
pixel_boost          512x512         ← on a ~100px face
```

**Model:** `hyperswap_1c_256`, `simswap_256`, `hififace_unofficial_256` are 256 native and `simswap_unofficial_512` is 512, so the crop is stretched half as far or not at all. The ComfyUI node's own default is `hyperswap_1c_256` — we were overriding it with the older model.

**Pixel boost:** at 512x512 on a 100px face the crop is interpolated up ~5x, then `implode_pixel_boost` reshapes it into 16 strided sub-images that carry no additional real signal — roughly 16x compute for the 128 result. Only worth raising when the face genuinely has >128px of detail.

## Change

`segment.faceswap_model` and `segment.faceswap_pixel_boost`, NULL-defaulted so today's behaviour is unchanged until a segment asks for something else. Paired API migration 055.

## Tests

Two new cases pinning defaults and overrides. 23 in the file, 85 across the suite.

## Deploy

Daemon change — needs a restart on the 3090 (`pkill -u david -f 'daemon.mai[n]'`, `Restart=always` brings it back).

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct