### PR TITLE
Track faceswap.sh in the repo, guard its execution provider

### DIFF
--- a/experiment/README.md
+++ b/experiment/README.md
@@ -1,0 +1,33 @@
+# experiment/
+
+Operator tools that drive the 3090 by hand, outside the daemon's job loop. Nothing here is
+imported by `daemon/` — these are scripts run from a laptop when a recipe needs to be applied to
+specific files rather than to a queued job.
+
+## faceswap.sh
+
+The locked FaceFusion stage-2 recipe, validated 2026-07-06: identity-locked, expressions carried,
+holds through head turns, body untouched (so it is safe on NSFW output). It uploads a face and a
+target video to 3090.zero, runs the swap there, and pulls the result back.
+
+    ./faceswap.sh --face k3llydw.png --video segment.mp4 --out swapped.mp4
+
+The settings in the script are the recipe — `--reference-face-distance` and the default landmarker
+are what make identity hold through angle changes, so treat the flags as findings rather than
+defaults to tune casually. `--distance` and `--face-index` exist for the multi-subject case: at the
+default 1.0 every face matches the reference, so targeting one person requires tightening to ~0.6.
+
+### It depends on an env this repo does not own
+
+The swap runs in the `facefusion` conda env on 3090.zero, which is a separate machine-local
+install. That env broke once already: a bare `onnxruntime` (CPU) wheel installed on top of
+`onnxruntime-gpu` shadowed it, CUDA silently disappeared, and the script died on an argparse error
+that named nothing useful (wanly-gpu-daemon#135). Upstream facefusion's own `requirements.txt`
+pins the CPU wheel, so a reinstall can reintroduce it at any time (#139).
+
+The script therefore checks `onnxruntime.get_available_providers()` before uploading anything and
+aborts with the repair command if CUDA is missing. `--allow-cpu` overrides that — correct output,
+roughly 15x slower (~500-870s/clip vs ~37s), so it is opt-in rather than a silent fallback.
+
+FaceFusion also wants the GPU relatively free; with a generation holding ~19GB it will OOM on a
+small allocation. Run bulk swaps against an idle daemon.

--- a/experiment/faceswap.sh
+++ b/experiment/faceswap.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Locked FaceFusion stage-2 recipe (validated 2026-07-06).
+# Identity-locked, expressions carried, sharp, holds through head turns/angles, NSFW-safe (body untouched).
+# Uploads face+video to the 3090, runs the swap, pulls the result back here.
+#
+# Usage: ./faceswap.sh --face <face.jpg|png> --video <target.mp4> [--out <output.mp4>]
+set -euo pipefail
+HOST=david@3090.zero
+
+FACE=""; VIDEO=""; OUT=""; FACE_INDEX="0"; DISTANCE=""; INDEX_SET=0; ALLOW_CPU=0
+usage() { echo "Usage: $0 --face <face.jpg|png> --video <target.mp4> [--out <out.mp4>] [--face-index N] [--distance 0.0-1.5] [--allow-cpu]"; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --face)       FACE="${2:?}"; shift 2 ;;
+    --video)      VIDEO="${2:?}"; shift 2 ;;
+    --out)        OUT="${2:?}"; shift 2 ;;
+    --face-index) FACE_INDEX="${2:?}"; INDEX_SET=1; shift 2 ;;  # which face: 0=first,1=second (left-to-right)
+    --distance)   DISTANCE="${2:?}"; shift 2 ;;                 # match looseness: high=holds angles, low=isolates one person
+    --allow-cpu)  ALLOW_CPU=1; shift ;;                         # run on CPU anyway (~15x slower) instead of aborting
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg: $1"; usage; exit 1 ;;
+  esac
+done
+# Distance: 1.0 (loose) for single-subject so the swap holds through head turns. But at 1.0 EVERY face
+# matches the reference, so a specific --face-index gets ignored and all faces swap. When a face is
+# targeted, tighten to 0.6 so only that person matches (isolates them). Override with --distance.
+if [ -z "$DISTANCE" ]; then [ "$INDEX_SET" = "1" ] && DISTANCE="0.6" || DISTANCE="1.0"; fi
+
+[ -n "$FACE" ]  || { echo "ERROR: --face required";  usage; exit 1; }
+[ -n "$VIDEO" ] || { echo "ERROR: --video required"; usage; exit 1; }
+[ -f "$FACE" ]  || { echo "ERROR: face not found: $FACE";   exit 1; }
+[ -f "$VIDEO" ] || { echo "ERROR: video not found: $VIDEO"; exit 1; }
+OUT="${OUT:-swapped_$(basename "${VIDEO%.*}").mp4}"
+
+RSRC="/tmp/ff_src_$$.${FACE##*.}"; RTGT="/tmp/ff_tgt_$$.mp4"; ROUT="/tmp/ff_out_$$.mp4"
+
+FF_PY="~/miniconda3/envs/facefusion/bin/python"
+FF_PIP="~/miniconda3/envs/facefusion/bin/pip"
+
+# Ask onnxruntime what it can actually do BEFORE uploading anything.
+#
+# On 2026-08-11 a bare `onnxruntime` (CPU-only) wheel got installed on top of `onnxruntime-gpu` in
+# this env. They unpack into the SAME package dir, the CPU .so files win, and CUDAExecutionProvider
+# vanishes -- at which point FaceFusion drops `cuda` from its argparse choices and this script died
+# on "invalid choice: 'cuda' (choose from 'cpu')", which says nothing about the real cause. The
+# fallback that matters is silent elsewhere (the RunPod path just runs on CPU at GPU prices), so
+# the rule here is: name the cause, and never quietly spend 15x the wall clock.
+echo "[1/5] checking the execution provider on ${HOST#*@}..."
+PROVIDERS="$(ssh "$HOST" "$FF_PY -c \"import onnxruntime as ort; print(','.join(ort.get_available_providers()))\"" 2>/dev/null || true)"
+
+if printf '%s' "$PROVIDERS" | grep -q 'CUDAExecutionProvider'; then
+  EP="cuda"
+  echo "      CUDAExecutionProvider present."
+else
+  EP="cpu"
+  echo
+  if [ -z "$PROVIDERS" ]; then
+    echo "  !! Could not query onnxruntime in the facefusion env on $HOST."
+    echo "     Either the host is unreachable or the env is gone. Providers unknown."
+  else
+    echo "  !! No CUDAExecutionProvider. onnxruntime reports: $PROVIDERS"
+    # The shadowing is the known cause, so check for it by name rather than making the operator
+    # rediscover it. Both packages present == this exact bug (wanly-gpu-daemon#135).
+    INSTALLED="$(ssh "$HOST" "$FF_PIP list 2>/dev/null | grep -iE '^onnxruntime(-gpu)?[[:space:]]'" 2>/dev/null || true)"
+    [ -n "$INSTALLED" ] && { echo "     Installed:"; printf '%s\n' "$INSTALLED" | sed 's/^/       /'; }
+    if printf '%s' "$INSTALLED" | grep -qiE '^onnxruntime[[:space:]]' && \
+       printf '%s' "$INSTALLED" | grep -qiE '^onnxruntime-gpu[[:space:]]'; then
+      echo "     ^ BOTH are installed. The CPU build is shadowing the GPU one -- this is #135."
+    fi
+    echo
+    echo "     Repair (facefusion 3.2.0 pins 1.21.1):"
+    echo "       ssh $HOST '$FF_PIP uninstall -y onnxruntime onnxruntime-gpu && $FF_PIP install onnxruntime-gpu==1.21.1'"
+    echo "       ssh $HOST '$FF_PY -c \"import onnxruntime as o; print(o.get_available_providers())\"'"
+  fi
+  echo
+  echo "     CPU still produces correct output, just ~15x slower (~500-870s/clip vs ~37s)."
+  if [ "$ALLOW_CPU" != "1" ]; then
+    echo "     Refusing to run on CPU by default. Re-run with --allow-cpu if that is what you want."
+    exit 1
+  fi
+  echo "     --allow-cpu given; continuing on CPU."
+  echo
+fi
+
+echo "[2/5] uploading face + video..."
+scp -q "$FACE" "$HOST:$RSRC"; scp -q "$VIDEO" "$HOST:$RTGT"
+
+echo "[3/5] freeing GPU + running FaceFusion (provider $EP, occlusion mask ON, face-index $FACE_INDEX, distance $DISTANCE)..."
+ssh "$HOST" "curl -sf -X POST http://localhost:8188/free -H 'Content-Type: application/json' -d '{\"unload_models\":true,\"free_memory\":true}' -o /dev/null 2>/dev/null; \
+  cd ~/projects/facefusion && ~/miniconda3/envs/facefusion/bin/python facefusion.py headless-run \
+  -s '$RSRC' -t '$RTGT' -o '$ROUT' \
+  --processors face_swapper face_enhancer \
+  --face-swapper-model inswapper_128 --face-swapper-pixel-boost 512x512 \
+  --face-enhancer-model gfpgan_1.4 \
+  --face-mask-types box occlusion \
+  --face-selector-mode reference --reference-face-distance $DISTANCE \
+  --face-selector-order left-right --reference-face-position $FACE_INDEX \
+  --execution-providers $EP 2>&1 | tail -2"
+
+echo "[4/5] pulling result..."
+scp -q "$HOST:$ROUT" "$OUT"
+ssh "$HOST" "rm -f '$RSRC' '$RTGT' '$ROUT'" 2>/dev/null || true
+echo "[5/5] DONE -> $OUT"


### PR DESCRIPTION
Refs #135, #139

Two things, both about the same script.

## 1. It is now version controlled

`faceswap.sh` — the locked stage-2 FaceFusion recipe validated 2026-07-06 — was an untracked file in a local scratch directory. No history, no diffs, no way to review a change to a recipe we treat as settled, while every issue about it was filed in this repo. It now lives at `experiment/faceswap.sh` with a short README covering what the directory is for and the env it depends on.

`experiment/` is operator tooling: run by hand from a laptop, never imported by `daemon/`.

## 2. It no longer fails opaquely when CUDA disappears

Per the open prevention item in #135. The env on 3090.zero broke once when a bare `onnxruntime` (CPU) wheel was installed over `onnxruntime-gpu` — same package dir, CPU `.so` files win, `CUDAExecutionProvider` vanishes, and FaceFusion drops `cuda` from its argparse choices. The failure message was `invalid choice: 'cuda' (choose from 'cpu')`, which names neither cause nor fix.

The script now probes `onnxruntime.get_available_providers()` over SSH **before** uploading:

| state | behaviour |
|---|---|
| CUDA present | unchanged — runs as before |
| CUDA absent | prints providers, runs `pip list`, names the shadowing explicitly if both packages are present, prints the repair command, **aborts before upload** |
| `--allow-cpu` (new) | takes the CPU path deliberately, with the ~500-870s/clip vs ~37s cost stated |
| host unreachable | "providers unknown" — not misdiagnosed as shadowing |

Aborting rather than falling back is the point. The same class of bug on the RunPod path degrades to CPU *silently*, which means paying GPU rates for CPU work with nothing on screen to say so.

## Verification
- `bash -n` clean.
- Live probe against 3090.zero returns `TensorrtExecutionProvider,CUDAExecutionProvider,CPUExecutionProvider` — env still healthy since the 08-11 repair, and the happy path threads `provider cuda` through to the run.
- Failure paths exercised with stubbed `ssh`/`pip`/`python`: shadowing is detected and attributed to #135, `EXIT=1`, and no upload occurs.
- `--allow-cpu` confirmed to continue with `provider cpu`.

No daemon code touched.