### PR TITLE
Measure the per-frame series against the job's ground truth

### DIFF
--- a/daemon/identity_score.py
+++ b/daemon/identity_score.py
@@ -222,7 +222,13 @@ def score_video(
                 cs_start.append(_cos(emb, emb_start))
             if emb_ref is not None:
                 cs_ref.append(_cos(emb, emb_ref))
-            primary = cs_start[-1] if emb_start is not None else cs_ref[-1]
+            # Prefer the GROUND TRUTH (the job's start image) over this segment's own start
+            # frame. They are the same image on segment 0, but on a continuation the own-start
+            # reference is the already-drifted last frame -- so a segment could read as stable
+            # while identity had collapsed since the job began. The headline trajectory is vs
+            # ground truth, so the series, the slope and the yaw bands must be too or the panel
+            # contradicts the numbers printed above it.
+            primary = cs_ref[-1] if emb_ref is not None else cs_start[-1]
             slope_x.append(idx)
             slope_y.append(primary)
             face_px.append(float(f.bbox[2] - f.bbox[0]))
@@ -288,7 +294,13 @@ def score_video(
                 "face_sharp_start": round(float(np.mean(sharps[:3])), 1) if len(sharps) >= 3 else None,
                 "face_sharp_end": round(float(np.mean(sharps[-3:])), 1) if len(sharps) >= 3 else None,
                 "yaw_bands": bands,
+                # Which reference `series`, `slope` and `yaw_bands` are measured against.
+                # Older clips predate this field and are all vs the segment's own start frame.
+                "series_ref": "ground_truth" if emb_ref is not None else "own_start",
                 "series": [round(v, 4) for v in slope_y[:600]],
+                # Within-segment drift, for contrast: how far the face moved from where THIS
+                # segment began, independent of what it inherited.
+                "series_own_start": [round(v, 4) for v in cs_start[:600]] if cs_start else None,
             },
         ), ""
     except ModuleNotFoundError as e:

--- a/tests/test_identity_score.py
+++ b/tests/test_identity_score.py
@@ -370,3 +370,45 @@ class TestFaceDetail:
             start_cos_ref=0.95, end_cos_ref=0.90,
         )
         assert "detail" not in s.summary()
+
+
+class TestSeriesReference:
+    """The per-frame series, the slope and the yaw bands must read the SAME reference as the
+    headline trajectory, which is the job's ground truth.
+
+    They did not. `primary` preferred the segment's OWN start frame, and on a continuation that
+    is the already-drifted last frame -- so the graph started at ~0.95 while the numbers printed
+    directly above it read 0.851. Confirmed on real data: every seg1 series began near 0.95
+    regardless of a cumulative start of 0.851-0.914. Harmless on segment 0, where both
+    references are the same image; misleading on everything after it."""
+
+    def test_ground_truth_is_preferred_over_own_start(self):
+        import inspect
+        from daemon import identity_score
+        src = inspect.getsource(identity_score.score_video)
+        assert "primary = cs_ref[-1] if emb_ref is not None else cs_start[-1]" in src, \
+            "series/slope/bands must prefer the ground-truth reference"
+
+    def test_metrics_declare_which_reference_was_used(self):
+        """Clips scored before this change are all vs own_start and have no such field, so a
+        reader must be able to tell them apart rather than assuming."""
+        import inspect
+        from daemon import identity_score
+        src = inspect.getsource(identity_score.score_video)
+        assert '"series_ref": "ground_truth" if emb_ref is not None else "own_start"' in src
+
+    def test_own_start_series_is_still_recorded(self):
+        """Within-segment drift stays available -- it answers a different question (how far did
+        the face move from where THIS segment began) and is what the dip detector wants."""
+        import inspect
+        from daemon import identity_score
+        assert '"series_own_start"' in inspect.getsource(identity_score.score_video)
+
+    def test_mean_and_min_cos_start_still_read_cs_start(self):
+        """Only slope, bands and series move. mean_cos_start/min_cos_start are explicitly the
+        vs-own-start figures and must not silently become vs-truth."""
+        import inspect
+        from daemon import identity_score
+        src = inspect.getsource(identity_score.score_video)
+        assert "mean_cos_start=float(np.mean(cs_start))" in src
+        assert "min_cos_start=float(np.min(cs_start))" in src


### PR DESCRIPTION
## The bug

The per-frame `series`, the `slope` and the `yaw_bands` all read the **segment's own start frame**, while the headline trajectory reads the **job's ground truth**.

On segment 0 those are the same image, so it never showed. On a continuation the own-start reference is the already-drifted last frame:

```
seg1 headline    0.851 -> 0.506      (vs ground truth)
seg1 series      starts ~0.95        (vs its own start frame)
```

Confirmed on real data — every seg1 series began near 0.95 against cumulative starts of 0.851–0.914. The graph and the numbers printed directly above it were measuring different things, and the panel could not show cumulative drift on any segment after the first.

## Change

`primary` now prefers `cs_ref`. Only `slope`, `yaw_bands` and `series` move — `mean_cos_start` and `min_cos_start` read `cs_start` directly and are deliberately unchanged, since they are explicitly the within-segment figures.

`metrics` gains:
- **`series_ref`** — names the reference actually used (`ground_truth` / `own_start`). Clips scored before this are all `own_start` and have no field, so a reader can tell them apart instead of assuming.
- **`series_own_start`** — keeps the within-segment view, which answers a different question and is what the dip detector wants.

## Tests

4 new (35 in file, 100 across the suite), including one pinning that `mean_cos_start`/`min_cos_start` did **not** silently become vs-truth.

## Deploy

Daemon change — needs a restart on the 3090.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct