### PR TITLE
Send the LoRA filename, not the bare name

### DIFF
--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -74,6 +74,17 @@ def build_submit_payload(
         lora = recipe.get("char_lora")
         s1, s2 = recipe.get("char_s1"), recipe.get("char_s2")
         if lora and s1 is not None and s2 is not None:
+            # The engine matches LoRAs by EXACT filename. Its own recipe path appends the
+            # extension; the explicit-lora path this uses does not. Names arrive bare because
+            # that is how the recipe sheet wrote them and how the console displays them, so a
+            # real render died on `no such lora 'pay_v2_e05'` while 'pay_v2_e05.safetensors'
+            # sat in the very list the error printed.
+            #
+            # Normalised here, at the boundary that talks to the engine, rather than in the
+            # database: what a LoRA is CALLED is a display concern and what file it IS is the
+            # engine's, and everything in between should not have to agree on the extension.
+            if not lora.endswith(".safetensors"):
+                lora = f"{lora}.safetensors"
             # Per-stage, never flat. Stage 1 generates at half size from noise and stage 2
             # refines the 2x-upscaled latent; the validated recipe runs 0.8 then 1.5, and
             # collapsing them to one number is a different configuration.

--- a/tests/test_ltx_routing.py
+++ b/tests/test_ltx_routing.py
@@ -43,7 +43,10 @@ def test_default_engine_is_wan_so_merging_this_changes_no_running_worker():
     ENGINE explicitly instead (wanly-gpu-docker#41).
     """
     from daemon.config import Settings
-    assert Settings().engine == "wan22"
+    # The FIELD default, not Settings(): instantiating reads .env, so this asserted whatever
+    # the local worker happened to be configured as. It passed in CI and failed on any box
+    # with a real .env — a test that measures the environment instead of the code.
+    assert Settings.model_fields["engine"].default == "wan22"
 
 
 def test_ltx_worker_does_not_claim_while_the_engine_is_down():

--- a/tests/test_ltx_submit.py
+++ b/tests/test_ltx_submit.py
@@ -36,7 +36,7 @@ def test_character_lora_is_sent_per_stage_not_flat():
     not the signed-off configuration.
     """
     lora = _payload()["loras"][0]
-    assert lora["name"] == "k3lly2026_v2"
+    assert lora["name"] == "k3lly2026_v2.safetensors"
     assert lora["strength_stage_1"] == 0.8
     assert lora["strength_stage_2"] == 1.5
 
@@ -88,3 +88,48 @@ def test_start_frame_becomes_a_data_uri_keyframe():
 
 def test_no_start_frame_is_an_empty_keyframe_list():
     assert _payload(image_bytes=None)["keyframes"] == []
+
+
+def test_strengths_arrive_as_strings_from_the_sheet_and_are_coerced():
+    """GET /recipes returns char_s1/char_s2 as STRINGS — '0.8', not 0.8.
+
+    Verified against the live engine on 2026-08-31. The recipe sheet is the source of truth
+    and its cells serialise as text, so the blob stored on the segment carries strings. Sent
+    unconverted they would reach the engine as strings too; float() here is load-bearing, not
+    defensive tidying.
+    """
+    lora = _payload(recipe={**RECIPE, "char_s1": "0.8", "char_s2": "1.5"})["loras"][0]
+    assert lora["strength_stage_1"] == 0.8
+    assert lora["strength_stage_2"] == 1.5
+    assert isinstance(lora["strength_stage_2"], float)
+
+
+def test_payload_keys_match_the_engines_request_model():
+    """Every key must exist on ltx-engine's JobRequest.
+
+    Checked against the live /openapi.json on 2026-08-31: 27 fields, only `keyframes`
+    required, and nothing the daemon sends is rejected. This encodes the field NAMES so a
+    rename on either side shows up here rather than as a 422 ten minutes into a render.
+    """
+    engine_job_request_fields = {
+        "prompt", "negative_prompt", "loras", "workflow", "checkpoint", "cfg",
+        "multimodal_guidance", "stg", "rescale", "stg_blocks", "cfg_stage_1", "cfg_stage_2",
+        "distilled_lora_strength", "steps_stage_1", "steps_stage_2", "recipe", "character",
+        "keyframes", "width", "height", "num_frames", "frame_rate", "seed", "snap_indices",
+    }
+    assert set(_payload()) <= engine_job_request_fields
+
+
+def test_lora_name_is_sent_with_its_file_extension():
+    """The engine matches LoRAs by exact filename.
+
+    A real render failed with `no such lora 'pay_v2_e05'` while
+    'pay_v2_e05.safetensors' sat in the list the error itself printed. Names arrive bare
+    because that is how the recipe sheet wrote them and how the console displays them.
+    """
+    assert _payload()["loras"][0]["name"] == "k3lly2026_v2.safetensors"
+
+
+def test_an_already_qualified_name_is_not_double_suffixed():
+    lora = _payload(recipe={**RECIPE, "char_lora": "k3lly2026_v2.safetensors"})["loras"][0]
+    assert lora["name"] == "k3lly2026_v2.safetensors"


### PR DESCRIPTION
The first end-to-end recipe render through the queue failed on this:

```
422: no such lora 'pay_v2_e05'
Available: [... 'pay_v2_e05.safetensors' ...]
```

The file was in the very list the error printed.

## Cause

The engine matches LoRAs by **exact filename**. Its own recipe path appends `.safetensors`; the explicit-lora path the daemon uses does not. Names arrive bare because that's how the recipe sheet wrote them and how the console displays them.

Normalised at the boundary that talks to the engine, not in the database — what a LoRA is *called* is a display concern, what file it *is* is the engine's, and nothing in between should have to agree about the extension.

## A test that measured the environment

`test_default_engine_is_wan` asserted `Settings().engine`, and instantiating `Settings` reads `.env` — so it asserted whatever the local worker happened to be configured as. Green in CI, red on any box with a real `.env`. Now asserts the field default.

## Verification

Deleted the normalisation and watched the guard fail: `'k3lly2026_v2' != 'k3lly2026_v2.safetensors'`. 152 passed.

## Context

Everything else in that run worked — the form created a job, it entered the queue, the worker claimed it, pulled a 1.1 MB start image from S3, and submitted to the engine. This was the last step.