### PR TITLE
Revert TE-on-CPU — measured: residency buys nothing, CPU encode costs ~70s/segment

### DIFF
--- a/daemon/workflow_builder.py
+++ b/daemon/workflow_builder.py
@@ -32,13 +32,7 @@ WAN_I2V_API_WORKFLOW: dict[str, Any] = {
         "inputs": {
             "clip_name": "umt5_xxl_fp8_e4m3fn_scaled.safetensors",
             "type": "wan",
-            # Text encoder on CPU. On "default" the 6.4GB umt5-xxl sits in VRAM for the whole
-            # render (ComfyUI never evicts it), and in CFG>1 mode — 13.5GB activation reserve
-            # via /tmp/wanly_estimate — that leaves ~2.6GB for the 14B expert: 11.5GB of
-            # weights stream over PCIe every step. Encoding runs once per segment; the CPU
-            # cost is seconds against minutes-per-step savings. (Keeper edit from #47,
-            # lost in the 2026-07-07 rollback.)
-            "device": "cpu",
+            "device": "default",
         },
     },
     "85": {


### PR DESCRIPTION
Reverts #144 on measurement. Same-day, like-for-like 832x480 cfg-3.0 segments on 3090.zero:

| config | UNET | total |
|---|---|---|
| TE on GPU (pre-#144) | 11GB offloaded | ~11.3 min |
| TE on CPU (post-#144) | fully resident | ~12.5 min |

The offload was a red herring on the image's pinned ComfyUI: weight streaming is asynchronous and effectively free (further confirmed by the cfg-3 high expert running exactly 2x the cfg-1 low expert per step while both offloaded — no streaming term visible). The +70s is the umt5-xxl CPU text-encode per segment.

At 720p, #144 changed nothing either way (usable pinned at the ~2.6GB floor with or without the TE's 6.4GB; ~180 s/step both before and after). The 39-minute 720p renders are resolution+mode compute, not a VRAM defect.

Full measurement trail in #143.