### PR TITLE
loras: sync the catalogue at boot, diffing on content not filenames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+# The daemon had no test CI at all until now — 85 tests that ran only when someone
+# remembered to run them. This repo is the one that has caused most of the production
+# incidents, and every one of them was a name that did not resolve at request time or a
+# path nobody exercised. Tests that only run by hand are tests that do not run.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      # The daemon's runtime deps include torch and insightface, which are enormous and
+      # need a GPU image to be meaningful. The tests do not touch them — they exercise
+      # routing, parsing and sync logic against fakes — so CI installs only what the suite
+      # actually imports. If a test ever needs the real stack, it belongs on a GPU runner,
+      # not here.
+      # This list was derived by running the suite in a clean venv until it went green,
+      # not by reading imports — two guesses were wrong. opencv is the HEADLESS build on
+      # purpose: plain opencv-python needs libGL, which a bare runner does not have.
+      - name: Install test dependencies
+        run: |
+          pip install pytest pytest-asyncio httpx pydantic pydantic-settings \
+                      numpy pillow websockets opencv-python-headless pyyaml
+
+      - name: Test
+        run: python -m pytest -q
+
+      # Undefined names are the single failure class that has cost this project the most:
+      # three production 500s this month, each one a name that imported fine and blew up at
+      # request time. Ruff catches them statically in under a second. Same guard as
+      # wanly-api, for the same reason.
+      - name: No undefined names
+        run: |
+          pip install "ruff>=0.5"
+          python -m ruff check --select F821 --output-format concise daemon/

--- a/daemon/lora_sync.py
+++ b/daemon/lora_sync.py
@@ -4,6 +4,7 @@ Only downloads files that are missing locally. Files are cached forever.
 Uses atomic writes (.tmp → rename) to prevent corrupt partial files.
 """
 
+import hashlib
 import logging
 import os
 
@@ -91,3 +92,137 @@ async def ensure_loras_available(
                 f.write(data)
             os.rename(tmp_path, local_path)
             logger.info("       %s: %s saved (%.1f MB)", label, filename, mb)
+
+
+# ---------------------------------------------------------------------------
+# Catalogue sync: hold every LoRA the bucket has, not just the one a claim named.
+#
+# ensure_loras_available() above is the WAN-era, pull-on-demand path: it fetches what a
+# claimed segment names, and skips anything already on disk WITH THAT NAME. The LTX path
+# never had an equivalent at all, so an LTX worker could only ever use whatever happened to
+# be baked onto its volume — which is why a fresh pod renders nothing with a character.
+#
+# The trap this fixes, and the reason the diff is on content and not on names: LoRAs get
+# RETRAINED and republished under the same name. k3lly2026_v2 today is not the file that
+# name meant last week. A name-only check calls that a hit, keeps the old weights, and the
+# worker renders the wrong character while the console shows the right one — wrong output
+# rather than a failure, which is the expensive kind.
+# ---------------------------------------------------------------------------
+
+
+def _local_md5(path: str) -> str:
+    digest = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _needs_download(local_path: str, remote: dict) -> str | None:
+    """Return a human reason to download, or None when the local copy is already right.
+
+    The reason is returned rather than logged here so the caller can put it in one line
+    per LoRA — when this goes wrong on a pod, the question is always "why did it decide
+    to (not) fetch this one", and the answer should be in the log without a rerun.
+    """
+    if not os.path.exists(local_path):
+        return "missing"
+
+    size = os.path.getsize(local_path)
+    if size < MIN_LORA_SIZE:
+        return f"local copy is only {size / (1024 * 1024):.1f} MB — truncated"
+
+    if remote.get("multipart"):
+        # A multipart ETag is "<md5-of-md5s>-<partcount>", not the md5 of the content, so
+        # there is nothing to compare it against. Falling back to size keeps us from
+        # re-downloading the same file on every single sync, forever; it also cannot catch
+        # a retrain that happened to land on the same byte count. Say so, out loud, rather
+        # than let a silent weaker check look like the strong one.
+        if size != remote["size"]:
+            return f"size {size} != remote {remote['size']}"
+        logger.warning(
+            "       %s: multipart ETag — verified by SIZE ONLY, a same-size retrain "
+            "would not be detected", os.path.basename(local_path),
+        )
+        return None
+
+    if size != remote["size"]:
+        return f"size {size} != remote {remote['size']}"
+
+    local = _local_md5(local_path)
+    if local != remote["etag"]:
+        return f"content changed (local md5 {local[:12]}, remote {remote['etag'][:12]})"
+
+    return None
+
+
+async def sync_lora_catalog(queue: QueueClient) -> bool:
+    """Diff the local LoRA directory against the bucket and fetch what differs.
+
+    Returns True when the local set matches the catalogue. Deliberately NOT fatal to boot:
+    a worker that exits here restart-loops, and a restart loop on a rented pod costs real
+    money and is miserable to diagnose (we have already lost an hour to one). A worker with
+    a missing LoRA fails the segment that needs it, loudly, with the name in the error —
+    which is a better failure than no worker at all.
+    """
+    lora_dir = _loras_dir()
+    os.makedirs(lora_dir, exist_ok=True)
+
+    try:
+        catalog = await queue.list_loras()
+    except Exception as e:
+        logger.error("LoRA sync: could not list the catalogue (%s) — keeping what is on disk", e)
+        return False
+
+    logger.info("LoRA sync: %d in the catalogue, checking %s", len(catalog), lora_dir)
+
+    ok = True
+    fetched = 0
+    for remote in catalog:
+        name = remote["name"]
+        local_path = os.path.join(lora_dir, name)
+        _cleanup_partials(lora_dir, name)
+
+        reason = _needs_download(local_path, remote)
+        if reason is None:
+            logger.info("       %s: current", name)
+            continue
+
+        logger.info("       %s: %s — downloading", name, reason)
+        tmp_path = local_path + ".tmp"
+        try:
+            got = await queue.stream_file(remote["uri"], tmp_path)
+        except Exception as e:
+            logger.error("       %s: download failed: %s", name, e)
+            ok = False
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)
+            continue
+
+        # Verify BEFORE the rename, so a bad transfer can never take the place of a good
+        # local copy. The .tmp is dropped and whatever was there is left alone.
+        if not remote.get("multipart") and got != remote["etag"]:
+            logger.error(
+                "       %s: md5 mismatch after download (got %s, expected %s) — discarding",
+                name, got[:12], remote["etag"][:12],
+            )
+            os.remove(tmp_path)
+            ok = False
+            continue
+
+        size = os.path.getsize(tmp_path)
+        if size != remote["size"]:
+            logger.error(
+                "       %s: size mismatch after download (got %d, expected %d) — discarding",
+                name, size, remote["size"],
+            )
+            os.remove(tmp_path)
+            ok = False
+            continue
+
+        os.rename(tmp_path, local_path)
+        fetched += 1
+        logger.info("       %s: saved (%.1f MB)", name, size / (1024 * 1024))
+
+    logger.info("LoRA sync: %d fetched, %d already current", fetched, len(catalog) - fetched)
+    return ok

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -12,6 +12,7 @@ from daemon.model_validator import cleanup_partial_downloads, validate_models
 from daemon.node_checker import check_and_install_nodes
 from daemon.queue_client import QueueClient
 from daemon.gpu_stats import get_gpu_stats
+from daemon.lora_sync import sync_lora_catalog
 from daemon.resource_sync import sync_resources
 from daemon.sd_scripts_monitor import get_status as get_sd_scripts_status
 from daemon.a1111_monitor import get_status as get_a1111_status
@@ -476,6 +477,16 @@ async def run():
         await comfyui.close()
         await queue.close()
         return
+
+    # Pre-flight: pull down any character LoRA this worker does not already hold.
+    #
+    # Before the GPU loop starts, so a fresh pod is useful on its first claim instead of
+    # failing the first character segment it is handed. Non-fatal by design — see
+    # sync_lora_catalog(): a restart loop is a worse failure than a missing LoRA.
+    if not await sync_lora_catalog(queue):
+        logger.warning(
+            "LoRA sync incomplete — this worker may fail segments that name a missing LoRA"
+        )
 
     # Pre-flight: clean up partial downloads
     cleaned = cleanup_partial_downloads(settings.comfyui_path)

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import logging
 import uuid
 from typing import Optional
@@ -201,6 +202,46 @@ class QueueClient:
         )
 
     # --- Worker registry methods (formerly in RegistryClient) ---
+
+    async def list_loras(self) -> list[dict]:
+        """Every character LoRA the API can serve, so this worker can diff against its disk.
+
+        Workers hold no AWS credentials on purpose, so they cannot list the bucket
+        themselves — the API does it for them. Returns [{name, size, etag, multipart, uri}].
+        """
+        resp = await self._request_with_retry("GET", "/loras", timeout=30)
+        if not resp.is_success:
+            _raise_with_details(resp, "list_loras")
+        return resp.json()
+
+    async def stream_file(self, s3_path: str, dest: str) -> str:
+        """Download to `dest`, returning the md5 of what actually landed.
+
+        Streams rather than using download_file(): that returns bytes, and a 700 MB LoRA
+        held whole in RAM on a pod sized for the GPU rather than the CPU is a needless way
+        to get OOM-killed. Hashing during the stream is free here and is what lets the
+        caller verify content instead of trusting the filename.
+
+        Same granular timeout as download_file: `read` caps the gap between chunks, so a
+        stall fails in ~60s while a slow-but-steady transfer of any size still completes.
+        """
+        timeout = httpx.Timeout(connect=15.0, read=60.0, write=60.0, pool=15.0)
+        digest = hashlib.md5()
+        total = 0
+        with open(dest, "wb") as f:
+            async with self.client.stream(
+                "GET", "/files", params={"path": s3_path},
+                timeout=timeout, follow_redirects=True,
+            ) as resp:
+                if not resp.is_success:
+                    await resp.aread()
+                    _raise_with_details(resp, f"stream_file {s3_path}")
+                async for chunk in resp.aiter_bytes(1024 * 1024):
+                    f.write(chunk)
+                    digest.update(chunk)
+                    total += len(chunk)
+        logger.info("       streamed %.1f MB from %s", total / (1024 * 1024), s3_path)
+        return digest.hexdigest()
 
     async def register(
         self,

--- a/tests/test_lora_catalog_sync.py
+++ b/tests/test_lora_catalog_sync.py
@@ -1,0 +1,123 @@
+"""The LoRA catalogue diff — what makes a worker fetch, skip, or refuse a file.
+
+The behaviour worth protecting is the retrain case. LoRAs are republished under the SAME
+name after retraining, so a name-only check keeps the old weights and the worker renders
+the wrong character while the console shows the right one. That is wrong output rather
+than a failure, so it is the one this file guards hardest.
+"""
+import hashlib
+import os
+
+import pytest
+
+from daemon import lora_sync
+
+BIG = 20 * 1024 * 1024  # comfortably over MIN_LORA_SIZE
+
+
+def _write(path, payload: bytes, size=BIG):
+    with open(path, "wb") as f:
+        f.write(payload + b"\0" * (size - len(payload)))
+    return hashlib.md5(open(path, "rb").read()).hexdigest()
+
+
+class FakeQueue:
+    """Records what was asked for, and writes whatever content it was configured with."""
+
+    def __init__(self, catalog, content=b"NEW"):
+        self.catalog = catalog
+        self.content = content
+        self.downloaded = []
+
+    async def list_loras(self):
+        return self.catalog
+
+    async def stream_file(self, uri, dest):
+        self.downloaded.append(uri)
+        return _write(dest, self.content)
+
+
+@pytest.fixture
+def lora_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(lora_sync, "_loras_dir", lambda: str(tmp_path))
+    return tmp_path
+
+
+async def test_a_retrain_under_the_same_name_is_detected_and_replaced(lora_dir):
+    """Same filename, same size, different bytes — the case a name check misses.
+
+    If this ever regresses the worker keeps rendering the previous character silently.
+    """
+    path = lora_dir / "k3lly2026_v2.safetensors"
+    _write(str(path), b"OLD-WEIGHTS")
+    new_md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+
+    q = FakeQueue([{
+        "name": "k3lly2026_v2.safetensors", "size": BIG,
+        "etag": new_md5, "multipart": False,
+        "uri": "s3://ltx-loras/k3lly2026_v2.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q) is True
+    assert q.downloaded == ["s3://ltx-loras/k3lly2026_v2.safetensors"]
+    assert open(path, "rb").read(3) == b"NEW"
+
+
+async def test_an_unchanged_lora_is_not_downloaded_again(lora_dir):
+    """Otherwise every boot re-pulls gigabytes over the wire for nothing."""
+    path = lora_dir / "p@y.safetensors"
+    md5 = _write(str(path), b"SAME")
+
+    q = FakeQueue([{
+        "name": "p@y.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/p@y.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q) is True
+    assert q.downloaded == []
+
+
+async def test_a_corrupt_download_never_replaces_a_good_local_copy(lora_dir):
+    """Verification happens on the .tmp, before the rename.
+
+    A transfer that truncates or flips bytes must leave the working file untouched — losing
+    a good LoRA to a bad network is not an acceptable outcome of a routine sync.
+    """
+    path = lora_dir / "k3llydw_v2.safetensors"
+    _write(str(path), b"GOOD-LOCAL")
+
+    q = FakeQueue([{
+        "name": "k3llydw_v2.safetensors", "size": BIG,
+        "etag": "0" * 32,  # will not match whatever the fake writes
+        "multipart": False, "uri": "s3://ltx-loras/k3llydw_v2.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q) is False   # reported, not swallowed
+    assert open(path, "rb").read(10) == b"GOOD-LOCAL"      # untouched
+    assert not os.path.exists(str(path) + ".tmp")          # and cleaned up
+
+
+async def test_a_multipart_etag_falls_back_to_size_instead_of_looping(lora_dir):
+    """A multipart ETag is not an md5, so comparing it as one never matches.
+
+    Treated as a hash it would re-download the same file on every sync forever.
+    """
+    path = lora_dir / "big.safetensors"
+    _write(str(path), b"WHATEVER")
+
+    q = FakeQueue([{
+        "name": "big.safetensors", "size": BIG, "etag": "abc-7",
+        "multipart": True, "uri": "s3://ltx-loras/big.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q) is True
+    assert q.downloaded == []
+
+
+async def test_an_unreachable_catalogue_leaves_the_disk_alone(lora_dir):
+    """The API being down must not delete or disturb LoRAs the worker already has."""
+    path = lora_dir / "k3lly2026_v2.safetensors"
+    _write(str(path), b"KEEP-ME")
+
+    class Broken(FakeQueue):
+        async def list_loras(self):
+            raise RuntimeError("connection refused")
+
+    assert await lora_sync.sync_lora_catalog(Broken([])) is False
+    assert open(path, "rb").read(7) == b"KEEP-ME"


### PR DESCRIPTION
The worker half of console#393. Pairs with wanly-api#feat/lora-sync-endpoint.

**The gap.** The LTX path had no LoRA sync at all. `ensure_loras_available()` is the WAN-era pull-on-demand path and `ltx_executor.py` never called it — so an LTX worker could only use what happened to be baked onto its volume. That is why a fresh pod renders nothing with a character.

**What this does**, per the design on #393: list what the bucket has, compare against the local dir, download the difference. Runs at boot, before the GPU loop, so a fresh pod is useful on its first claim.

**The comparison is on content.** Size first as a cheap reject, then md5 against the etag. Not the filename: a retrain republished under the same name is a false hit that silently keeps old weights. Not size alone: two of the three LoRAs in the bucket right now are exactly the same byte count and are different people.

Where the etag is multipart it isn't an md5 and can't be compared, so that case falls back to size and **says so in the log** rather than letting a weaker check pass for the strong one.

**Downloads are verified before the rename.** Stream to `.tmp`, check md5 and size, then rename. A truncated transfer can never replace a working local file — losing a good LoRA to a bad network is not an acceptable outcome of a routine sync. Streaming also keeps a 700 MB file off the heap.

**Not fatal to boot.** A worker that exits here restart-loops, and a restart loop on a rented pod costs money and is miserable to diagnose (we have lost an hour to one). A worker missing a LoRA fails the segment that names it, loudly, with the name in the error. That is the better failure.

Five tests, covering the retrain case, the no-op case, corrupt-download-does-not-clobber, the multipart fallback, and API-unreachable-leaves-disk-alone.

Not in scope, deliberately: on-demand fetch when a claim names a LoRA that arrived after boot. The periodic re-sync and that fallback are worth a follow-up; #393 as scoped is the diff.

Refs console#393