### PR TITLE
Remove the PainterLongVideo swap, which did nothing on Wan 2.2 i2v

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -45,9 +45,6 @@ class Settings(BaseSettings):
     # (hologram_depth_scale_m, set in the console dialog) wins when present.
     depth_scale_m: float = 0.30
 
-    # PainterLongVideo motion parameters (identity anchoring)
-    painter_motion_amplitude: float = 1.3  # Range: 1.0-2.0, higher = more motion
-    painter_motion_frames: int = 5  # Range: 1-20, controls motion cycle length
 
     # Identity scoring device. Defaults to CPU, which is what every recorded identity score to
     # date was produced on.
@@ -72,11 +69,8 @@ class Settings(BaseSettings):
     # cost of not waiting long enough is a discarded segment.
     drain_wait_seconds: int = 3600
 
-    # Motion matching (optical flow based)
-    motion_matching_enabled: bool = True  # Enable automatic motion amplitude matching
-    motion_amplitude_default: float = 1.3  # Default motion_amplitude for segment 0
-    motion_amplitude_min: float = 1.0  # Minimum motion_amplitude (no motion boost)
-    motion_amplitude_max: float = 2.0  # Maximum motion_amplitude (extreme motion)
+    # The PainterLongVideo and motion-amplitude settings were removed with the swap that read
+    # them (see #124). extra="ignore" below means a .env still carrying them is harmless.
 
     # sd-scripts LoRA training monitor
     sd_scripts_path: str = "~/projects/sd-scripts"

--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -11,7 +11,6 @@ from typing import Any
 
 from daemon.config import settings
 from daemon.schemas import SegmentClaim
-from daemon.motion_analyzer import estimate_motion_from_flow
 from daemon.stage_log import log_event
 
 logger = logging.getLogger(__name__)
@@ -182,42 +181,6 @@ def _calculate_generation_params(target_fps: int, duration_sec: float, speed: fl
         "rife_multiplier": rife_multiplier,
         "output_fps": output_fps,
     }
-
-
-def _calculate_motion_amplitude(
-    segment_index: int,
-    previous_motion_magnitude: float | None,
-    motion_amplitude_setting: float,
-) -> float:
-    """Calculate motion_amplitude for a segment based on previous motion data.
-    
-    Args:
-        segment_index: Index of the segment being built (0 = first segment)
-        previous_motion_magnitude: Measured motion from previous segment (px/frame)
-        motion_amplitude_setting: Default/configured motion_amplitude value
-        
-    Returns:
-        motion_amplitude to use for this segment
-    """
-    # Segment 0 uses the default/configured value
-    if segment_index == 0:
-        return motion_amplitude_setting
-    
-    # If no previous motion data, use default
-    if previous_motion_magnitude is None:
-        return motion_amplitude_setting
-    
-    # Motion matching enabled: estimate amplitude to match previous motion
-    # Use previous_motion_magnitude as target to achieve consistency
-    estimated = estimate_motion_from_flow(
-        previous_motion_magnitude=previous_motion_magnitude,
-        previous_motion_amplitude=motion_amplitude_setting,
-        target_motion_magnitude=previous_motion_magnitude,
-    )
-    
-    # Clamp to valid range
-    from daemon.config import settings
-    return max(settings.motion_amplitude_min, min(settings.motion_amplitude_max, estimated))
 
 
 def _add_user_loras(workflow: dict, loras: list[dict]) -> None:
@@ -477,26 +440,27 @@ def build_workflow(
         start_image_filename: The ComfyUI-local filename of the start image
             (already uploaded). If None, the LoadImage node (97) is removed
             for text-to-video generation.
-        initial_reference_image_filename: The ComfyUI-local filename of the
-            job's original input image for PainterLongVideo identity anchoring.
-            When provided (segment > 0), node 98 is swapped from WanImageToVideo
-            to PainterLongVideo with dual-reference inputs.
-            identity for characters. PainterLongVideo only accepts a single
-            clip_vision_output, so multi-frame reference frames are not used.
-        previous_motion_magnitude: Measured motion magnitude from previous 
-            segment (px/frame). Used to auto-adjust motion_amplitude for 
-            consistent motion across segments.
+        initial_reference_image_filename: Accepted and ignored. It fed a
+            PainterLongVideo swap that was inert on Wan 2.2 i2v and has been
+            removed; the parameter stays so the executor's call site and any
+            queued segments carrying an identity_reference_image keep working.
+        previous_motion_magnitude: Accepted and ignored, for the same reason.
+            It fed motion_amplitude, which PainterLongVideo only applied on a
+            branch this graph never took.
+
+    Note on what was removed (see wanly-gpu-daemon#124): the swap replaced node
+    98 with PainterLongVideo whenever a segment had both an initial reference
+    and a start image. On Wan 2.2 i2v every one of its distinguishing inputs was
+    dead -- previous_video was wired to a single-frame LoadImage so the motion
+    reference resolved to None, reference_latents needs a ref_conv weight this
+    checkpoint does not have, clip_vision_output needs an img_emb it does not
+    have, and motion_amplitude is only read on the previous-video-only branch.
+    With start and end connected the node does exactly what stock
+    WanFirstLastFrameToVideo does. It was WanImageToVideo with a wasted VAE
+    encode and a wasted CLIP Vision load.
     """
     gen = _calculate_generation_params(segment.fps, segment.duration_seconds, segment.speed)
     
-    # Calculate motion_amplitude based on previous segment's motion
-    motion_amplitude = _calculate_motion_amplitude(
-        segment_index=segment.index,
-        previous_motion_magnitude=previous_motion_magnitude,
-        motion_amplitude_setting=settings.painter_motion_amplitude,
-    )
-    logger.info("Segment %d motion_amplitude: %.2f (previous_magnitude=%s)",
-                segment.index, motion_amplitude, previous_motion_magnitude)
     workflow = copy.deepcopy(WAN_I2V_API_WORKFLOW)
 
     # Inject model filenames from config
@@ -568,57 +532,6 @@ def build_workflow(
         # Text-to-video: remove LoadImage and disconnect from WanImageToVideo
         del workflow["97"]
         del workflow["98"]["inputs"]["start_image"]
-
-    # PainterLongVideo swap for identity anchoring on segment > 0
-    if initial_reference_image_filename and start_image_filename:
-        # Node 300: load original input image (identity anchor)
-        workflow["300"] = {
-            "class_type": "LoadImage",
-            "inputs": {"image": initial_reference_image_filename},
-            "_meta": {"title": "Initial Reference Image"},
-        }
-        # Node 301: CLIP Vision model loader
-        workflow["301"] = {
-            "class_type": "CLIPVisionLoader",
-            "inputs": {"clip_name": settings.clip_vision_model},
-            "_meta": {"title": "CLIP Vision Loader"},
-        }
-        # Node 302: Encode reference image with CLIP Vision
-        workflow["302"] = {
-            "class_type": "CLIPVisionEncode",
-            "inputs": {
-                "clip_vision": ["301", 0],
-                "image": ["300", 0],
-                "crop": "center",
-            },
-            "_meta": {"title": "CLIP Vision Encode Reference"},
-        }
-        # Replace WanImageToVideo with PainterLongVideo
-        workflow["98"] = {
-            "class_type": "PainterLongVideo",
-            "inputs": {
-                "positive": ["93", 0],
-                "negative": ["89", 0],
-                "vae": ["90", 0],
-                "width": segment.width,
-                "height": segment.height,
-                "length": gen["wan_frames"],
-                "batch_size": 1,
-                "previous_video": ["97", 0],
-                "motion_frames": settings.painter_motion_frames,
-                "motion_amplitude": motion_amplitude,
-                "initial_reference_image": ["300", 0],
-                "clip_vision_output": ["302", 0],
-                "start_image": ["97", 0],
-            },
-            "_meta": {"title": "PainterLongVideo Identity Anchor"},
-        }
-        logger.info(
-            "Swapped to PainterLongVideo (segment %d, ref=%s, clip_vision=%s)",
-            segment.index,
-            initial_reference_image_filename,
-            settings.clip_vision_model,
-        )
 
     # User LoRAs
     if segment.loras:

--- a/tests/test_no_painterlongvideo.py
+++ b/tests/test_no_painterlongvideo.py
@@ -1,0 +1,62 @@
+"""The PainterLongVideo swap is gone, and must not come back (wanly-gpu-daemon#124).
+
+It replaced node 98 with PainterLongVideo whenever a segment had both an initial reference image
+and a start image. On Wan 2.2 i2v every distinguishing input was dead:
+
+  previous_video      wired to a single-frame LoadImage, so the motion reference resolved to None
+  reference_latents   only read by checkpoints carrying ref_conv.weight (Wan 2.1 FLF2V)
+  clip_vision_output  Wan 2.2 i2v has no img_emb; the official template has no CLIPVisionLoader
+  motion_amplitude    applied only on the previous-video-only branch, which this graph never took
+  end_image           never passed
+
+With start and end connected the node does line for line what stock WanFirstLastFrameToVideo
+does, so it was WanImageToVideo with a wasted VAE encode and a wasted CLIP Vision load -- plus a
+"Segment N motion_amplitude: X" log line for a value that was computed and discarded, which is
+what made it look like a live tuning lever during the motion investigation.
+
+The reference-image parameters are still ACCEPTED, because segments queued with an
+identity_reference_image must keep building.
+"""
+
+from tests.test_seed_reanchor import make_segment
+
+from daemon.workflow_builder import build_workflow
+
+
+class TestSwapIsGone:
+    def test_reference_image_still_builds_the_stock_node(self):
+        wf = build_workflow(
+            make_segment(index=1),
+            start_image_filename="start.png",
+            initial_reference_image_filename="original.png",
+        )
+        assert wf["98"]["class_type"] == "WanImageToVideo"
+
+    def test_no_clip_vision_nodes_are_added(self):
+        # Loading a CLIP Vision model to feed an input nothing reads is pure cost on a card
+        # already tight for VRAM.
+        wf = build_workflow(
+            make_segment(index=1),
+            start_image_filename="start.png",
+            initial_reference_image_filename="original.png",
+        )
+        classes = {n.get("class_type") for n in wf.values()}
+        assert "CLIPVisionLoader" not in classes
+        assert "CLIPVisionEncode" not in classes
+        assert "PainterLongVideo" not in classes
+
+    def test_a_reference_image_changes_nothing_at_all(self):
+        # The strongest statement of the finding: passing the reference produced an identical
+        # graph, so every run that took this path paid for it and got nothing.
+        common = dict(start_image_filename="start.png")
+        with_ref = build_workflow(make_segment(index=1),
+                                  initial_reference_image_filename="original.png", **common)
+        without = build_workflow(make_segment(index=1), **common)
+        assert with_ref == without
+
+    def test_previous_motion_magnitude_is_accepted_and_inert(self):
+        # It only ever fed motion_amplitude on a branch this graph never took.
+        a = build_workflow(make_segment(index=1), start_image_filename="s.png",
+                           previous_motion_magnitude=0.9)
+        b = build_workflow(make_segment(index=1), start_image_filename="s.png")
+        assert a == b


### PR DESCRIPTION
Closes #124.

The swap replaced node 98 with `PainterLongVideo` whenever a segment carried both an initial reference image and a start image. On Wan 2.2 i2v **every input that distinguishes that node from stock `WanImageToVideo` was dead**:

| input | why it did nothing |
|---|---|
| `previous_video` | wired to a single-frame `LoadImage`, so the motion reference resolved to `None` |
| `reference_latents` | only read by checkpoints carrying `ref_conv.weight` (Wan 2.1 FLF2V) |
| `clip_vision_output` | Wan 2.2 i2v has no `img_emb`; the official template has no CLIPVisionLoader |
| `motion_amplitude` | applied only on the previous-video-only branch, which this graph never took |
| `end_image` | never passed at all |

So it cost a VAE encode, a CLIP Vision model load and two extra nodes to produce a graph identical to the one it replaced. **A test asserts exactly that** — passing a reference image now yields a byte-identical workflow, which is the strongest statement of the finding: every run down that path paid for it and got nothing.

## The expensive part

It logged `Segment N motion_amplitude: X` on every run, for a value that was computed and discarded. That is precisely what made it look like a live tuning lever during the motion investigation, and several hours went into asking why the knob wasn't moving anything.

## Compatibility

`initial_reference_image_filename` and `previous_motion_magnitude` are still **accepted** — segments already queued with an `identity_reference_image` have to keep building — and are now documented as inert.

The config keys that only fed this are removed. Safe because the settings model is `extra: "ignore"`, so a `.env` still carrying them cannot break a boot.

136 passing, 4 new.

End-frame conditioning is worth revisiting deliberately through stock `WanFirstLastFrameToVideo` (#125) rather than through a custom node that reimplements it less well.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct