### PR TITLE
Persist per-frame series for motion, expression and detail

### DIFF
--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -30,7 +30,7 @@ from PIL import Image
 from daemon.comfyui_client import ComfyUIClient, ComfyUIExecutionError
 from daemon.lora_sync import ensure_loras_available
 from daemon.motion_extractor import _augment_prompt_with_motion, extract_motion_keywords
-from daemon.motion_analyzer import measure_motion_magnitude
+from daemon.motion_analyzer import measure_motion_series
 from daemon import identity_score
 from daemon.progress import ProgressLog
 from daemon.queue_client import QueueClient
@@ -941,7 +941,9 @@ async def execute_segment(
 
         # Optical flow over every frame — synchronous OpenCV, ~38s measured at 289 frames.
         # Off the event loop, or the heartbeat stops for its duration (see below).
-        motion_magnitude = await asyncio.to_thread(measure_motion_magnitude, video_data)
+        motion_magnitude, motion_series = await asyncio.to_thread(
+            measure_motion_series, video_data
+        )
         if motion_magnitude:
             await progress.log(f"[7/7] Motion magnitude: {motion_magnitude:.2f} px/frame")
 
@@ -954,6 +956,13 @@ async def execute_segment(
         identity_fields = await _score_segment_identity(
             segment, video_data, queue, progress,
         )
+
+        # Motion is measured separately from the face metrics, so its series is merged in here
+        # rather than at the source. All four then live in one blob and the chart can read them
+        # together without the console knowing which subsystem produced which.
+        metrics = identity_fields.get("identity_metrics")
+        if isinstance(metrics, dict) and motion_series:
+            metrics["series_motion"] = motion_series
 
         segment_result = SegmentResult(
             status="completed",

--- a/daemon/identity_score.py
+++ b/daemon/identity_score.py
@@ -313,7 +313,8 @@ def score_video(
                 w = max(1.0, float(x2 - x1))
                 h = max(1.0, float(y2 - y1))
                 inner = np.asarray(lmk[33:], dtype=np.float64)
-                lmk_series.append(np.stack([(inner[:, 0] - x1) / w, (inner[:, 1] - y1) / h], axis=1))
+                norm = np.stack([(inner[:, 0] - x1) / w, (inner[:, 1] - y1) / h], axis=1)
+                lmk_series.append(norm)
 
             idx += 1
         cap.release()
@@ -370,6 +371,12 @@ def score_video(
                 # persisted as JSON, so this needs no migration and no API change.
                 "face_sharp_mean": round(float(np.mean(sharps)), 1) if sharps else None,
                 "expression": _expression_std(lmk_series),
+                # Per-frame series for the trajectory chart. The headline numbers say where a
+                # clip ended up; these say how it got there — and a mean hides shape. A face
+                # that animates once and then freezes averages the same as one that stays alive
+                # throughout, and those are not the same take.
+                "series_detail": _downsample(sharps),
+                "series_expression": _expression_series(lmk_series),
                 "face_sharp_start": round(float(np.mean(sharps[:3])), 1) if len(sharps) >= 3 else None,
                 "face_sharp_end": round(float(np.mean(sharps[-3:])), 1) if len(sharps) >= 3 else None,
                 "yaw_bands": bands,
@@ -396,6 +403,35 @@ def score_video(
                 os.unlink(tmp)
             except OSError:
                 pass
+
+
+def _downsample(values: list, cap: int = 600) -> list:
+    """Evenly spaced sample, so a long clip keeps its shape rather than only its opening."""
+    vals = [v for v in values if v is not None]
+    if not vals:
+        return []
+    if len(vals) <= cap:
+        return [round(float(v), 3) for v in vals]
+    step = len(vals) / cap
+    return [round(float(vals[int(i * step)]), 3) for i in range(cap)]
+
+
+def _expression_series(lmk_series: list) -> list:
+    """Per-frame facial movement: how far the landmarks shifted since the previous frame.
+
+    Deliberately a different quantity from the headline `expression`, which is the deviation
+    over the whole clip. This one answers "is the face alive right now", so it can be read
+    against identity and motion on the same time axis — a dead patch in the middle is visible
+    here and invisible in either aggregate.
+    """
+    if len(lmk_series) < 2:
+        return []
+    try:
+        arr = np.stack(lmk_series)
+        deltas = np.linalg.norm(np.diff(arr, axis=0), axis=2).mean(axis=1) * 1000
+        return _downsample(list(deltas))
+    except Exception:
+        return []
 
 
 def _expression_std(lmk_series: list) -> Optional[float]:

--- a/daemon/motion_analyzer.py
+++ b/daemon/motion_analyzer.py
@@ -15,7 +15,36 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
+def _downsample(values: list[float], cap: int = 600) -> list[float]:
+    """Evenly spaced sample, so a long clip keeps its SHAPE rather than its first 600 frames.
+
+    Truncating would silently plot only the opening of a long segment, which is worse than
+    plotting a coarser version of the whole thing.
+    """
+    if len(values) <= cap:
+        return [round(float(v), 4) for v in values]
+    step = len(values) / cap
+    return [round(float(values[int(i * step)]), 4) for i in range(cap)]
+
+
+def measure_motion_series(video_data: bytes, fps: int = 15) -> tuple[Optional[float], list[float]]:
+    """Mean optical flow magnitude AND the per-frame series behind it.
+
+    The series was always computed and then discarded. Keeping it lets motion be plotted beside
+    identity, expression and detail on one chart — which matters because the mean hides shape:
+    a clip that surges once and then freezes averages the same as one that moves steadily, and
+    those are not the same clip.
+    """
+    mean, series = _measure(video_data, fps)
+    return mean, series
+
+
 def measure_motion_magnitude(video_data: bytes, fps: int = 15) -> Optional[float]:
+    """Mean only. Kept so existing callers are unaffected."""
+    return _measure(video_data, fps)[0]
+
+
+def _measure(video_data: bytes, fps: int = 15) -> tuple[Optional[float], list[float]]:
     """Measure average optical flow magnitude in a video.
 
     Uses Farneback algorithm to compute dense optical flow between consecutive frames,
@@ -36,19 +65,19 @@ def measure_motion_magnitude(video_data: bytes, fps: int = 15) -> Optional[float
         cap = cv2.VideoCapture(tmp_video_path)
         if not cap.isOpened():
             logger.warning("Could not open video for motion analysis")
-            return None
+            return None, []
 
         frame_count = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
         if frame_count < 2:
             logger.warning("Video has fewer than 2 frames, cannot measure motion")
-            return None
+            return None, []
 
         magnitudes: list[float] = []
 
         ret, prev_frame = cap.read()
         if not ret:
             logger.warning("Could not read first frame")
-            return None
+            return None, []
 
         prev_gray = cv2.cvtColor(prev_frame, cv2.COLOR_BGR2GRAY)
 
@@ -87,14 +116,14 @@ def measure_motion_magnitude(video_data: bytes, fps: int = 15) -> Optional[float
                 avg_motion,
                 len(magnitudes),
             )
-            return avg_motion
+            return avg_motion, _downsample(magnitudes)
 
         logger.warning("No motion data extracted from video")
-        return None
+        return None, []
 
     except Exception as e:
         logger.warning("Motion analysis failed: %s", e)
-        return None
+        return None, []
     finally:
         try:
             os.unlink(tmp_video_path)

--- a/tests/test_event_loop_not_blocked.py
+++ b/tests/test_event_loop_not_blocked.py
@@ -23,7 +23,7 @@ from pathlib import Path
 
 from daemon import executor
 
-BLOCKING_CALLS = ["measure_motion_magnitude", "identity_score.score_video"]
+BLOCKING_CALLS = ["measure_motion_series", "identity_score.score_video"]
 
 
 def _executor_source() -> str:

--- a/tests/test_identity_score.py
+++ b/tests/test_identity_score.py
@@ -469,3 +469,56 @@ class TestExpressionMetric:
         from daemon.identity_score import _expression_std
 
         assert _expression_std([np.zeros((73, 2)), np.zeros((70, 2)), np.zeros((73, 2))]) is None
+
+
+class TestPerFrameSeries:
+    """Series exist so the axes can be read against each other on one time axis.
+
+    A mean hides shape. A clip that animates once and then freezes averages the same as one
+    that stays alive throughout, and those are not the same take — which is the whole reason
+    the headline numbers were not enough.
+    """
+
+    def test_expression_series_tracks_frame_to_frame_change(self):
+        import numpy as np
+
+        from daemon.identity_score import _expression_series
+
+        base = np.zeros((73, 2))
+        moved = base + 0.05
+        # still, still, jump, still
+        series = _expression_series([base, base, moved, moved])
+        assert len(series) == 3
+        assert series[0] == 0.0 and series[2] == 0.0
+        assert series[1] > 0, "the frame where the face moved must register"
+
+    def test_expression_series_needs_two_frames(self):
+        import numpy as np
+
+        from daemon.identity_score import _expression_series
+
+        assert _expression_series([np.zeros((73, 2))]) == []
+        assert _expression_series([]) == []
+
+    def test_downsample_keeps_the_shape_not_the_opening(self):
+        """Truncating would plot only the first 600 frames of a long clip, which reads as a
+        complete picture and is not one."""
+        from daemon.identity_score import _downsample
+
+        values = list(range(2000))
+        out = _downsample(values, cap=100)
+        assert len(out) == 100
+        assert out[0] == 0
+        assert out[-1] > 1900, "the end of the clip must be represented"
+
+    def test_downsample_leaves_short_series_alone(self):
+        from daemon.identity_score import _downsample
+
+        assert _downsample([1.0, 2.0, 3.0], cap=600) == [1.0, 2.0, 3.0]
+
+    def test_a_ragged_landmark_series_yields_no_series_rather_than_raising(self):
+        import numpy as np
+
+        from daemon.identity_score import _expression_series
+
+        assert _expression_series([np.zeros((73, 2)), np.zeros((70, 2))]) == []


### PR DESCRIPTION
Identity already had one. The other three axes were computed per frame and then **averaged away**, so the chart could show where a clip ended up but not how it got there.

A mean hides shape: a face that animates once and then freezes averages the same as one that stays alive throughout, and those are not the same take. Same for motion — one surge and a still hold averages like steady movement.

### What was already there

Motion's series existed inside the optical-flow loop and was discarded at the end. Detail's likewise. Only **expression** needed a new quantity: the headline number is deviation across the whole clip, while the series is **frame-to-frame change** — which is what answers *is the face alive right now* and can be read against the others on a shared time axis.

### Downsampling, not truncation

All series cap at 600 points by even sampling. Truncating a long clip would plot only its opening **while looking like a complete picture**. There is a test pinning that, verified to fail when truncation is substituted.

### Plumbing

Motion is measured by a different subsystem from the face metrics, so its series is merged into the blob in the executor — all four then live together and the console needn't know which part of the daemon produced which.

**No migration**:  is JSONB and passes through untouched.

**132 tests pass.** The event-loop guard from #117 caught the motion call being renamed, which is exactly what it exists for.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct