### PR TITLE
loras: boot fetches character LoRAs only, content waits for first use

### DIFF
--- a/daemon/lora_sync.py
+++ b/daemon/lora_sync.py
@@ -156,10 +156,31 @@ def _needs_download(local_path: str, remote: dict) -> str | None:
     return None
 
 
-async def sync_lora_catalog(queue: QueueClient) -> bool:
+async def sync_lora_catalog(queue: QueueClient, eager_kinds: tuple[str, ...] = ("character",)) -> bool:
     """Diff the local LoRA directory against the bucket and fetch what differs.
 
-    Returns True when the local set matches the catalogue. Deliberately NOT fatal to boot:
+    EAGER ONLY FOR SOME KINDS, and by default only for character LoRAs.
+
+    Boot sync blocks registration, so every byte fetched here is a worker not yet taking
+    work. Measured on the 3090: one 408 MB content LoRA published while the pod was down
+    added FIVE MINUTES to boot, during which the queue had no worker. A content library is
+    expected to grow, so eager-fetching all of it makes every worker's boot slower forever,
+    for LoRAs most of them will never be asked for.
+
+    Character LoRAs stay eager because the set is small, bounded by how many characters
+    exist, and effectively every job names one — so fetching them at boot is work that was
+    going to happen on the first claim anyway.
+
+    Content LoRAs are left to ensure_named_loras_present() at claim time. The cost moves
+    from every boot to the first claim that actually needs one, which is the claim that was
+    going to wait for that download regardless.
+
+    Non-eager kinds are still CHECKED, and a stale one is reported — the diff is cheap and
+    silence about a LoRA that is present but wrong is exactly what the content comparison
+    exists to prevent. Only the download is deferred.
+
+    Returns True when everything eager is in place and nothing deferred looks broken.
+    Deliberately NOT fatal to boot:
     a worker that exits here restart-loops, and a restart loop on a rented pod costs real
     money and is miserable to diagnose (we have already lost an hour to one). A worker with
     a missing LoRA fails the segment that needs it, loudly, with the name in the error —
@@ -195,6 +216,7 @@ async def sync_lora_catalog(queue: QueueClient) -> bool:
 
     ok = not clashing
     fetched = 0
+    deferred: list[str] = []
     for remote in catalog:
         name = remote["name"]
         if name in clashing:
@@ -205,6 +227,14 @@ async def sync_lora_catalog(queue: QueueClient) -> bool:
         reason = _needs_download(local_path, remote)
         if reason is None:
             logger.info("       %s: current", name)
+            continue
+
+        kind = remote.get("kind", "character")
+        if kind not in eager_kinds:
+            # Checked, reported, and deliberately not fetched here. The claim that names it
+            # will fetch it; boot does not wait for a LoRA nothing has asked for yet.
+            deferred.append(name)
+            logger.info("       %s: %s — deferred (%s, fetched on demand)", name, reason, kind)
             continue
 
         logger.info("       %s: %s — downloading", name, reason)
@@ -243,7 +273,11 @@ async def sync_lora_catalog(queue: QueueClient) -> bool:
         fetched += 1
         logger.info("       %s: saved (%.1f MB)", name, size / (1024 * 1024))
 
-    logger.info("LoRA sync: %d fetched, %d already current", fetched, len(catalog) - fetched)
+    logger.info(
+        "LoRA sync: %d fetched, %d already current%s",
+        fetched, len(catalog) - fetched - len(deferred),
+        f", {len(deferred)} deferred to first use ({', '.join(deferred)})" if deferred else "",
+    )
     return ok
 
 

--- a/tests/test_lora_catalog_sync.py
+++ b/tests/test_lora_catalog_sync.py
@@ -6,6 +6,7 @@ the wrong character while the console shows the right one. That is wrong output 
 than a failure, so it is the one this file guards hardest.
 """
 import hashlib
+import logging
 import os
 
 import pytest
@@ -246,3 +247,74 @@ async def test_a_corrupt_on_demand_download_does_not_land(lora_dir):
     assert await lora_sync.ensure_named_loras_present(["k3lly2026_v2"], q) == []
     assert not (lora_dir / "k3lly2026_v2.safetensors").exists()
     assert not (lora_dir / "k3lly2026_v2.safetensors.tmp").exists()
+
+
+# ---------------------------------------------------------------------------------------
+# Boot sync is eager for characters only.
+#
+# Boot sync blocks registration, so every byte fetched there is a worker not yet taking
+# work. Measured on the 3090: one 408 MB content LoRA published while the pod was down
+# added five minutes to boot, with no worker on the queue for that time. The content
+# library is expected to grow; the character set is bounded by how many characters exist.
+# ---------------------------------------------------------------------------------------
+
+
+async def test_a_missing_character_lora_is_still_fetched_at_boot(lora_dir):
+    """Effectively every job names one, so this download was going to happen on the first
+    claim anyway. Doing it at boot costs nothing extra and keeps the first claim fast."""
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "k3lly2026_v2.safetensors", "kind": "character",
+        "key": "character/k3lly2026_v2.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q) is True
+    assert q.downloaded == ["s3://ltx-loras/character/k3lly2026_v2.safetensors"]
+
+
+async def test_a_missing_content_lora_is_not_downloaded_at_boot(lora_dir):
+    """The five minutes this saves is five minutes of no worker on the queue, for a LoRA
+    that may never be asked for on this box."""
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+        "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q) is True
+    assert q.downloaded == []                                     # deferred
+    assert not (lora_dir / "sfbehind_LTX2_3_v0_1.safetensors").exists()
+
+
+async def test_a_deferred_lora_is_still_checked_and_named(lora_dir, caplog):
+    """Deferring the DOWNLOAD must not mean skipping the CHECK.
+
+    A content LoRA that is present but stale is exactly what the content comparison exists
+    to catch, and silence about it would be the failure that renders the wrong motion.
+    """
+    # caplog captures WARNING and above by default; the deferral line is INFO, which is the
+    # right level for it — this is normal operation, not a problem.
+    caplog.set_level(logging.INFO, logger="daemon.lora_sync")
+    _write(str(lora_dir / "sfbehind_LTX2_3_v0_1.safetensors"), b"OLD")
+    q = FakeQueue([{
+        "name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+        "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG,
+        "etag": hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest(),
+        "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors",
+    }])
+    await lora_sync.sync_lora_catalog(q)
+    assert "sfbehind_LTX2_3_v0_1.safetensors" in caplog.text
+    assert "deferred" in caplog.text
+    assert "content changed" in caplog.text     # the reason, not just the fact
+
+
+async def test_eager_kinds_is_overridable(lora_dir):
+    """A box that wants everything up front can still say so, without editing this file."""
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+        "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors",
+    }])
+    assert await lora_sync.sync_lora_catalog(q, eager_kinds=("character", "content")) is True
+    assert q.downloaded == ["s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors"]


### PR DESCRIPTION
Follow-up to the on-demand fetch (#163), with a number from production behind it.

**The measurement.** Boot sync blocks registration. On the 3090 today, one 408 MB content LoRA published while the pod was down added **five minutes** to boot — five minutes with no worker on the queue:

```
14:55:21  epic_cumshots-V1-LTX_2_3-CUMSH0T.safetensors: missing — downloading
15:00:12  streamed 408.3 MB
15:00:14  Registered as 3090.zero
```

The content library is expected to grow. Eager-fetching all of it makes every worker's boot slower forever, for LoRAs most of them will never be asked for.

**Character LoRAs stay eager.** That set is bounded by how many characters exist, and effectively every job names one — the download was going to happen on the first claim anyway, so doing it at boot costs nothing and keeps the first claim fast.

**Content LoRAs defer to claim time**, handled by `ensure_named_loras_present()` from #163. The cost moves from *every boot* to *the first claim that actually needs one* — which is the claim that was going to wait for that download regardless.

**Deferring the download is not deferring the check.** A deferred LoRA is still diffed and a stale one still reported, with its reason:

```
sfbehind_LTX2_3_v0_1.safetensors: content changed (local md5 …, remote …) — deferred (content, fetched on demand)
```

A content LoRA that is present but *wrong* is exactly what the content comparison exists to catch, and silence about it renders the wrong motion. Only the fetch moves.

`eager_kinds` is a parameter, not a constant, so a box that wants everything up front can say so without editing the file.

4 new tests, 104 total.