### PR TITLE
fix: restore TE-on-CPU — keeper edit lost in the July 7 rollback

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -32,7 +32,13 @@ WAN_I2V_API_WORKFLOW: dict[str, Any] = {
         "inputs": {
             "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
             "type": "wan",
-            "device": "default",
+            # Text encoder on CPU. On "default" the 6.4GB umt5-xxl sits in VRAM for the whole
+            # render (ComfyUI never evicts it), and in CFG>1 mode — 13.5GB activation reserve
+            # via /tmp/wanly_estimate — that leaves ~2.6GB for the 14B expert: 11.5GB of
+            # weights stream over PCIe every step. Encoding runs once per segment; the CPU
+            # cost is seconds against minutes-per-step savings. (Keeper edit from #47,
+            # lost in the 2026-07-07 rollback.)
+            "device": "cpu",
         },
     },
     "85": {


### PR DESCRIPTION
Full diagnosis in #143. One-line mechanism: CFG>1's 13.5GB activation reserve + a never-evicted 6.4GB GPU text encoder leave ~2.6GB for the active 14B expert, which streams 11.5GB of weights per step — 39-minute segments that used to take 11.

`CLIPLoader device=cpu` restores the validated #47 keeper edit that the 2026-07-07 rollback (2b6d159) silently dropped. Verified against live ComfyUI `/object_info`: `device` is an accepted optional input (`["default", "cpu"]`) on the image's pinned commit.

136 daemon tests pass. Workers pick this up on restart: RunPod pods clone main at boot; the 3090 container needs a restart (I'll do it between segments).

Closes #143