### PR TITLE
Reword the clean-seed log line so it stops reading as re-anchor

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -917,7 +917,7 @@ async def execute_segment(
         # carry identity -- the next segment's own faceswap restores it on every output frame.
         last_frame_data = await _clean_seed_frame(history, comfyui)
         if last_frame_data is not None:
-            await progress.log("[7/7] Using pre-swap frame as continuation seed")
+            await progress.log("[7/7] Continuation seed taken BEFORE the faceswap (keeps face detail)")
         else:
             last_frame_data = await _extract_last_frame(video_data)
 


### PR DESCRIPTION
`[7/7] Using pre-swap frame as continuation seed` appears whenever **faceswap** is on — which is correct — but it reads as the seed **re-anchor** firing, so it prompted a "is this a bug?" on a job where re-anchor was off.

They're different features and the wording conflated them:

| | fires when | what it fixes |
|---|---|---|
| clean seed | faceswap is on at all | face DETAIL — takes the continuation frame from before the swap so the ~18% swap cost doesn't compound (233 → 79 across two segments before, 233 → 133 after) |
| seed re-anchor | opt-in `seed_faceswap` | IDENTITY — swaps the seed frame toward the character |

Now reads: `Continuation seed taken BEFORE the faceswap (keeps face detail)`.

100 tests pass. Needs a daemon restart, which is already queued behind #103.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct