### PR TITLE
loras: refuse two shelves claiming one filename

### DIFF
--- a/daemon/lora_sync.py
+++ b/daemon/lora_sync.py
@@ -176,10 +176,29 @@ async def sync_lora_catalog(queue: QueueClient) -> bool:
 
     logger.info("LoRA sync: %d in the catalogue, checking %s", len(catalog), lora_dir)
 
-    ok = True
+    # The bucket files LoRAs under character/ and content/, but they land here FLAT, because
+    # that is what a ComfyUI LoraLoader and ltx_characters.char_lora both expect — neither
+    # knows the prefix exists. Flattening means two kinds could claim one filename, and the
+    # second would silently overwrite the first: a character LoRA replaced by a motion LoRA
+    # renders a stranger, successfully. Refuse the pair rather than pick one.
+    seen: dict[str, str] = {}
+    clashing: set[str] = set()
+    for r in catalog:
+        prior = seen.get(r["name"])
+        if prior is not None and prior != r.get("key", r["name"]):
+            clashing.add(r["name"])
+            logger.error(
+                "       %s: same filename under two prefixes (%s and %s) — SKIPPING BOTH, "
+                "rename one in the bucket", r["name"], prior, r.get("key", r["name"]),
+            )
+        seen[r["name"]] = r.get("key", r["name"])
+
+    ok = not clashing
     fetched = 0
     for remote in catalog:
         name = remote["name"]
+        if name in clashing:
+            continue
         local_path = os.path.join(lora_dir, name)
         _cleanup_partials(lora_dir, name)
 

--- a/tests/test_lora_catalog_sync.py
+++ b/tests/test_lora_catalog_sync.py
@@ -121,3 +121,41 @@ async def test_an_unreachable_catalogue_leaves_the_disk_alone(lora_dir):
 
     assert await lora_sync.sync_lora_catalog(Broken([])) is False
     assert open(path, "rb").read(7) == b"KEEP-ME"
+
+
+async def test_two_prefixes_claiming_one_filename_are_both_refused(lora_dir):
+    """The bucket files under character/ and content/, but files land here FLAT.
+
+    ComfyUI's LoraLoader and ltx_characters.char_lora both use the bare filename and neither
+    knows a prefix exists, so flattening is required. The cost is that two kinds can claim
+    one name — and the loser is silently overwritten, which renders a stranger successfully.
+    Refuse the pair; a skipped LoRA fails loudly, a swapped one does not.
+    """
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([
+        {"name": "clash.safetensors", "kind": "character", "key": "character/clash.safetensors",
+         "size": BIG, "etag": md5, "multipart": False, "uri": "s3://ltx-loras/character/clash.safetensors"},
+        {"name": "clash.safetensors", "kind": "content", "key": "content/clash.safetensors",
+         "size": BIG, "etag": md5, "multipart": False, "uri": "s3://ltx-loras/content/clash.safetensors"},
+    ])
+    assert await lora_sync.sync_lora_catalog(q) is False   # reported, not silently resolved
+    assert q.downloaded == []                              # neither one wins
+    assert not os.path.exists(lora_dir / "clash.safetensors")
+
+
+async def test_prefixed_keys_land_flat_where_comfyui_looks(lora_dir):
+    """A character/ key must become <lora_dir>/<basename>, not <lora_dir>/character/...
+
+    ComfyUI resolves lora_name relative to its loras directory, and the DB stores the bare
+    name. A file written into a subdirectory is a file ComfyUI cannot find.
+    """
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "k3lly2026_v2.safetensors", "kind": "character",
+        "key": "character/k3lly2026_v2.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q) is True
+    assert (lora_dir / "k3lly2026_v2.safetensors").exists()          # flat
+    assert not (lora_dir / "character").exists()                     # no subdirectory
+    assert q.downloaded == ["s3://ltx-loras/character/k3lly2026_v2.safetensors"]


### PR DESCRIPTION
Pairs with wanly-api `feat/lora-kinds`.

The bucket now files LoRAs under `character/` and `content/`, but they still land in the worker's LoRA directory **flat** — ComfyUI resolves `lora_name` relative to that one directory, and `ltx_characters.char_lora` stores the bare name. Neither knows a prefix exists, so a file written into a subdirectory is a file ComfyUI cannot find.

**No change was needed to the download path**: `name` is already the basename and `uri` already carries the full key, so prefixed objects land in the right place. A test pins that (`character/` lands flat, no subdirectory created) so a future refactor can't quietly start writing subdirectories.

**What flattening costs, and this PR's actual point:** two kinds can claim the same filename, and the second download silently overwrites the first. A character LoRA replaced by a motion LoRA renders *a stranger*, successfully — no error, just the wrong person. So the pair is refused and both keys named in the log, rather than resolved by arrival order. A skipped LoRA fails loudly on the segment that wants it; a swapped one does not fail at all.

7 tests.