### PR TITLE
loras: fetch a LoRA the pose names but this worker has never seen

### DIFF
--- a/daemon/lora_sync.py
+++ b/daemon/lora_sync.py
@@ -245,3 +245,84 @@ async def sync_lora_catalog(queue: QueueClient) -> bool:
 
     logger.info("LoRA sync: %d fetched, %d already current", fetched, len(catalog) - fetched)
     return ok
+
+
+async def ensure_named_loras_present(
+    names: list[str | None], queue: QueueClient
+) -> list[str]:
+    """Fetch any of `names` this worker does not already hold. Returns what was fetched.
+
+    The boot sync (sync_lora_catalog) answers "is my whole set correct?" and verifies by
+    CONTENT, because a retrained LoRA republished under the same name is the failure that
+    renders a stranger. This answers a narrower question at claim time — "do I have a file
+    by this name at all?" — and deliberately does NOT re-verify hashes.
+
+    That split is the point. Hashing 650 MB per LoRA on every claim would cost seconds of
+    GPU time per segment to re-answer a question boot already answered, while the case this
+    exists for is simply a LoRA published after this worker booted. Correctness stays with
+    boot; availability lives here.
+
+    Missing LoRAs are fetched, not merely reported: a worker that could have downloaded the
+    file and instead failed the segment is a worker that made the queue wait for a restart.
+    """
+    lora_dir = _loras_dir()
+    os.makedirs(lora_dir, exist_ok=True)
+
+    wanted: list[str] = []
+    for raw in names:
+        if not raw:
+            continue
+        n = str(raw).strip()
+        if not n or n.lower() == "none":
+            continue
+        if not n.endswith(".safetensors"):
+            n += ".safetensors"
+        local = os.path.join(lora_dir, n)
+        # Size floor as well as existence: a truncated file from an interrupted fetch is
+        # present but useless, and would otherwise be treated as a hit forever.
+        if os.path.exists(local) and os.path.getsize(local) >= MIN_LORA_SIZE:
+            continue
+        wanted.append(n)
+
+    if not wanted:
+        return []
+
+    logger.info("LoRA on-demand: %s not present locally — fetching", ", ".join(wanted))
+    try:
+        catalog = {o["name"]: o for o in await queue.list_loras()}
+    except Exception as e:
+        logger.error("LoRA on-demand: could not list the catalogue (%s)", e)
+        return []
+
+    fetched: list[str] = []
+    for name in wanted:
+        remote = catalog.get(name)
+        if remote is None:
+            # Nothing to fetch. Said plainly here so the engine's later "no such lora" is
+            # not the first hint, and so the cause reads as "not published" rather than
+            # "download failed".
+            logger.error(
+                "       %s: not in the bucket at all — the pose names a LoRA that was "
+                "never uploaded", name,
+            )
+            continue
+        local = os.path.join(lora_dir, name)
+        _cleanup_partials(lora_dir, name)
+        tmp = local + ".tmp"
+        try:
+            got = await queue.stream_file(remote["uri"], tmp)
+        except Exception as e:
+            logger.error("       %s: download failed: %s", name, e)
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            continue
+        # Verified before the rename, exactly as the boot sync does. A bad transfer must
+        # never take the place of a file the next claim will trust.
+        if not remote.get("multipart") and got != remote["etag"]:
+            logger.error("       %s: md5 mismatch after download — discarding", name)
+            os.remove(tmp)
+            continue
+        os.rename(tmp, local)
+        fetched.append(name)
+        logger.info("       %s: fetched (%.1f MB)", name, os.path.getsize(local) / (1024 * 1024))
+    return fetched

--- a/daemon/ltx_executor.py
+++ b/daemon/ltx_executor.py
@@ -22,6 +22,7 @@ from daemon.executor import (
     _extract_last_frame,
     _validate_image_data,
 )
+from daemon.lora_sync import ensure_named_loras_present
 from daemon.ltx_client import LtxClient, LtxEngineError
 from daemon.progress import ProgressLog
 from daemon.queue_client import QueueClient
@@ -79,6 +80,17 @@ async def execute_ltx_segment(segment: SegmentClaim, queue: QueueClient) -> None
         # back to duration x fps — but a recipe's own frame count wins, because it is part of
         # the configuration that was validated.
         num_frames = recipe.get("frames") or round(segment.duration_seconds * segment.fps)
+
+        # A LoRA the pose names may have been published AFTER this worker booted — the boot
+        # sync is a snapshot, and the console offers a LoRA the moment it reaches the bucket.
+        # Fetching it here turns "this segment fails until someone restarts the pod" into a
+        # one-off download. Costs a stat() per LoRA in the normal case, where both are
+        # already on disk.
+        fetched = await ensure_named_loras_present(
+            [recipe.get("char_lora"), recipe.get("content_lora")], queue
+        )
+        if fetched:
+            await progress.log(f"[2/6] Fetched missing LoRA(s): {', '.join(fetched)}")
 
         await progress.log("[2/6] Submitting to ltx-engine...")
         job_id = await client.submit(

--- a/tests/test_lora_catalog_sync.py
+++ b/tests/test_lora_catalog_sync.py
@@ -159,3 +159,90 @@ async def test_prefixed_keys_land_flat_where_comfyui_looks(lora_dir):
     assert (lora_dir / "k3lly2026_v2.safetensors").exists()          # flat
     assert not (lora_dir / "character").exists()                     # no subdirectory
     assert q.downloaded == ["s3://ltx-loras/character/k3lly2026_v2.safetensors"]
+
+
+# ---------------------------------------------------------------------------------------
+# On-demand fetch at claim time.
+#
+# The boot sync is a snapshot; the console offers a LoRA the moment it reaches the bucket.
+# Without this, a pose naming a newly published LoRA fails every segment until somebody
+# restarts the pod — the queue waiting on an operator for something the worker could just
+# download.
+# ---------------------------------------------------------------------------------------
+
+
+async def test_a_lora_published_after_boot_is_fetched_at_claim(lora_dir):
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+        "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors",
+    }])
+    got = await lora_sync.ensure_named_loras_present(["sfbehind_LTX2_3_v0_1"], q)
+    assert got == ["sfbehind_LTX2_3_v0_1.safetensors"]
+    assert (lora_dir / "sfbehind_LTX2_3_v0_1.safetensors").exists()
+
+
+async def test_the_common_case_costs_no_network_call(lora_dir):
+    """Both LoRAs already present — the overwhelmingly normal claim.
+
+    It must not list the catalogue, and must not re-hash: 650 MB per LoRA per segment to
+    re-answer what boot already answered would be seconds of GPU time thrown away.
+    """
+    _write(str(lora_dir / "k3lly2026_v2.safetensors"), b"X")
+    _write(str(lora_dir / "sfbehind_LTX2_3_v0_1.safetensors"), b"Y")
+
+    class Loud(FakeQueue):
+        async def list_loras(self):
+            raise AssertionError("must not hit the API when everything is present")
+
+    got = await lora_sync.ensure_named_loras_present(
+        ["k3lly2026_v2", "sfbehind_LTX2_3_v0_1"], Loud([]))
+    assert got == []
+
+
+async def test_none_and_empty_are_not_treated_as_filenames(lora_dir):
+    """"none" is how a pose says "no content LoRA". Looking it up would fetch nothing and
+    log a scary "not in the bucket" for a perfectly normal pose."""
+    class Loud(FakeQueue):
+        async def list_loras(self):
+            raise AssertionError("must not hit the API for 'none'")
+
+    assert await lora_sync.ensure_named_loras_present(["none", "", None], Loud([])) == []
+
+
+async def test_a_truncated_local_file_is_replaced_not_trusted(lora_dir):
+    """Present-but-tiny is what an interrupted fetch leaves behind. Treated as a hit, it
+    would be trusted forever and every render with it would fail in ComfyUI instead."""
+    p = lora_dir / "k3lly2026_v2.safetensors"
+    p.write_bytes(b"truncated")
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "k3lly2026_v2.safetensors", "kind": "character",
+        "key": "character/k3lly2026_v2.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors",
+    }])
+    assert await lora_sync.ensure_named_loras_present(["k3lly2026_v2"], q) == [
+        "k3lly2026_v2.safetensors"]
+    assert p.stat().st_size == BIG
+
+
+async def test_a_lora_that_was_never_uploaded_is_named_plainly(lora_dir, caplog):
+    """The pose references something not in the bucket at all. Nothing to fetch — but the
+    cause is "never published", not "download failed", and the log should say which."""
+    got = await lora_sync.ensure_named_loras_present(["ghost_lora"], FakeQueue([]))
+    assert got == []
+    assert "never uploaded" in caplog.text
+
+
+async def test_a_corrupt_on_demand_download_does_not_land(lora_dir):
+    """Same rule as the boot sync: verify before the rename, so the next claim never
+    inherits a bad file that now looks present."""
+    q = FakeQueue([{
+        "name": "k3lly2026_v2.safetensors", "kind": "character",
+        "key": "character/k3lly2026_v2.safetensors", "size": BIG, "etag": "0" * 32,
+        "multipart": False, "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors",
+    }])
+    assert await lora_sync.ensure_named_loras_present(["k3lly2026_v2"], q) == []
+    assert not (lora_dir / "k3lly2026_v2.safetensors").exists()
+    assert not (lora_dir / "k3lly2026_v2.safetensors.tmp").exists()


### PR DESCRIPTION
On-demand fetch at claim time — option 2 from the three we discussed.

**The gap:** the boot sync is a snapshot, but the console offers a LoRA the moment it reaches the bucket. So a pose can name one published *after* this worker booted, and until now that failed every segment using it until somebody restarted the pod. The queue waiting on an operator for a file the worker could just download.

**Cheap in the normal case.** A `stat()` per LoRA when both are already on disk — no API call at all. There's a test that fails if the catalogue is fetched when nothing is missing.

**It deliberately does NOT re-verify hashes**, and that split is the point:

| | question | check |
|---|---|---|
| boot sync | is my whole set *correct*? | md5 vs ETag — catches a retrain republished under the same name |
| on-demand | do I have a file by this name *at all*? | existence + size floor |

Hashing 650 MB per LoRA on every claim would spend seconds of GPU time per segment re-answering what boot already answered. Correctness stays with boot; availability lives here.

**Present-but-truncated counts as missing** — an interrupted fetch leaves a small file behind, and treating it as a hit would trust it forever while every render using it failed inside ComfyUI instead.

**A name not in the bucket at all** logs as "never uploaded" rather than a download failure. Different causes, different fixes, and the engine's later `no such lora` shouldn't be the first hint.

Downloads verify before the rename, same as the boot sync: the next claim must never inherit a bad file that now looks present.

6 new tests, 100 total.