### PR TITLE
Run post-sampling analysis off the event loop so the heartbeat keeps beating

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -720,7 +720,18 @@ async def _score_segment_identity(
             except Exception as e:
                 logger.info("identity: could not fetch ground truth (%s)", e)
 
-        score, reason = identity_score.score_video(video_data, start_bytes, ref_bytes)
+        # insightface detection + recognition over every frame: 9s at 480p, but 126s on a 720p
+        # segment and 3m43s on one continuation. Run inline it blocked the daemon's event loop
+        # for that whole time, which stopped the heartbeat — and the API marks a worker offline
+        # after 120s of silence.
+        #
+        # That was not merely cosmetic. The offline sweep overwrites a `draining` status, so a
+        # pending drain was silently lost; and the stale-claim reaper's premise is explicitly
+        # "a healthy worker mid-render is still heartbeating", which stopped being true, putting
+        # a still-running segment at risk of being reclaimed by another worker.
+        score, reason = await asyncio.to_thread(
+            identity_score.score_video, video_data, start_bytes, ref_bytes
+        )
         if score is None:
             await progress.log(f"[7/7] Identity: not scored ({reason})")
             logger.info("Identity not scored for segment %d: %s", segment.index, reason)
@@ -928,8 +939,9 @@ async def execute_segment(
                 segment, last_frame_data, comfyui, queue, progress,
             )
 
-        # Measure motion magnitude using optical flow
-        motion_magnitude = measure_motion_magnitude(video_data)
+        # Optical flow over every frame — synchronous OpenCV, ~38s measured at 289 frames.
+        # Off the event loop, or the heartbeat stops for its duration (see below).
+        motion_magnitude = await asyncio.to_thread(measure_motion_magnitude, video_data)
         if motion_magnitude:
             await progress.log(f"[7/7] Motion magnitude: {motion_magnitude:.2f} px/frame")
 

--- a/tests/test_event_loop_not_blocked.py
+++ b/tests/test_event_loop_not_blocked.py
@@ -1,0 +1,56 @@
+"""The post-sampling analysis must not block the daemon's event loop.
+
+Reported live: a RunPod worker showed `offline` on the Workers page while it was plainly still
+working a segment. Its last heartbeat was 240s old; the pod was RUNNING.
+
+Cause: motion analysis (OpenCV optical flow, ~38s measured) and identity scoring (insightface
+over 289 frames — 9s at 480p, 126s at 720p, 3m43s on one continuation) both ran inline on the
+event loop. While they ran, nothing else on that loop could — including the 30s heartbeat.
+
+Three consequences, in increasing severity:
+
+  1. The worker reads as offline while working. Confusing.
+  2. The API's offline sweep overwrites a `draining` status, so a pending drain is silently
+     lost and the worker resumes claiming once heartbeats resume.
+  3. The stale-claim reaper is documented as safe because "a healthy worker mid-render is still
+     heartbeating". That premise was false, so a segment still being finished could be reclaimed
+     by another worker.
+"""
+
+import ast
+import inspect
+from pathlib import Path
+
+from daemon import executor
+
+BLOCKING_CALLS = ["measure_motion_magnitude", "identity_score.score_video"]
+
+
+def _executor_source() -> str:
+    return Path(inspect.getfile(executor)).read_text()
+
+
+class TestOffloaded:
+    def test_heavy_analysis_runs_in_a_thread(self):
+        src = _executor_source()
+        for call in BLOCKING_CALLS:
+            # The call must appear as an argument to to_thread, never invoked directly.
+            assert f"asyncio.to_thread(\n            {call}" in src or f"asyncio.to_thread({call}" in src, (
+                f"{call} must be offloaded with asyncio.to_thread — inline it blocks the "
+                f"heartbeat for its whole duration"
+            )
+
+    def test_no_direct_invocation_remains(self):
+        """A leftover direct call would reintroduce the stall even with a threaded one present."""
+        tree = ast.parse(_executor_source())
+        offenders = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            name = ast.unparse(node.func)
+            if name not in BLOCKING_CALLS:
+                continue
+            # Fine when it is the *argument* to to_thread (that is a Name/Attribute, not a Call),
+            # so any Call node with these names is a direct invocation.
+            offenders.append(name)
+        assert not offenders, f"called directly on the event loop: {offenders}"


### PR DESCRIPTION
A RunPod worker showed **offline** while plainly still working a segment — last heartbeat 240s old, pod RUNNING, job progressing.

### Cause

Motion analysis (OpenCV optical flow, ~38s over 289 frames) and identity scoring (insightface — **9s at 480p, 126s at 720p, 3m43s** on one continuation) both ran **inline on the event loop**. While they ran, nothing else on that loop could — including the 30s heartbeat. The API marks a worker offline after **120s** of silence, so any 720p segment reliably crossed that line.

### Not cosmetic — three consequences, increasing in severity

1. The worker reads as offline while working.
2. **The offline sweep overwrites `draining`.** A pending drain was silently lost: `heartbeat()` sets `online-idle` when it sees the worker was offline, so it resumed claiming. Third instance of that bug class today, in a third place.
3. **The stale-claim reaper's stated premise was false.** Its comment justifies the 5-minute rule with *"a healthy worker mid-render is still heartbeating"*. It was not. A segment still being finished could be reclaimed by another worker — and 3m43s scoring + 38s motion + decode was not far off the limit.

### Fix

Both now run via `asyncio.to_thread` — which is what the hologram path already does, for exactly this reason. That **restores** the reaper's premise rather than working around it.

### Tests

An AST guard that fails on any direct invocation, so a future inline call is caught even if a threaded one exists alongside it. **118 pass.** Verified it fails when either call is put back inline.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct
