### PR TITLE
Point at wanly-gpu-docker after the repo rename

### DIFF
--- a/daemon/model_validator.py
+++ b/daemon/model_validator.py
@@ -25,7 +25,7 @@ MIN_SIZES = {
 # Multiple subfolders because ComfyUI searches several dirs per model type
 # (e.g. CLIPLoader searches both clip/ and text_encoders/)
 #
-# One engine, one list: the native Wan 2.2 i2v path. Mirrors what wanly-runpod's
+# One engine, one list: the native Wan 2.2 i2v path. Mirrors what wanly-gpu-docker's
 # download_models.sh stages — a worker validates exactly what it was provisioned with.
 MODEL_CHECKS = [
     ("vae_model",           "VAELoader",            ["vae"],                    MIN_SIZES["vae"]),


### PR DESCRIPTION
`wanly-runpod` was renamed to `wanly-gpu-docker` — it is the GPU worker image now, not a RunPod-specific script.

GitHub redirects the old URL so nothing was broken, but leaving stale names in a clone command and a comment just costs someone a double-take later.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct