### PR TITLE
Free the mouth from the faceswap mask so generated lip motion survives

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -314,7 +314,12 @@ def _add_faceswap(
             "use_occlusion_mask": True,
             "use_area_mask": True,
             "use_region_mask": False,
-            "face_mask_areas": "upper-face,lower-face,mouth",
+            # The FaceFusion masks INTERSECT (box ∩ occlusion ∩ area), so an area only gets
+            # swapped if it's listed here. "mouth" is deliberately excluded: with it in, the
+            # source lips overwrite whatever motion the generation produced, flattening the
+            # face. Leaving it out swaps identity everywhere else (incl. jaw/chin via
+            # "lower-face") while the generated lip/mouth motion survives. See #133.
+            "face_mask_areas": "upper-face,lower-face",
             "face_mask_regions": "skin,nose,mouth,upper-lip,lower-lip",
             "face_mask_padding": "0,0,0,0",
             "reference_image": ["188", 0],


### PR DESCRIPTION
## What

Drops `mouth` from `face_mask_areas` in the FaceFusion node (`daemon/workflow_builder.py`).

## Why

FaceFusion's masks **intersect** (box ∩ occlusion ∩ area), so an area only gets swapped when it's listed in `face_mask_areas`. With `mouth` in the list, the source face's lips overwrote whatever motion the generation produced — this is the mechanism behind "faceswap kills expression."

Removing `mouth` swaps identity everywhere else (including jaw/chin via `lower-face`) while leaving the mouth/lip region to the generation, so prompt-driven lip motion carries through. This is lever 1 from #133.

## Scope

Direct code change per the [#133 comment](https://github.com/DavidJBarnes/wanly-gpu-daemon/issues/133) — no UI or `Settings` plumbing. `use_region_mask` (lever 2, finer lip/interior control) remains available as a follow-up if freeing the whole mouth area proves too loose.

Refs #133.

https://claude.ai/code/session_01U5SVx7NvWY59zSgLvJruct