### PR TITLE
Stop writing presigned S3 URLs into the log and into tracebacks

### DIFF
--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -11,14 +11,37 @@ from daemon.schemas import SegmentClaim, SegmentResult
 logger = logging.getLogger(__name__)
 
 
+def _redact_url(url) -> str:
+    """Host and path only — never the query string.
+
+    Presigned S3 URLs carry AWSAccessKeyId, Signature and x-amz-security-token in the query.
+    They are short-lived, but daemon.log is bind-mounted to the host and gets pasted into
+    tickets, so they must not be written there at all.
+    """
+    try:
+        return f"{url.scheme}://{url.host}{url.path}"
+    except Exception:
+        return "<url unavailable>"
+
+
 def _raise_with_details(resp: httpx.Response, context: str) -> None:
-    """Log HTTP error details before raising."""
+    """Log HTTP error details before raising, without leaking a signed URL.
+
+    httpx builds raise_for_status()'s message from resp.url. After follow_redirects that is the
+    presigned S3 URL, so the default exception put the full credential set into the log and into
+    every traceback. The message is rebuilt here instead. See #112.
+    """
     try:
         body = resp.text[:500]
     except Exception:
         body = "<unreadable>"
-    logger.error("%s — HTTP %d: %s", context, resp.status_code, body)
-    resp.raise_for_status()
+    where = _redact_url(resp.url)
+    logger.error("%s — HTTP %d for %s: %s", context, resp.status_code, where, body)
+    raise httpx.HTTPStatusError(
+        f"{context} — HTTP {resp.status_code} for {where}",
+        request=resp.request,
+        response=resp,
+    )
 
 
 class QueueClient:

--- a/tests/test_url_redaction.py
+++ b/tests/test_url_redaction.py
@@ -1,0 +1,60 @@
+"""The daemon must never write a presigned S3 URL to its log (#112).
+
+Real incident: a segment failed on a 404 and the traceback put AWSAccessKeyId, Signature and
+x-amz-security-token into daemon.log — which is bind-mounted to the host and gets pasted into
+tickets. The copy in wanly-api#156 had to be handled carefully before it could be quoted.
+"""
+
+import logging
+
+import httpx
+import pytest
+
+from daemon.queue_client import _raise_with_details, _redact_url
+
+# Shape of the real thing, credentials shortened.
+PRESIGNED = (
+    "https://wanly-images.s3.amazonaws.com/2026-07-09/00054-1151936895-swapped.png"
+    "?AWSAccessKeyId=ASIA3QP5JFGTUPQDM4GR&Signature=O1tbz32YO7Qr9sDzbm16KhfAOaU%3D"
+    "&x-amz-security-token=IQoJb3JpZ2luX2VjEI7SECRETTOKENVALUE&Expires=1786145348"
+)
+SECRETS = ("AWSAccessKeyId", "Signature=", "x-amz-security-token", "SECRETTOKENVALUE")
+
+
+def _response(status=404):
+    request = httpx.Request("GET", PRESIGNED)
+    return httpx.Response(status, text="<Error><Code>NoSuchKey</Code></Error>", request=request)
+
+
+class TestRedaction:
+    def test_keeps_the_useful_part(self):
+        out = _redact_url(httpx.URL(PRESIGNED))
+        assert out == "https://wanly-images.s3.amazonaws.com/2026-07-09/00054-1151936895-swapped.png"
+
+    def test_drops_every_credential(self):
+        out = _redact_url(httpx.URL(PRESIGNED))
+        for secret in SECRETS:
+            assert secret not in out
+
+    def test_nothing_secret_reaches_the_log(self, caplog):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(httpx.HTTPStatusError):
+                _raise_with_details(_response(), "download_file s3://wanly-images/x.png")
+        logged = "\n".join(r.getMessage() for r in caplog.records)
+        for secret in SECRETS:
+            assert secret not in logged, f"{secret} leaked into the log"
+        # and it still says what failed
+        assert "404" in logged and "wanly-images" in logged
+
+    def test_nothing_secret_reaches_the_exception_message(self):
+        """The traceback is the copy that ends up pasted into tickets."""
+        with pytest.raises(httpx.HTTPStatusError) as exc:
+            _raise_with_details(_response(), "download_file s3://wanly-images/x.png")
+        message = str(exc.value)
+        for secret in SECRETS:
+            assert secret not in message, f"{secret} leaked into the exception"
+        assert "404" in message
+
+    def test_still_raises_httpstatuserror_so_callers_are_unaffected(self):
+        with pytest.raises(httpx.HTTPStatusError):
+            _raise_with_details(_response(500), "upload_segment_output abc")


### PR DESCRIPTION
Closes #112.

httpx builds `raise_for_status()`'s message from `resp.url`. After `follow_redirects` that is the **presigned S3 URL**, so a failed download wrote `AWSAccessKeyId`, `Signature` and `x-amz-security-token` into `daemon.log` and into every traceback derived from it.

Not theoretical — a segment failed on a 404 today and the credentials landed in a log that is bind-mounted to the host. The copy quoted in wanly-api#156 had to be handled carefully before it could be pasted anywhere.

The message is now rebuilt from the status code plus a host+path-only URL. The query string was never the useful part:

```
before: ... for url 'https://wanly-images.s3.amazonaws.com/...png?AWSAccessKeyId=ASIA...&Signature=...&x-amz-security-token=IQoJb3JpZ2luX2VjEI7...' (600+ chars)
after:  download_file s3://wanly-images/... — HTTP 404 for https://wanly-images.s3.amazonaws.com/2026-07-09/00054-1151936895-swapped.png
```

Still raises `httpx.HTTPStatusError`, so callers are unaffected.

### Tests

5 new, asserting no credential reaches **either** the log or the exception message — the traceback is the copy that ends up in tickets. **116 pass.** Verified the exception-message test fails when `raise_for_status()` is restored.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct