### PR TITLE
feat: forward img_compression to the engine

### DIFF
--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -71,6 +71,11 @@ def build_submit_payload(
         for key in ("recipe", "character"):
             if recipe.get(key):
                 payload[key] = recipe[key]
+        # `is not None`, not truthiness: img_compression 0 is a real setting — it bypasses
+        # the conditioning-frame encode — and a falsy check would drop it, leaving the engine
+        # on its workflow default while the pose said otherwise.
+        if recipe.get("img_compression") is not None:
+            payload["img_compression"] = int(recipe["img_compression"])
         lora = recipe.get("char_lora")
         s1, s2 = recipe.get("char_s1"), recipe.get("char_s2")
         if lora and s1 is not None and s2 is not None:


### PR DESCRIPTION
Third hop of wanly-api#235. The API resolves it into the `ltx_recipe` blob and the engine applies it; this passes it across, alongside `recipe` and `character`.

`is not None` again: **0 bypasses the conditioning-frame encode** and is exactly the setting a falsy check drops, leaving the engine on its workflow default while the pose said otherwise.

Verified: 0 survives the payload, 4 is forwarded, the key is absent when the pose has no override, and `graph_sha256` is still never echoed back.

https://claude.ai/code/session_01QbfxnoQgRx4bZX4MZgFntG