### PR TITLE
Default identity scoring to CPU — the GPU switch is not yet justified

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -49,11 +49,19 @@ class Settings(BaseSettings):
     painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion
     painter_motion_frames: int = 5  # Range: 1-20, controls motion cycle length
 
-    # Identity scoring. Scoring runs AFTER generation and BEFORE the next claim, so on a box
-    # where the daemon owns the card it can use the GPU freely — VRAM is back down to ~2GB by
-    # then. Set false on the 3090, which shares its card with A1111 and sd-scripts and may not
-    # have the headroom. Falls back to CPU on its own if the CUDA provider won't load.
-    identity_scoring_gpu: bool = True
+    # Identity scoring device. Defaults to CPU, which is what every recorded identity score to
+    # date was produced on.
+    #
+    # Moving it to GPU is issue #106 and is NOT yet justified: the measurement that motivated it
+    # (scoring = 23-29% of job time) did not reproduce — a later run scored 289 frames in 9s, and
+    # motion analysis, not scoring, dominated that phase. Worse, nobody has yet checked whether
+    # CUDA and CPU produce the SAME embeddings. If they differ, every score after the switch sits
+    # on a different scale from every score before it, and the recorded history stops being
+    # comparable — the same hazard the DET_SIZE comment warns about.
+    #
+    # So: opt in per worker, never on by default, until #106 measures both the speedup and the
+    # embedding agreement.
+    identity_scoring_gpu: bool = False
 
     # Motion matching (optical flow based)
     motion_matching_enabled: bool = True  # Enable automatic motion amplitude matching


### PR DESCRIPTION
The GPU option reached `main` by accident. I cut the drain-fix branch (#109) from an unmerged identity-scoring branch instead of from `main`, so a change belonging to #106 shipped under an unrelated title, **defaulting to on**.

It should not be on:

- **#106's motivating measurement did not reproduce.** A later run scored the same 289 frames in **9 seconds**, and motion analysis — not identity scoring — dominated that phase. I retracted the 23–29% figure on that issue.
- **Nobody has checked whether CUDA and CPU produce the same embeddings.** If they differ, every score recorded after the switch sits on a different scale from every score before it, and the identity history stops being comparable. `identity_score.py` already warns about exactly this hazard for `DET_SIZE`.

The option stays — it is useful and probably correct — but as opt-in per worker via `IDENTITY_SCORING_GPU=true`, until #106 measures both the speedup **and** the embedding agreement.

103 tests pass.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct