### PR TITLE
A pod cannot terminate itself over REST — go back to GraphQL

### DIFF
--- a/daemon/main.py
+++ b/daemon/main.py
@@ -314,17 +314,35 @@ async def _terminate_runpod_pod() -> bool:
         return False
 
     logger.info("Terminating RunPod pod %s ...", pod_id)
+
+    # GraphQL podTerminate, not REST DELETE /v1/pods/{id}.
+    #
+    # A pod cannot delete ITSELF through the REST API — the identical key, on the identical
+    # endpoint, returns 403 from inside the container and 204 from outside it. This was found in
+    # production: a drain finished its segment, tried to terminate, got 403, and parked.
+    #
+    # The GraphQL mutation has no such restriction, which is why the earlier podStop worked from
+    # inside. podTerminate gives the terminate semantics we want; podStop only stopped the pod
+    # and left it billing for disk.
+    query = f'mutation {{ podTerminate(input: {{podId: "{pod_id}"}}) }}'
     try:
         async with _httpx.AsyncClient(timeout=15) as client:
-            resp = await client.delete(
-                f"https://rest.runpod.io/v1/pods/{pod_id}",
-                headers={"Authorization": f"Bearer {api_key}"},
+            resp = await client.post(
+                f"https://api.runpod.io/graphql?api_key={api_key}",
+                json={"query": query},
             )
-            # 404 means it is already gone, which is the state we wanted.
-            if resp.status_code == 404:
+            resp.raise_for_status()
+            body = resp.json()
+            errors = body.get("errors") or []
+            # POD_NOT_FOUND means it is already gone, which is the state we wanted.
+            if errors and all(
+                (e.get("extensions") or {}).get("code") == "POD_NOT_FOUND" for e in errors
+            ):
                 logger.info("RunPod pod %s already gone", pod_id)
                 return True
-            resp.raise_for_status()
+            if errors:
+                logger.error("RunPod refused to terminate %s: %s", pod_id, errors)
+                return False
             logger.info("RunPod pod %s terminated", pod_id)
             return True
     except Exception as e:

--- a/tests/test_drain_terminate.py
+++ b/tests/test_drain_terminate.py
@@ -49,6 +49,39 @@ class TestMissingCredentials:
         assert "RUNPOD_API_KEY=MISSING" in msg
 
 
+class TestUsesGraphQLNotRest:
+    """A pod cannot terminate ITSELF through the REST API.
+
+    Found in production: a drain finished its segment, called
+    DELETE /v1/pods/{id}, and got 403 Forbidden. The identical key on the identical endpoint
+    returns 204 when called from outside the pod — so it is not a permissions problem with the
+    key, it is a restriction on self-deletion.
+
+    GraphQL has no such restriction, which is why the earlier podStop worked from inside.
+    podTerminate keeps that property while giving terminate rather than stop semantics.
+    """
+
+    def test_terminate_calls_graphql(self):
+        import inspect
+
+        src = inspect.getsource(main._terminate_runpod_pod)
+        assert "podTerminate" in src, "must use the GraphQL mutation"
+        assert "api.runpod.io/graphql" in src
+        assert "rest.runpod.io" not in src, (
+            "REST DELETE returns 403 when a pod tries to terminate itself"
+        )
+
+    def test_does_not_use_podstop(self):
+        """podStop leaves the pod EXITED and still billing for its disk.
+
+        Matches the mutation call, not the bare word — the comment above it explains why podStop
+        used to work, and a test should not be broken by its own explanation.
+        """
+        import inspect
+
+        assert "podStop(input:" not in inspect.getsource(main._terminate_runpod_pod)
+
+
 class TestReturnValue:
     """The caller now decides whether to deregister based on this, so it has to be honest.
 
@@ -69,14 +102,17 @@ class TestReturnValue:
         monkeypatch.setattr(main.settings, "runpod_api_key", "revoked")
 
         class _Resp:
-            text = "unauthorized"
-            status_code = 401
+            text = "forbidden"
+            status_code = 403
 
             def raise_for_status(self):
                 raise httpx.HTTPStatusError(
-                    "401 Unauthorized", request=httpx.Request("POST", "http://x"),
-                    response=httpx.Response(401),
+                    "403 Forbidden", request=httpx.Request("POST", "http://x"),
+                    response=httpx.Response(403),
                 )
+
+            def json(self):
+                return {}
 
         class _Client:
             async def __aenter__(self):
@@ -85,7 +121,7 @@ class TestReturnValue:
             async def __aexit__(self, *a):
                 return False
 
-            async def delete(self, *a, **k):
+            async def post(self, *a, **k):
                 return _Resp()
 
         monkeypatch.setattr(httpx, "AsyncClient", lambda **k: _Client())
@@ -98,11 +134,14 @@ class TestReturnValue:
         monkeypatch.setattr(main.settings, "runpod_api_key", "goodkey")
 
         class _Resp:
-            text = ""
-            status_code = 204
+            text = '{"data":{"podTerminate":null}}'
+            status_code = 200
 
             def raise_for_status(self):
                 return None
+
+            def json(self):
+                return {"data": {"podTerminate": None}}
 
         class _Client:
             async def __aenter__(self):
@@ -111,7 +150,7 @@ class TestReturnValue:
             async def __aexit__(self, *a):
                 return False
 
-            async def delete(self, *a, **k):
+            async def post(self, *a, **k):
                 return _Resp()
 
         monkeypatch.setattr(httpx, "AsyncClient", lambda **k: _Client())


### PR DESCRIPTION
Fixes a regression I shipped in #113.

That PR switched self-termination from GraphQL `podStop` to `DELETE /v1/pods/{id}`, on the grounds that REST is the current API and `podStop` only *stopped* the pod rather than terminating it. **The terminate semantics were right. The transport was not.**

### Caught in production tonight

```
03:00:12  Drain active — segment finished, shutting down
03:00:12  Terminating RunPod pod am1jpuqdjm4m18 ...
03:00:13  ERROR Failed to terminate RunPod pod: Client error '403 Forbidden'
03:00:13  ERROR DRAIN INCOMPLETE: the pod is still running and could not be terminated.
```

**Not a permissions problem.** The identical key, on the identical endpoint, against the identical pod:

| called from | result |
|---|---|
| inside the container | **403 Forbidden** |
| outside (my laptop) | **204** |

RunPod does not allow a pod to delete itself over REST. GraphQL has no such restriction — which is why `podStop` worked from inside all along, and why this afternoon's drain-proof run succeeded. `podTerminate` keeps that property *and* gives terminate semantics, so the pod stops billing for its disk.

### What I got wrong

I did verify the key against REST DELETE before shipping #113 — **from my laptop**, which is exactly the context that works. The environment the call actually runs in was the one thing not tested.

### What worked

The park-on-failure path from #113 did its job: the worker stayed registered as `draining`, claimed nothing further, and said precisely what was wrong. That turned a potential mystery into one log line. The api#163 fix also held — the worker was still `draining` after 450s of silence rather than being swept to `offline`.

### Tests

Pin the transport with the reason, matching the mutation call rather than the bare word so the comment explaining `podStop` does not break its own test. **120 pass**; verified the guard fails when REST is restored.
