### PR TITLE
Report the RunPod pod id when registering

### DIFF
--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -202,14 +202,22 @@ class QueueClient:
         ip_address: str,
         comfyui_running: bool,
     ) -> tuple[uuid.UUID, str]:
+        # The pod id is how the console pairs this worker with the RunPod pod behind it.
+        # Pairing on name only worked for pods the console launcher created; a pod started from
+        # the template has an auto-generated name and showed as "Starting" forever beside the
+        # worker it had already become. Empty on anything self-hosted.
+        payload = {
+            "friendly_name": friendly_name,
+            "hostname": hostname,
+            "ip_address": ip_address,
+            "comfyui_running": comfyui_running,
+        }
+        if settings.runpod_pod_id:
+            payload["runpod_pod_id"] = settings.runpod_pod_id
+
         resp = await self.client.post(
             "/workers",
-            json={
-                "friendly_name": friendly_name,
-                "hostname": hostname,
-                "ip_address": ip_address,
-                "comfyui_running": comfyui_running,
-            },
+            json=payload,
         )
         if not resp.is_success:
             _raise_with_details(resp, "register")

--- a/tests/test_poll_retry.py
+++ b/tests/test_poll_retry.py
@@ -82,3 +82,54 @@ class TestKeepaliveExpiry:
             "keepalive_expiry must sit below the far end's idle timeout, or reaped connections "
             "keep being handed out"
         )
+
+
+class TestRegistrationReportsPodId:
+    """The console pairs a pod with its worker by pod id (wanly-console#291 follow-up).
+
+    Pairing on name only worked for pods the console launcher created. A pod started from the
+    RunPod template has an auto-generated name while its worker registers as runpod-<pod id>,
+    so the two never matched and the pod showed as "Starting" forever.
+    """
+
+    async def test_pod_id_is_sent_when_running_on_runpod(self, monkeypatch):
+        from daemon.config import settings
+
+        monkeypatch.setattr(settings, "runpod_pod_id", "pod-xyz")
+        sent = {}
+
+        class _Client:
+            async def post(self, url, json=None, **kw):
+                sent.update(json or {})
+                return httpx.Response(
+                    201, json={"id": "00000000-0000-0000-0000-000000000001",
+                               "friendly_name": "w"},
+                    request=httpx.Request("POST", "http://x"),
+                )
+
+        client = QueueClient()
+        client.client = _Client()
+        await client.register("w", "h", "127.0.0.1", True)
+        assert sent.get("runpod_pod_id") == "pod-xyz"
+
+    async def test_omitted_when_self_hosted(self, monkeypatch):
+        """The 3090 is not a pod. Sending an empty string would create a worker that looks like
+        it belongs to a pod called "" and never pairs with anything."""
+        from daemon.config import settings
+
+        monkeypatch.setattr(settings, "runpod_pod_id", None)
+        sent = {}
+
+        class _Client:
+            async def post(self, url, json=None, **kw):
+                sent.update(json or {})
+                return httpx.Response(
+                    201, json={"id": "00000000-0000-0000-0000-000000000001",
+                               "friendly_name": "w"},
+                    request=httpx.Request("POST", "http://x"),
+                )
+
+        client = QueueClient()
+        client.client = _Client()
+        await client.register("w", "h", "127.0.0.1", True)
+        assert "runpod_pod_id" not in sent


### PR DESCRIPTION
Pairs with wanly-api#167.

The console pairs a RunPod pod with its worker so a booting pod shows as **Starting** and stops showing once the worker appears. That pairing was done on name, which only holds for pods the console launcher created.

A pod started from the **RunPod template** gets an auto-generated name while its worker registers as `runpod-<pod id>` — so the two never matched and the pod showed as Starting indefinitely beside the worker it had already become.

The daemon already reads `RUNPOD_POD_ID` for self-termination, so this is just sending what it knows.

**Omitted entirely when not on RunPod** — sending an empty string would create a worker that looks like it belongs to a pod named `""` and pairs with nothing. Both cases are tested.

120 tests pass.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct