### PR TITLE
The result upload was gated on a metric

### DIFF
--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -124,7 +124,14 @@ class QueueClient:
             _raise_with_details(resp, f"upload_segment_output {segment_id}")
         logger.info("Uploaded segment output via API for %s", segment_id)
 
-        if result and result.motion_magnitude:
+        # Unconditional. This was `if result and result.motion_magnitude:` — the segment's
+        # status update rode on a metric being truthy, so a render whose motion happened to
+        # measure 0.0 never got its result sent at all. Removing motion analysis (#151) turned
+        # that latent bug into an AttributeError on every completed segment.
+        #
+        # `result` carries the status. Whether any metric was produced has nothing to do with
+        # whether the segment finished.
+        if result:
             await self.update_segment(segment_id, result)
 
     async def upload_hologram_output(

--- a/tests/test_event_loop_not_blocked.py
+++ b/tests/test_event_loop_not_blocked.py
@@ -67,3 +67,34 @@ def test_the_modules_are_not_imported_anywhere_in_the_daemon():
         assert "import identity_score" not in src, f"{f.name} imports identity_score"
         assert "import motion_analyzer" not in src, f"{f.name} imports motion_analyzer"
         assert "from daemon.motion_analyzer" not in src, f"{f.name} imports motion_analyzer"
+
+
+def test_uploading_a_result_is_not_gated_on_any_metric():
+    """The segment's status update must not depend on a measurement existing.
+
+    It used to read `if result and result.motion_magnitude:` — so a render whose motion
+    measured 0.0 never had its result sent, and the segment sat un-updated. Removing the
+    metrics turned that latent bug into an AttributeError on every completed segment.
+
+    Whether a metric was produced has nothing to do with whether the segment finished.
+    """
+    import inspect
+    import textwrap
+    from daemon import queue_client
+
+    # Parsed, not grepped: the explanatory comment in that function names the very attribute
+    # this asserts absent, so a text search matches its own documentation.
+    src = textwrap.dedent(inspect.getsource(queue_client.QueueClient.upload_segment_output))
+    fn = ast.parse(src).body[0]
+    guards = [n.test for n in ast.walk(fn) if isinstance(n, ast.If)]
+    for test in guards:
+        names = {
+            getattr(a, "attr", "") for a in ast.walk(test) if isinstance(a, ast.Attribute)
+        }
+        assert not (names & {"motion_magnitude"}), (
+            "the result upload is gated on a metric again — status has nothing to do with "
+            "whether a measurement was produced"
+        )
+        assert not any(n.startswith("identity_") for n in names), (
+            "the result upload is gated on an identity metric"
+        )


### PR DESCRIPTION
Live failure on a real render:

```
AttributeError: 'SegmentResult' object has no attribute 'motion_magnitude'
```

## Cause

`queue_client.upload_segment_output` read:

```python
if result and result.motion_magnitude:
    await self.update_segment(segment_id, result)
```

The segment's **status** update rode on a measurement being truthy. That was already a bug — a render whose motion happened to measure `0.0` never had its result sent, and the segment sat un-updated with no error anywhere. Removing motion analysis (#151) turned a latent bug into an immediate one.

**Mine.** I removed the field after grepping the executors and schemas and didn't check every reader. This was the reader I missed.

Now unconditional. `result` carries the status; whether a metric was produced has nothing to do with whether the segment finished.

## The guard parses rather than greps

The comment explaining this fix names the very attribute the test asserts absent, so the first version of the test failed against its own documentation. It now walks the AST of the function and checks the `if` conditions for metric attributes.

Verified by reintroducing the gate and watching it fail. 108 passed.