### PR TITLE
Drive ltx-engine instead of building WAN graphs

### DIFF
--- a/daemon/config.py
+++ b/daemon/config.py
@@ -12,6 +12,28 @@ class Settings(BaseSettings):
     queue_api_key: str = ""
     poll_interval: int = 5
 
+    # Which generation engine this worker drives.
+    #
+    # "wan22" -> ComfyUI directly, via workflow_builder (the original path)
+    # "ltx"   -> ltx-engine over HTTP, which owns graph assembly itself
+    #
+    # LTX 2.3 replaces WAN 2.2 (wanly-gpu-docker#41), but the default stays "wan22" so that
+    # merging LTX support cannot change what an existing worker does. start.sh git-pulls this
+    # daemon on every boot, so a default flip here would retarget any running worker the moment
+    # it restarted. The LTX image sets ENGINE=ltx explicitly instead.
+    engine: str = "wan22"
+
+    # ltx-engine's job API, in the same container. NOT ComfyUI on 8191: the engine owns the
+    # graph — it uploads keyframes, resolves the recipe, patches the workflow and submits.
+    # Driving ComfyUI directly for LTX would put graph assembly back in a caller, which is
+    # where every structural bug on that project came from.
+    ltx_engine_url: str = "http://localhost:8190"
+    # A render is 8-12 minutes and can queue behind another. Sized from the slowest realistic
+    # case and then doubled: a timeout that gives up early costs a finished render, and that
+    # has happened before (4 of 9 lost to a 90-minute wait loop).
+    ltx_timeout_seconds: int = 5400
+    ltx_poll_interval: int = 5
+
     # Model filenames (vary per GPU worker — override in .env)
     clip_model: str = "umt5_xxl_fp8_e4m3fn_scaled.safetensors"
     vae_model: str = "wan_2.1_vae.safetensors"

--- a/daemon/executor.py
+++ b/daemon/executor.py
@@ -758,6 +758,17 @@ async def execute_segment(
     if segment.reprocess_type == "smashcut_concat":
         return await _execute_smashcut_concat(segment, queue)
 
+    # LTX 2.3 renders go to ltx-engine, which owns graph assembly. Imported here rather than
+    # at module scope because ltx_executor reuses this module's helpers — the deferred import
+    # is what keeps that from being a cycle.
+    #
+    # Selected by config, not by inspecting the segment: ENGINE is a property of the worker
+    # (which models and services its container actually has), not of the job. A worker without
+    # ltx-engine must never claim-and-attempt an LTX render on the strength of a field.
+    if settings.engine == "ltx":
+        from daemon.ltx_executor import execute_ltx_segment
+        return await execute_ltx_segment(segment, queue)
+
     # Retired engines. wanly-api may still set these fields on older jobs, so they are
     # handled here rather than ignored silently:
     #   lynx — a different base model family (Wan2.1 T2V). No sensible fallback exists, and

--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -1,0 +1,184 @@
+"""HTTP client for ltx-engine, the LTX 2.3 render service.
+
+The engine runs in the same container and owns graph assembly and recipe resolution. This
+client does not build graphs, patch workflows or know what a node is — it submits a job,
+waits, and collects an mp4.
+
+That division is deliberate. Every structural bug on the storyboard project came from
+rewriting a downloaded graph's topology in a caller to cover a job shape it was not built
+for; none came from the reference workflows themselves. So the engine keeps the graph and
+the daemon keeps the queue.
+"""
+
+import asyncio
+import base64
+import logging
+import time
+from typing import Any
+
+import httpx
+
+from .config import settings
+
+logger = logging.getLogger(__name__)
+
+# The engine's own vocabulary. "None" means queued — its word, not ours.
+TERMINAL = {"Done", "Failed"}
+
+
+class LtxEngineError(RuntimeError):
+    """The engine reported a failed render, or could not be reached."""
+
+
+def build_submit_payload(
+    *,
+    image_bytes: bytes | None,
+    prompt: str,
+    negative_prompt: str | None,
+    width: int,
+    height: int,
+    num_frames: int,
+    frame_rate: int,
+    seed: int,
+    recipe: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """The engine's /job body. Pure, so it can be asserted without an engine.
+
+    `recipe` is the RESOLVED configuration handed down in the claim. It is read, never
+    looked up — see the module docstring.
+    """
+    payload: dict[str, Any] = {
+        "prompt": prompt,
+        "negative_prompt": negative_prompt,
+        "width": width,
+        "height": height,
+        "num_frames": num_frames,
+        "frame_rate": frame_rate,
+        # The engine takes a signed 32-bit seed; the queue derives a 63-bit one. Narrow it
+        # here rather than letting the engine reject it or silently wrap it.
+        "seed": seed % (2**31 - 1),
+        "keyframes": [],
+    }
+    if image_bytes is not None:
+        b64 = base64.b64encode(image_bytes).decode()
+        payload["keyframes"] = [{"image": f"data:image/png;base64,{b64}"}]
+
+    if recipe:
+        # ONLY the fields the engine's request model carries. Everything else in the blob is
+        # a record of what ran, not an input — graph_sha256 above all. Sending that back
+        # would offer the engine a hash to honour instead of one to produce, which inverts
+        # the entire point of hashing the resolved graph.
+        for key in ("recipe", "character"):
+            if recipe.get(key):
+                payload[key] = recipe[key]
+        lora = recipe.get("char_lora")
+        s1, s2 = recipe.get("char_s1"), recipe.get("char_s2")
+        if lora and s1 is not None and s2 is not None:
+            # Per-stage, never flat. Stage 1 generates at half size from noise and stage 2
+            # refines the 2x-upscaled latent; the validated recipe runs 0.8 then 1.5, and
+            # collapsing them to one number is a different configuration.
+            payload["loras"] = [{
+                "name": lora,
+                "strength": float(s1),
+                "strength_stage_1": float(s1),
+                "strength_stage_2": float(s2),
+            }]
+    return payload
+
+
+class LtxClient:
+    def __init__(self, base_url: str | None = None):
+        self.base_url = (base_url or settings.ltx_engine_url).rstrip("/")
+        # Submitting returns immediately; only the video GET streams anything large.
+        self._client = httpx.AsyncClient(base_url=self.base_url, timeout=120.0)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def health(self) -> dict[str, Any]:
+        r = await self._client.get("/health")
+        r.raise_for_status()
+        result: dict[str, Any] = r.json()
+        return result
+
+    async def submit(
+        self,
+        *,
+        image_bytes: bytes | None,
+        prompt: str,
+        negative_prompt: str | None,
+        width: int,
+        height: int,
+        num_frames: int,
+        frame_rate: int,
+        seed: int,
+        recipe: dict[str, Any] | None,
+    ) -> str:
+        """Queue a render. Returns the engine's job id."""
+        payload = build_submit_payload(
+            image_bytes=image_bytes, prompt=prompt, negative_prompt=negative_prompt,
+            width=width, height=height, num_frames=num_frames, frame_rate=frame_rate,
+            seed=seed, recipe=recipe,
+        )
+        r = await self._client.post("/job", json=payload)
+        if r.status_code >= 400:
+            raise LtxEngineError(f"submit failed: {r.status_code} {r.text[:500]}")
+        job_id: str = r.json()["job_id"]
+        logger.info("ltx-engine accepted job %s", job_id)
+        return job_id
+
+    async def wait(self, job_id: str, progress: Any = None) -> dict[str, Any]:
+        """Poll until the render finishes. Returns the final job record.
+
+        A transient failure to reach the engine is NOT treated as a failed render: the engine
+        holds jobs in memory, so a restart loses the record while the mp4 survives on disk.
+        Declaring failure on a dropped poll would abandon work that is still running or
+        already finished.
+        """
+        deadline = time.monotonic() + settings.ltx_timeout_seconds
+        last_status = None
+        consecutive_errors = 0
+
+        while True:
+            if time.monotonic() > deadline:
+                raise LtxEngineError(
+                    f"job {job_id} still {last_status or 'unknown'} after "
+                    f"{settings.ltx_timeout_seconds}s"
+                )
+            try:
+                r = await self._client.get(f"/job/{job_id}")
+                r.raise_for_status()
+                job: dict[str, Any] = r.json()
+                consecutive_errors = 0
+            except Exception as e:
+                consecutive_errors += 1
+                # Loud after a while, but never fatal — see the docstring.
+                if consecutive_errors in (1, 12) or consecutive_errors % 60 == 0:
+                    logger.warning(
+                        "ltx-engine poll failed (%d in a row, still waiting): %s",
+                        consecutive_errors, e,
+                    )
+                await asyncio.sleep(settings.ltx_poll_interval)
+                continue
+
+            status = job.get("status")
+            if status != last_status:
+                logger.info("ltx-engine job %s: %s", job_id, status)
+                if progress is not None:
+                    await progress.log(f"[4/6] ltx-engine: {status}")
+                last_status = status
+
+            if status in TERMINAL:
+                if status == "Failed":
+                    raise LtxEngineError(job.get("error") or "engine reported Failed")
+                return job
+
+            await asyncio.sleep(settings.ltx_poll_interval)
+
+    async def fetch_video(self, job_id: str) -> bytes:
+        """Download the rendered mp4."""
+        async with httpx.AsyncClient(base_url=self.base_url, timeout=900.0) as c:
+            r = await c.get(f"/job/{job_id}/video")
+            if r.status_code >= 400:
+                raise LtxEngineError(f"video fetch failed: {r.status_code} {r.text[:200]}")
+            return r.content

--- a/daemon/ltx_executor.py
+++ b/daemon/ltx_executor.py
@@ -1,0 +1,144 @@
+"""Execute a segment on LTX 2.3, via ltx-engine.
+
+Kept in its own module rather than branching inside executor.py, so that retiring WAN 2.2 is
+deleting files rather than unpicking merged functions.
+
+What is DIFFERENT from the WAN path is only the middle: instead of building a ComfyUI graph
+and driving ComfyUI over a websocket, this hands the job to ltx-engine, which owns graph
+assembly and recipe resolution.
+
+What is the SAME is everything either side of that, and deliberately so — the start image
+still comes from the queue, and the finished mp4 still gets its last frame extracted, its
+motion measured, its identity scored and its bytes uploaded through exactly the same calls.
+That is what makes an LTX render appear in Videos, carry identity chips and accept
+observations without any of that machinery knowing which engine produced it.
+"""
+
+import asyncio
+import logging
+import time
+
+from daemon.executor import (
+    _download_with_retry,
+    _extract_last_frame,
+    _score_segment_identity,
+    _validate_image_data,
+)
+from daemon.ltx_client import LtxClient, LtxEngineError
+from daemon.motion_analyzer import measure_motion_series
+from daemon.progress import ProgressLog
+from daemon.queue_client import QueueClient
+from daemon.schemas import SegmentClaim, SegmentResult
+
+logger = logging.getLogger(__name__)
+
+
+async def _start_image_bytes(segment: SegmentClaim, queue: QueueClient) -> bytes | None:
+    """The start frame as raw bytes.
+
+    The WAN path uploads it to ComfyUI and passes a filename; the engine takes a data URI in
+    the submit payload instead, so there is nothing to upload and no ComfyUI involved.
+    """
+    ref = segment.start_image
+    if not ref:
+        return None
+    if not ref.startswith("s3://"):
+        # A bare ComfyUI filename means a WAN-shaped claim reached the LTX path. There is no
+        # ComfyUI upload area to read it back out of, so say so rather than rendering t2v and
+        # returning a clip of the wrong person.
+        raise LtxEngineError(
+            f"start_image {ref!r} is not an s3:// path — the LTX engine needs the image "
+            "itself, not a ComfyUI filename"
+        )
+    data = await _download_with_retry(lambda: queue.download_file(ref), "start_image")
+    _validate_image_data(data, "start_image")
+    return data
+
+
+async def execute_ltx_segment(segment: SegmentClaim, queue: QueueClient) -> None:
+    """Render one segment on ltx-engine and report the result."""
+    recipe = segment.ltx_recipe or {}
+    logger.info(
+        "=== Segment %d (job %s) on LTX === %s | prompt: %s",
+        segment.index, str(segment.job_id)[:8],
+        f"recipe={recipe.get('recipe')!r} character={recipe.get('character')!r}"
+        if recipe else "free-form",
+        segment.prompt[:80],
+    )
+
+    progress = ProgressLog(segment.id, queue)
+    started = time.monotonic()
+    client = LtxClient()
+
+    try:
+        await progress.log("[1/6] Downloading start image...")
+        image_bytes = await _start_image_bytes(segment, queue)
+        await progress.log(
+            f"[1/6] Start image ready ({len(image_bytes)} bytes)" if image_bytes
+            else "[1/6] No start image (text-to-video)"
+        )
+
+        # Frames come from the recipe when there is one. The queue speaks seconds, so fall
+        # back to duration x fps — but a recipe's own frame count wins, because it is part of
+        # the configuration that was validated.
+        num_frames = recipe.get("frames") or round(segment.duration_seconds * segment.fps)
+
+        await progress.log("[2/6] Submitting to ltx-engine...")
+        job_id = await client.submit(
+            image_bytes=image_bytes,
+            prompt=segment.prompt,
+            negative_prompt=segment.negative_prompt,
+            width=segment.width,
+            height=segment.height,
+            num_frames=int(num_frames),
+            frame_rate=segment.fps,
+            seed=segment.seed,
+            recipe=recipe or None,
+        )
+        await progress.log(f"[3/6] Queued as {job_id}")
+
+        job = await client.wait(job_id, progress=progress)
+
+        # The engine's notes carry the recipe name and the resolved graph hash. That hash is
+        # the regression trail — it is what makes this render provably the configuration that
+        # was signed off — so it goes in the segment's own log, not just the engine's.
+        for note in job.get("notes") or []:
+            await progress.log(f"[4/6] {note}")
+
+        await progress.log("[5/6] Downloading video...")
+        video_data = await client.fetch_video(job_id)
+        await progress.log(f"[5/6] Video downloaded ({len(video_data) / 1e6:.1f} MB)")
+
+        await progress.log("[6/6] Extracting last frame and uploading...")
+        last_frame_data = await _extract_last_frame(video_data)
+
+        # Identical to the WAN path from here. Motion is synchronous OpenCV over every frame
+        # (~38s at 289 frames), so it goes off the event loop or the heartbeat stops with it.
+        motion_magnitude, motion_series = await asyncio.to_thread(
+            measure_motion_series, video_data
+        )
+        if motion_magnitude:
+            await progress.log(f"[6/6] Motion magnitude: {motion_magnitude:.2f} px/frame")
+
+        identity_fields = await _score_segment_identity(segment, video_data, queue, progress)
+        metrics = identity_fields.get("identity_metrics")
+        if isinstance(metrics, dict) and motion_series:
+            metrics["series_motion"] = motion_series
+
+        await queue.upload_segment_output(
+            segment.id, video_data, last_frame_data,
+            SegmentResult(status="completed", motion_magnitude=motion_magnitude,
+                          **identity_fields),
+        )
+        logger.info("Segment %d complete in %.1fs", segment.index, time.monotonic() - started)
+
+    except Exception as e:
+        error_msg = f"{type(e).__name__}: {e}"
+        logger.exception("LTX segment %s failed", segment.id)
+        await queue.update_segment(
+            segment.id,
+            SegmentResult(status="failed", error_message=error_msg[:2000],
+                          progress_log=progress.text),
+        )
+    finally:
+        await client.close()

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -156,6 +156,19 @@ async def heartbeat_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_
             logger.error("Heartbeat failed: %s: %s", type(e).__name__, e)
 
 
+async def _ltx_healthy() -> bool:
+    """Is ltx-engine up and answering? Never raises — a probe failure means 'not now'."""
+    from daemon.ltx_client import LtxClient
+    client = LtxClient()
+    try:
+        await client.health()
+        return True
+    except Exception:
+        return False
+    finally:
+        await client.close()
+
+
 async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_event, executing_event, drain_event):
     """Poll the queue for segments and execute them one at a time."""
     poll_count = 0
@@ -180,6 +193,15 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
         if not await comfyui.check_health():
             if poll_count == 0 or poll_count % 60 == 0:
                 logger.warning("ComfyUI offline — skipping poll")
+            poll_count += 1
+            continue
+
+        # Same rule for ltx-engine: claiming a segment this worker cannot render burns it.
+        # The segment would fail, and a failed segment is not free — it needs a human to
+        # notice and retry. Better to leave it queued for a worker that can take it.
+        if settings.engine == "ltx" and not await _ltx_healthy():
+            if poll_count == 0 or poll_count % 60 == 0:
+                logger.warning("ltx-engine offline — skipping poll")
             poll_count += 1
             continue
 
@@ -450,13 +472,27 @@ async def run():
     if cleaned:
         logger.info("Cleaned %d partial download(s)", cleaned)
 
-    # Pre-flight: validate all required models
-    models_ok = await validate_models(comfyui)
-    if not models_ok:
-        logger.error("Model validation failed. Exiting.")
-        await comfyui.close()
-        await queue.close()
-        return
+    # Which engine this worker drives, stated before anything else uses it. Per AGENTS.md the
+    # expensive failure here is silence: a worker on the wrong engine still produces plausible
+    # output that is not comparable to anything.
+    logger.info("ENGINE=%s", settings.engine)
+
+    # Pre-flight: validate all required models.
+    #
+    # MODEL_CHECKS describes the WAN 2.2 model set, so it is meaningless for an LTX worker and
+    # would refuse a perfectly good one. ltx-engine validates its own models at startup, and
+    # the LTX health gate below will not let this worker claim until it is up — so an LTX
+    # worker is checked, just by the service that knows what to check for.
+    # Replacing MODEL_CHECKS with the LTX set is wanly-gpu-docker#41.
+    if settings.engine == "ltx":
+        logger.info("Skipping WAN model validation — ltx-engine validates its own models")
+    else:
+        models_ok = await validate_models(comfyui)
+        if not models_ok:
+            logger.error("Model validation failed. Exiting.")
+            await comfyui.close()
+            await queue.close()
+            return
 
     # Log GPU/VRAM info
     system_info = await comfyui.get_system_info()

--- a/daemon/schemas.py
+++ b/daemon/schemas.py
@@ -51,6 +51,11 @@ class SegmentClaim(BaseModel):
     sampler_name: Optional[str] = None       # KSampler sampler (None/"" -> daemon default euler)
     scheduler: Optional[str] = None          # KSampler scheduler (None/"" -> simple)
     negative_prompt: Optional[str] = None
+    # LTX recipe render: the RESOLVED (character, pose) configuration, passed through by the
+    # API. Never looked up here — an engine that cannot look a recipe up cannot look up a
+    # STALE one, which is the failure this shape exists to prevent (wanly-api#207).
+    # None means "not a recipe render"; an LTX free-form render is prompt-only.
+    ltx_recipe: Optional[dict] = None
     reprocess_type: Optional[str] = None
     output_path: Optional[str] = None
     # Retired engine selectors, still sent by wanly-api on older jobs. Kept on the schema so

--- a/tests/test_ltx_routing.py
+++ b/tests/test_ltx_routing.py
@@ -1,0 +1,69 @@
+"""Which engine a worker drives, and when it declines to claim.
+
+ENGINE is a property of the WORKER — which models and services its container actually has —
+not of the job. Deciding per segment instead would let a worker with no ltx-engine claim an
+LTX render on the strength of a field and then fail it, and a failed segment is not free: it
+needs a human to notice and retry.
+"""
+
+import ast
+from pathlib import Path
+
+
+def _source(path: str) -> str:
+    return Path(path).read_text()
+
+
+def test_ltx_route_is_selected_by_config_not_by_the_segment():
+    """The branch must read settings.engine, never segment.ltx_recipe.
+
+    Routing on the presence of a recipe would also misroute a free-form LTX render, which
+    legitimately has no recipe at all.
+    """
+    src = _source("daemon/executor.py")
+    tree = ast.parse(src)
+    dispatch = next(
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.AsyncFunctionDef) and n.name == "execute_segment"
+    )
+    branch = next(
+        (n for n in ast.walk(dispatch)
+         if isinstance(n, ast.Compare)
+         and isinstance(n.left, ast.Attribute) and n.left.attr == "engine"),
+        None,
+    )
+    assert branch is not None, "execute_segment does not branch on settings.engine"
+
+
+def test_default_engine_is_wan_so_merging_this_changes_no_running_worker():
+    """start.sh git-pulls the daemon on EVERY boot.
+
+    A default of "ltx" here would therefore retarget any existing worker the moment it
+    restarted, pointing it at an ltx-engine its container does not run. The LTX image sets
+    ENGINE explicitly instead (wanly-gpu-docker#41).
+    """
+    from daemon.config import Settings
+    assert Settings().engine == "wan22"
+
+
+def test_ltx_worker_does_not_claim_while_the_engine_is_down():
+    """Claiming work this worker cannot render burns the segment."""
+    src = _source("daemon/main.py")
+    assert "_ltx_healthy" in src
+    poll = src.split("async def job_poll_loop")[1]
+    gate = poll.index("_ltx_healthy()")
+    claim = poll.index("queue.claim_next")
+    assert gate < claim, "the ltx-engine health gate must precede the claim, not follow it"
+
+
+def test_wan_model_validation_is_skipped_for_an_ltx_worker():
+    """MODEL_CHECKS describes the WAN 2.2 model set.
+
+    Running it against an LTX worker would refuse a perfectly good one at boot. Replacing the
+    set is wanly-gpu-docker#41; until then it is skipped, and the health gate above is what
+    keeps an unready LTX worker from claiming.
+    """
+    src = _source("daemon/main.py")
+    assert 'settings.engine == "ltx"' in src
+    head = src.index('if settings.engine == "ltx":')
+    assert src.index("validate_models(comfyui)", head) > head

--- a/tests/test_ltx_submit.py
+++ b/tests/test_ltx_submit.py
@@ -1,0 +1,90 @@
+"""What the daemon asks ltx-engine for.
+
+Pure-logic tests over build_submit_payload. The interesting failures here are all silent:
+every one of them still returns a perfectly plausible video, just not the one that was
+validated — which is exactly the class of bug the graph hash exists to catch, and which is
+worth catching one layer earlier.
+"""
+
+from daemon.ltx_client import build_submit_payload
+
+RECIPE = {
+    "recipe": "Missionary POV",
+    "character": "k3lly2026",
+    "char_lora": "k3lly2026_v2",
+    "char_s1": 0.8,
+    "char_s2": 1.5,
+    "frames": 241,
+    "graph_sha256": "85649768667ba700fdd75643be3ba031",
+}
+
+
+def _payload(**over):
+    args = dict(
+        image_bytes=None, prompt="a prompt", negative_prompt="bad things",
+        width=768, height=1344, num_frames=241, frame_rate=24, seed=42, recipe=RECIPE,
+    )
+    args.update(over)
+    return build_submit_payload(**args)
+
+
+def test_character_lora_is_sent_per_stage_not_flat():
+    """0.8/1.5 is the validated split; one number for both stages is a different config.
+
+    Stage 1 generates at half size from noise and stage 2 refines the 2x-upscaled latent, so
+    the two are not interchangeable. Collapsing them renders something that looks fine and is
+    not the signed-off configuration.
+    """
+    lora = _payload()["loras"][0]
+    assert lora["name"] == "k3lly2026_v2"
+    assert lora["strength_stage_1"] == 0.8
+    assert lora["strength_stage_2"] == 1.5
+
+
+def test_graph_hash_is_never_sent_back_to_the_engine():
+    """graph_sha256 is a record of what ran, not an input.
+
+    Sending it back would offer the engine a hash to honour rather than one to produce,
+    inverting the point of hashing the resolved graph — the check would then confirm that we
+    told it what to say.
+    """
+    assert "graph_sha256" not in _payload()
+
+
+def test_recipe_and_character_are_passed_through():
+    p = _payload()
+    assert p["recipe"] == "Missionary POV"
+    assert p["character"] == "k3lly2026"
+
+
+def test_seed_is_narrowed_to_what_the_engine_accepts():
+    """The queue derives 63-bit seeds; the engine takes signed 32-bit.
+
+    Narrowed here so the engine never has to reject or silently wrap it — a wrapped seed
+    reproduces a different clip from the number recorded beside it.
+    """
+    assert _payload(seed=2**62 + 7)["seed"] < 2**31 - 1
+
+
+def test_free_form_render_sends_no_recipe_fields():
+    p = _payload(recipe=None)
+    assert "recipe" not in p and "character" not in p and "loras" not in p
+    assert p["prompt"] == "a prompt"
+
+
+def test_partial_recipe_does_not_produce_a_half_configured_lora():
+    """A recipe missing a strength must send NO lora, not one with a guessed strength.
+
+    Defaulting the missing half would render at a strength nobody chose and report success.
+    """
+    assert "loras" not in _payload(recipe={**RECIPE, "char_s2": None})
+    assert "loras" not in _payload(recipe={**RECIPE, "char_lora": None})
+
+
+def test_start_frame_becomes_a_data_uri_keyframe():
+    p = _payload(image_bytes=b"\x89PNG\r\n\x1a\n" + b"0" * 32)
+    assert p["keyframes"][0]["image"].startswith("data:image/png;base64,")
+
+
+def test_no_start_frame_is_an_empty_keyframe_list():
+    assert _payload(image_bytes=None)["keyframes"] == []


### PR DESCRIPTION
The daemon can now render a segment on LTX 2.3. The claim half is untouched; only execution changes.

Refs #146

## The daemon does not build LTX graphs

ltx-engine already owns graph assembly and recipe resolution, and that stays put. Every structural bug on the storyboard project came from rewriting a downloaded graph's topology in a caller to cover a job shape it was not built for; none came from the reference workflows. So the engine keeps the graph, the daemon keeps the queue, and they talk over `localhost:8190`.

```
ltx-engine container
  ComfyUI          :8188   background
  ltx-engine API   :8190   background   <- graph + recipe assembly
  wanly-gpu-daemon         foreground   <- this PR
```

## Same either side, different only in the middle

`ltx_executor.py` is its own module rather than a branch inside `executor.py`, so retiring WAN is deleting files rather than unpicking merged functions.

What differs is only the middle. Everything around it is deliberately identical — the start image still comes from the queue, and the finished mp4 still gets its last frame extracted, motion measured, identity scored and bytes uploaded through the same calls. **That is what makes an LTX render show up in Videos, carry identity chips and accept observations** without any of that machinery knowing which engine produced it.

## Merging this changes no running worker

`ENGINE` defaults to `wan22`. `start.sh` git-pulls this daemon on **every** boot, so a default of `ltx` would retarget every existing worker the moment it restarted, pointing it at an engine its container does not run. The LTX image sets `ENGINE=ltx` explicitly instead (wanly-gpu-docker#41).

Selection is by worker config, never by inspecting the segment. Which engine a worker can drive is a property of its container, not of the job — and a free-form LTX render legitimately carries no recipe to inspect anyway.

## Not claiming what it cannot render

An LTX worker declines to claim while ltx-engine is down. Claiming work it cannot render *burns* the segment: it fails, and a failed segment needs a human to notice and retry, where leaving it queued costs nothing.

WAN model validation is skipped for an LTX worker — `MODEL_CHECKS` describes the WAN model set and would refuse a perfectly good worker at boot. The health gate covers it until #41 replaces the set.

## Two details worth the comments they got

**Seed narrowing.** The queue derives 63-bit seeds; the engine takes signed 32-bit. Narrowed here, because a silently wrapped seed reproduces a different clip from the number recorded beside it.

**`graph_sha256` is never sent back.** It is a record of what ran, not an input. Returning it would offer the engine a hash to honour rather than one to produce, which inverts the entire point of hashing the resolved graph — the check would then confirm that we told it what to say.

## Verification

Payload construction is a pure function so it can be asserted without an engine. Every failure it guards is **silent** — each still returns a plausible video, just not the validated one.

Proven against broken code, not just green:

| break | caught by |
|---|---|
| per-stage strengths flattened to one number | `assert 0.8 == 1.5` |
| `graph_sha256` leaked into the payload | `assert 'graph_sha256' not in {...}` |
| health gate moved after the claim | `the ltx-engine health gate must precede the claim` |

148 passed. Both new modules mypy-clean (the 76 pre-existing errors elsewhere are untouched).

**Not exercised against a real engine.** No LTX render has gone through the queue yet — ltx-engine was down throughout (a LoRA training run holds the GPU). The submit payload, poll loop and video fetch are all unverified against the live service, and that is the next thing to do once the card frees up.

## Note

`daemon/workflow_builder.py` and `tests/test_seed_reanchor.py` have uncommitted changes in the working tree from an in-flight faceswap experiment ("ARM A", `hyperswap_1c_256`). Not mine and not included here.