### PR TITLE
Scrub a real AWS key id out of the redaction test

### DIFF
--- a/tests/test_url_redaction.py
+++ b/tests/test_url_redaction.py
@@ -12,13 +12,23 @@ import pytest
 
 from daemon.queue_client import _raise_with_details, _redact_url
 
-# Shape of the real thing, credentials shortened.
+# Structurally identical to a real presigned URL, with entirely invented values.
+#
+# The first version of this file pasted the shape from an actual failure and left a real
+# STS access key id in it, which GitHub secret scanning flagged — a test about not writing
+# credentials down, writing a credential down. The placeholders below are deliberately not
+# valid-looking: no ASIA/AKIA prefix, nothing that resembles a real signature.
 PRESIGNED = (
     "https://wanly-images.s3.amazonaws.com/2026-07-09/00054-1151936895-swapped.png"
-    "?AWSAccessKeyId=ASIA3QP5JFGTUPQDM4GR&Signature=O1tbz32YO7Qr9sDzbm16KhfAOaU%3D"
-    "&x-amz-security-token=IQoJb3JpZ2luX2VjEI7SECRETTOKENVALUE&Expires=1786145348"
+    "?AWSAccessKeyId=EXAMPLEKEYIDNOTREAL0&Signature=EXAMPLESIGNATUREVALUE%3D"
+    "&x-amz-security-token=EXAMPLESECURITYTOKENVALUE&Expires=1786145348"
 )
-SECRETS = ("AWSAccessKeyId", "Signature=", "x-amz-security-token", "SECRETTOKENVALUE")
+SECRETS = (
+    "AWSAccessKeyId",
+    "Signature=",
+    "x-amz-security-token",
+    "EXAMPLESECURITYTOKENVALUE",
+)
 
 
 def _response(status=404):


### PR DESCRIPTION
GitHub secret scanning alert on `tests/test_url_redaction.py#L18`, commit `daab303`.

My mistake, and an ironic one: the first version of that file pasted the shape of an actual failing presigned URL and left a **real STS access key id** in it — a test asserting that credentials are never written down, writing a credential down.

Replaced with invented values that are deliberately not valid-looking (no `ASIA`/`AKIA` prefix, nothing resembling a real signature), so scanning has nothing to match and a future reader is not tempted to paste a real one back in.

### Exposure assessment

- The value was a **temporary STS access key id** from a presigned URL with `Expires=1786145348`, which has passed.
- A key id alone is not usable — it needs the signature and session token, and those in the committed text were already partly placeholder.
- **It remains in git history** on this branch's parent commit. Removing it entirely needs a history rewrite; given it is an expired temporary credential, that may not be worth it — David's call.
- Worth rotating the underlying role credentials if that role is long-lived.

5 tests still pass.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct