### PR TITLE
Drain terminates the pod, and waits long enough for the segment to finish

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -63,6 +63,15 @@ class Settings(BaseSettings):
     # embedding agreement.
     identity_scoring_gpu: bool = False
 
+    # How long a drain waits for the in-flight segment before giving up.
+    #
+    # Was 600s, which is shorter than the work: measured segments run 329s at 480p/3s, ~570s at
+    # 480p/5s and ~1780s at 720x1056/5s. A drain during a 720p segment hit the old timeout at
+    # the 10 minute mark and abandoned ~20 minutes of finished-but-unreported work. Now generous
+    # by default, because the cost of waiting too long is a slightly later shutdown, while the
+    # cost of not waiting long enough is a discarded segment.
+    drain_wait_seconds: int = 3600
+
     # Motion matching (optical flow based)
     motion_matching_enabled: bool = True  # Enable automatic motion amplitude matching
     motion_amplitude_default: float = 1.3  # Default motion_amplitude for segment 0

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -288,8 +288,11 @@ async def hologram_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutd
                 logger.error("Failed to report hologram failure: %s", report_err)
 
 
-async def _stop_runpod_pod() -> bool:
-    """Call RunPod API to stop this pod. Returns True if the pod was told to stop.
+async def _terminate_runpod_pod() -> bool:
+    """Terminate this pod. Returns True if RunPod accepted the termination.
+
+    Terminate, not stop. podStop leaves the pod EXITED and still billing for its disk; the
+    operator then has to notice and clean it up by hand. A drained worker should cost nothing.
 
     Missing credentials are logged loudly rather than ignored: this runs at the end of a
     drain, and if the pod does not actually stop the container respawns, the daemon
@@ -302,7 +305,7 @@ async def _stop_runpod_pod() -> bool:
     api_key = settings.runpod_api_key
     if not pod_id or not api_key:
         logger.warning(
-            "Drained, but cannot stop the pod: RUNPOD_POD_ID=%s, RUNPOD_API_KEY=%s. "
+            "Drained, but cannot terminate the pod: RUNPOD_POD_ID=%s, RUNPOD_API_KEY=%s. "
             "The container will respawn and this worker will start claiming work again. "
             "Set both as pod environment variables to make drain actually stop the pod.",
             "set" if pod_id else "MISSING",
@@ -310,22 +313,25 @@ async def _stop_runpod_pod() -> bool:
         )
         return False
 
-    logger.info("Stopping RunPod pod %s ...", pod_id)
-    query = f'mutation {{ podStop(input: {{podId: "{pod_id}"}}) {{ id desiredStatus }} }}'
+    logger.info("Terminating RunPod pod %s ...", pod_id)
     try:
         async with _httpx.AsyncClient(timeout=15) as client:
-            resp = await client.post(
-                f"https://api.runpod.io/graphql?api_key={api_key}",
-                json={"query": query},
+            resp = await client.delete(
+                f"https://rest.runpod.io/v1/pods/{pod_id}",
+                headers={"Authorization": f"Bearer {api_key}"},
             )
+            # 404 means it is already gone, which is the state we wanted.
+            if resp.status_code == 404:
+                logger.info("RunPod pod %s already gone", pod_id)
+                return True
             resp.raise_for_status()
-            logger.info("RunPod stop response: %s", resp.text)
+            logger.info("RunPod pod %s terminated", pod_id)
             return True
     except Exception as e:
         # A revoked API key lands here as a 401. That is not hypothetical: the key baked into
         # the pod template was revoked, every drain 401'd, and because the failure was silent
         # the worker simply carried on taking jobs. See wanly-console#286.
-        logger.error("Failed to stop RunPod pod: %s", e)
+        logger.error("Failed to terminate RunPod pod: %s", e)
     return False
 
 
@@ -470,15 +476,28 @@ async def run():
         await asyncio.gather(heartbeat_task, job_task, holo_task)
     finally:
         # Graceful shutdown: wait for current segment if executing
+        segment_abandoned = False
         if executing_event.is_set():
-            logger.info("Waiting for current segment to finish (up to 10 minutes)...")
+            # executing_event wraps the WHOLE of execute_segment, including the [7/7] upload —
+            # so clearing it means the segment is finished and reported, not merely that the GPU
+            # went quiet. That distinction matters: decode, RIFE, stitching, faceswap and
+            # identity scoring all run after the GPU idles, for 47s to over 2 minutes.
+            logger.info(
+                "Waiting for current segment to finish (up to %ds)...",
+                settings.drain_wait_seconds,
+            )
             try:
                 await asyncio.wait_for(
                     asyncio.create_task(_wait_for_clear(executing_event)),
-                    timeout=600,
+                    timeout=settings.drain_wait_seconds,
                 )
             except asyncio.TimeoutError:
-                logger.warning("Timed out waiting for segment, forcing shutdown")
+                segment_abandoned = True
+                logger.error(
+                    "Timed out after %ds waiting for the segment to finish. It is still "
+                    "running. NOT terminating the pod — that would destroy work in progress.",
+                    settings.drain_wait_seconds,
+                )
 
         # Stop the pod BEFORE deregistering, not after.
         #
@@ -488,11 +507,24 @@ async def run():
         # depends on. So if the pod does not actually stop, the container respawns, the daemon
         # registers fresh as online-idle, and goes straight back to claiming work. The drain is
         # silently undone, which is indistinguishable from the drain never having been requested.
-        stopped = False
+        terminated = False
         on_runpod = bool(settings.runpod_pod_id)
+        if drain_event.is_set() and on_runpod and segment_abandoned:
+            # Park rather than terminate. The segment is still running inside this container;
+            # destroying the pod now loses it outright.
+            logger.error(
+                "DRAIN INCOMPLETE: segment still running past the drain timeout. Staying "
+                "registered as 'draining' and NOT terminating. Raise DRAIN_WAIT_SECONDS if "
+                "segments legitimately take this long."
+            )
+            await queue.close()
+            await comfyui.close()
+            while True:
+                await asyncio.sleep(3600)
+
         if drain_event.is_set() and on_runpod:
-            stopped = await _stop_runpod_pod()
-            if not stopped:
+            terminated = await _terminate_runpod_pod()
+            if not terminated:
                 # Park. Do not deregister, do not exit.
                 #
                 # Exiting would respawn the container into the same failed drain, in a loop.
@@ -500,10 +532,10 @@ async def run():
                 # worker that is visibly not finishing — which is the honest picture — and the
                 # job poll loop has already stopped, so it claims nothing while parked.
                 logger.error(
-                    "DRAIN INCOMPLETE: the pod is still running and could not be stopped. "
+                    "DRAIN INCOMPLETE: the pod is still running and could not be terminated. "
                     "Staying registered as 'draining' so this worker does NOT resume claiming "
-                    "work. Stop the pod from the RunPod console, and check that RUNPOD_API_KEY "
-                    "is valid — a revoked key returns 401 here."
+                    "work. Terminate the pod from the RunPod console, and check RUNPOD_API_KEY "
+                    "— a revoked key returns 401 here."
                 )
                 await queue.close()
                 await comfyui.close()

--- a/tests/test_drain_terminate.py
+++ b/tests/test_drain_terminate.py
@@ -1,6 +1,6 @@
-"""Tests for _stop_runpod_pod's handling of missing RunPod credentials.
+"""Tests for _terminate_runpod_pod's handling of missing RunPod credentials.
 
-The regression this guards: _stop_runpod_pod returned silently when RUNPOD_POD_ID or
+The regression this guards: the terminate call returned silently when RUNPOD_POD_ID or
 RUNPOD_API_KEY was unset. That runs at the end of a drain — so the pod kept running, the
 container respawned, the daemon re-registered and resumed claiming work, and the log said
 nothing at all about why the drain appeared to do nothing.
@@ -26,7 +26,7 @@ class TestMissingCredentials:
         monkeypatch.setattr(main.settings, "runpod_pod_id", pod_id)
         monkeypatch.setattr(main.settings, "runpod_api_key", api_key)
         with caplog.at_level(logging.WARNING, logger=main.logger.name):
-            await main._stop_runpod_pod()
+            await main._terminate_runpod_pod()
         assert caplog.records, "missing credentials must not fail silently"
         msg = caplog.records[-1].getMessage()
         assert expect_missing in msg
@@ -36,14 +36,14 @@ class TestMissingCredentials:
         """It runs inside the shutdown finally-block; raising would mask the real path."""
         monkeypatch.setattr(main.settings, "runpod_pod_id", "")
         monkeypatch.setattr(main.settings, "runpod_api_key", "")
-        await main._stop_runpod_pod()  # must simply return
+        await main._terminate_runpod_pod()  # must simply return
 
     async def test_set_credentials_are_reported_as_set(self, monkeypatch, caplog):
         """Only the absent one is named — so the log points at the actual gap."""
         monkeypatch.setattr(main.settings, "runpod_pod_id", "pod123")
         monkeypatch.setattr(main.settings, "runpod_api_key", "")
         with caplog.at_level(logging.WARNING, logger=main.logger.name):
-            await main._stop_runpod_pod()
+            await main._terminate_runpod_pod()
         msg = caplog.records[-1].getMessage()
         assert "RUNPOD_POD_ID=set" in msg
         assert "RUNPOD_API_KEY=MISSING" in msg
@@ -59,7 +59,7 @@ class TestReturnValue:
     async def test_returns_false_when_credentials_missing(self, monkeypatch):
         monkeypatch.setattr(main.settings, "runpod_pod_id", "")
         monkeypatch.setattr(main.settings, "runpod_api_key", "")
-        assert await main._stop_runpod_pod() is False
+        assert await main._terminate_runpod_pod() is False
 
     async def test_returns_false_when_the_api_rejects_the_key(self, monkeypatch):
         """A revoked key 401s. That is what actually happened, and it must not read as success."""
@@ -70,6 +70,7 @@ class TestReturnValue:
 
         class _Resp:
             text = "unauthorized"
+            status_code = 401
 
             def raise_for_status(self):
                 raise httpx.HTTPStatusError(
@@ -84,11 +85,11 @@ class TestReturnValue:
             async def __aexit__(self, *a):
                 return False
 
-            async def post(self, *a, **k):
+            async def delete(self, *a, **k):
                 return _Resp()
 
         monkeypatch.setattr(httpx, "AsyncClient", lambda **k: _Client())
-        assert await main._stop_runpod_pod() is False
+        assert await main._terminate_runpod_pod() is False
 
     async def test_returns_true_on_success(self, monkeypatch):
         import httpx
@@ -97,7 +98,8 @@ class TestReturnValue:
         monkeypatch.setattr(main.settings, "runpod_api_key", "goodkey")
 
         class _Resp:
-            text = '{"data":{"podStop":{"id":"pod123"}}}'
+            text = ""
+            status_code = 204
 
             def raise_for_status(self):
                 return None
@@ -109,8 +111,38 @@ class TestReturnValue:
             async def __aexit__(self, *a):
                 return False
 
-            async def post(self, *a, **k):
+            async def delete(self, *a, **k):
                 return _Resp()
 
         monkeypatch.setattr(httpx, "AsyncClient", lambda **k: _Client())
-        assert await main._stop_runpod_pod() is True
+        assert await main._terminate_runpod_pod() is True
+
+
+class TestDrainWaitWindow:
+    """The drain must outlast a real segment.
+
+    The old timeout was 600s. Measured segment durations on the same worker:
+
+        480p / 3s  ->  329s
+        480p / 5s  ->  566s, 575s
+        720x1056/5s -> 1774s, 1787s
+
+    So a drain issued during a 720p segment gave up at the 10 minute mark and abandoned roughly
+    twenty more minutes of work that was about to finish. With terminate rather than stop, that
+    stops being wasted time and becomes a destroyed pod with the segment still inside it.
+    """
+
+    def test_default_outlasts_the_longest_measured_segment(self):
+        from daemon.config import Settings
+
+        longest_measured = 1787.4
+        assert Settings().drain_wait_seconds > longest_measured, (
+            "the drain wait must exceed a real 720p segment, or draining discards finished work"
+        )
+
+    def test_is_configurable_per_worker(self, monkeypatch):
+        """Bigger shapes will take longer than anything measured so far."""
+        monkeypatch.setenv("DRAIN_WAIT_SECONDS", "7200")
+        from daemon.config import Settings
+
+        assert Settings().drain_wait_seconds == 7200


### PR DESCRIPTION
Closes #110, and completes the launcher work in wanly-console#288.

### 1. Terminate, not stop

`podStop` left the pod `EXITED` and still billing for its disk — a drained worker kept costing money until someone noticed. Now `DELETE /v1/pods/{id}` via REST with a Bearer header, the same call verified working against the current API.

### 2. The drain wait was shorter than the work — this is the real bug

It was **600s**. Measured segment durations on one worker today:

| shape | duration |
|---|---|
| 480p / 3s | 329s |
| 480p / 5s | 566s, 575s |
| **720x1056 / 5s** | **1774s, 1787s** |

A drain during a 720p segment gave up at the 10 minute mark and abandoned ~20 more minutes of nearly-finished work. Wasteful with `podStop`; with terminate it **destroys the pod with the segment still inside it**.

Default is now 3600s, configurable via `DRAIN_WAIT_SECONDS`. **On timeout the daemon explicitly does not terminate** — it parks, stays registered as `draining`, claims nothing, and says why.

### A correction worth recording

I previously argued terminate was dangerous because it might key off GPU/VRAM idle. That was wrong about this code: `executing_event` wraps the whole of `execute_segment` **including the [7/7] upload**, so waiting for it to clear means the segment is finished and reported, not that the GPU went quiet. The real hazard was always the timeout, not the signal.

### Tests

105 pass. Verified the new timeout test **fails** against the old 600s default.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct