### PR TITLE
An LTX worker must not clear ComfyUI's queue at startup

### DIFF
--- a/daemon/main.py
+++ b/daemon/main.py
@@ -440,12 +440,26 @@ async def run():
         a1111_stat["a1111_running"],
     )
 
-    # Clear any orphaned ComfyUI queue items from previous daemon runs
-    if comfyui_running:
+    # Clear any orphaned ComfyUI queue items from previous daemon runs.
+    #
+    # NEVER on the LTX path. There, ltx-engine owns ComfyUI's queue — it patches the workflow,
+    # submits, and polls for its own job — so a daemon restarting mid-render would clear that
+    # job out from under it. There is one GPU and one queue, and clearing it kills whatever is
+    # actually rendering; the right way to remove something is to delete a specific pending
+    # item by prompt id.
+    #
+    # The damage would also be invisible from here: the engine reports its job failed or
+    # vanished, and the daemon never learns it caused that. A worker restart is exactly when
+    # someone is already debugging something else.
+    #
+    # Under WAN the daemon DID own the queue, so the clear was correct there and stays.
+    if comfyui_running and settings.engine != "ltx":
         if await comfyui.clear_queue():
             logger.info("Cleared ComfyUI queue")
         else:
             logger.warning("Failed to clear ComfyUI queue")
+    elif comfyui_running:
+        logger.info("Not clearing the ComfyUI queue — ltx-engine owns it")
 
     # Check and install required ComfyUI custom nodes
     nodes_ok = await check_and_install_nodes(comfyui)

--- a/tests/test_ltx_routing.py
+++ b/tests/test_ltx_routing.py
@@ -70,3 +70,31 @@ def test_wan_model_validation_is_skipped_for_an_ltx_worker():
     assert 'settings.engine == "ltx"' in src
     head = src.index('if settings.engine == "ltx":')
     assert src.index("validate_models(comfyui)", head) > head
+
+
+def test_an_ltx_worker_does_not_clear_comfyuis_queue_at_startup():
+    """ltx-engine owns ComfyUI's queue on the LTX path.
+
+    The daemon clearing it at startup would kill whatever the engine is rendering — there is
+    one GPU and one queue, and a wholesale clear takes the in-flight job with it. The damage
+    is invisible from the daemon's side too: the engine reports its job failed, and nothing
+    connects that to a worker restart.
+
+    Under WAN the daemon DID own the queue, so the clear was correct there and stays.
+    """
+    src = _source("daemon/main.py")
+    tree = ast.parse(src)
+    guarded = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        # the clear_queue call has to sit under a test that mentions the engine
+        body = ast.dump(ast.Module(body=node.body, type_ignores=[]))
+        if "clear_queue" not in body:
+            continue
+        if "engine" in ast.dump(node.test):
+            guarded = True
+    assert guarded, (
+        "clear_queue at startup is not gated on settings.engine — an LTX worker restarting "
+        "mid-render would clear the engine's job out from under it"
+    )


### PR DESCRIPTION
Seen in the boot log of the first LTX worker:

```
12:28:49 INFO Cleared ComfyUI queue
```

Harmless that time — the GPU was idle. But on the LTX path **ltx-engine owns ComfyUI's queue**: it patches the workflow, submits, and polls for its own job. A daemon restarting mid-render clears that job out from under it.

There's one GPU and one queue, and a wholesale clear kills whatever is actually rendering. The right way to remove something is to delete a specific pending item by prompt id.

**The damage would be invisible from the daemon's side.** The engine reports its job failed or vanished, and nothing connects that to a worker restart — which is exactly when someone is already debugging something else.

## Gated, not removed

Under WAN the daemon *did* own the queue, so the clear was correct there and stays.

## Guard

Walks `main.py`'s AST for a `clear_queue` call and asserts it sits under a test that mentions the engine — rather than string-matching, which would pass on a comment.

Verified by removing the gate and watching it fail. 109 passed.

Closes #148