### PR TITLE
loras: report what the last sync concluded, in the heartbeat

### DIFF
--- a/daemon/lora_sync.py
+++ b/daemon/lora_sync.py
@@ -6,6 +6,7 @@ Uses atomic writes (.tmp → rename) to prevent corrupt partial files.
 
 import hashlib
 import logging
+from datetime import datetime, timezone
 import os
 
 from daemon.config import settings
@@ -108,6 +109,55 @@ async def ensure_loras_available(
 # worker renders the wrong character while the console shows the right one — wrong output
 # rather than a failure, which is the expensive kind.
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------------------
+# The inventory this worker reports to the API (console#... / daemon#165).
+#
+# Deliberately a CACHE of what the last sync concluded, never a fresh computation. The
+# honest answer to "do I hold the right k3lly2026_v2?" is an md5 of 650 MB; doing that on
+# every heartbeat would hash gigabytes a minute to render a status page. sync_lora_catalog()
+# already reaches that verdict — this stores it.
+#
+# Which means it can go stale in one specific way: ensure_named_loras_present() changes the
+# disk mid-life, hours after boot. It updates this too. Without that the page would show
+# "deferred" for a LoRA already downloaded, which is worse than showing nothing — it is
+# confidently wrong.
+# ---------------------------------------------------------------------------------------
+
+# state          meaning                                            severity
+# current        present, md5 matches the ETag                      fine
+# deferred       absent BY DESIGN (content, fetched on demand)      fine
+# unverifiable   present, multipart ETag, size-only check           note
+# stale          present but the content differs                    the one that matters
+# missing        should be here and is not                          real problem
+_INVENTORY: dict = {"synced_at": None, "dir": None, "items": []}
+
+
+def inventory() -> dict:
+    """What the last sync concluded, for the heartbeat. Never recomputes."""
+    return dict(_INVENTORY, items=list(_INVENTORY["items"]))
+
+
+def _record(items: list[dict]) -> None:
+    _INVENTORY["synced_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    _INVENTORY["dir"] = _loras_dir()
+    _INVENTORY["items"] = items
+
+
+def _note_fetched(names: list[str]) -> None:
+    """Mark on-demand fetches current, so the report does not contradict the disk."""
+    if not names:
+        return
+    by_name = {i["name"]: i for i in _INVENTORY["items"]}
+    for n in names:
+        item = by_name.get(n)
+        if item is not None:
+            item["state"] = "current"
+            item.pop("note", None)
+        else:
+            _INVENTORY["items"].append({"name": n, "kind": "unknown", "state": "current"})
+    _INVENTORY["synced_at"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
 
 def _local_md5(path: str) -> str:
@@ -217,6 +267,10 @@ async def sync_lora_catalog(queue: QueueClient, eager_kinds: tuple[str, ...] = (
     ok = not clashing
     fetched = 0
     deferred: list[str] = []
+    # One entry per catalogue object, carrying the verdict _needs_download() already reached.
+    # Built here rather than in a second pass so there is exactly one implementation of
+    # "is this current" — two would drift, which is the recipes.json trap in the wiki.
+    report: list[dict] = []
     for remote in catalog:
         name = remote["name"]
         if name in clashing:
@@ -227,6 +281,14 @@ async def sync_lora_catalog(queue: QueueClient, eager_kinds: tuple[str, ...] = (
         reason = _needs_download(local_path, remote)
         if reason is None:
             logger.info("       %s: current", name)
+            report.append({
+                "name": name, "kind": remote.get("kind", "unknown"),
+                # A multipart ETag is not an md5, so "current" here rests on size alone.
+                # Surfaced rather than folded into "current", because the difference is
+                # exactly whether a same-size retrain would have been caught.
+                "state": "unverifiable" if remote.get("multipart") else "current",
+                **({"note": "multipart ETag — size only"} if remote.get("multipart") else {}),
+            })
             continue
 
         kind = remote.get("kind", "character")
@@ -235,6 +297,14 @@ async def sync_lora_catalog(queue: QueueClient, eager_kinds: tuple[str, ...] = (
             # will fetch it; boot does not wait for a LoRA nothing has asked for yet.
             deferred.append(name)
             logger.info("       %s: %s — deferred (%s, fetched on demand)", name, reason, kind)
+            # "missing" is by design here and must not read as a fault; but a file that is
+            # PRESENT AND WRONG is a fault whether or not we chose to defer the download,
+            # so the two are reported differently.
+            report.append({
+                "name": name, "kind": kind,
+                "state": "deferred" if reason == "missing" else "stale",
+                "note": reason,
+            })
             continue
 
         logger.info("       %s: %s — downloading", name, reason)
@@ -271,7 +341,21 @@ async def sync_lora_catalog(queue: QueueClient, eager_kinds: tuple[str, ...] = (
 
         os.rename(tmp_path, local_path)
         fetched += 1
+        report.append({"name": name, "kind": remote.get("kind", "unknown"),
+                       "state": "current"})
         logger.info("       %s: saved (%.1f MB)", name, size / (1024 * 1024))
+
+    # Whatever never made it into the report failed to download — present in the catalogue,
+    # absent from disk, and not deferred. That is the "real problem" state.
+    seen = {r["name"] for r in report}
+    for remote in catalog:
+        if remote["name"] not in seen and remote["name"] not in clashing:
+            report.append({"name": remote["name"], "kind": remote.get("kind", "unknown"),
+                           "state": "missing", "note": "download failed"})
+    for name in sorted(clashing):
+        report.append({"name": name, "kind": "conflict", "state": "missing",
+                       "note": "same filename on two shelves — refused"})
+    _record(report)
 
     logger.info(
         "LoRA sync: %d fetched, %d already current%s",
@@ -359,4 +443,6 @@ async def ensure_named_loras_present(
         os.rename(tmp, local)
         fetched.append(name)
         logger.info("       %s: fetched (%.1f MB)", name, os.path.getsize(local) / (1024 * 1024))
+    # Keep the reported inventory honest: this ran hours after boot and changed the disk.
+    _note_fetched(fetched)
     return fetched

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -12,7 +12,7 @@ from daemon.model_validator import cleanup_partial_downloads, validate_models
 from daemon.node_checker import check_and_install_nodes
 from daemon.queue_client import QueueClient
 from daemon.gpu_stats import get_gpu_stats
-from daemon.lora_sync import sync_lora_catalog
+from daemon.lora_sync import inventory as lora_inventory, sync_lora_catalog
 from daemon.resource_sync import sync_resources
 from daemon.sd_scripts_monitor import get_status as get_sd_scripts_status
 from daemon.a1111_monitor import get_status as get_a1111_status
@@ -115,7 +115,8 @@ async def heartbeat_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_
         is_busy = comfyui_busy or sd_scripts_training
 
         try:
-            data = await queue.heartbeat(worker_id, comfyui_running, gpu_stats, sd_scripts_status, a1111_status)
+            data = await queue.heartbeat(worker_id, comfyui_running, gpu_stats, sd_scripts_status, a1111_status,
+                                         loras=lora_inventory())
             beat_count += 1
 
             # Pick up renames from the registry

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -279,6 +279,7 @@ class QueueClient:
         gpu_stats: dict | None = None,
         sd_scripts_status: dict | None = None,
         a1111_status: dict | None = None,
+        loras: dict | None = None,
     ) -> dict:
         """Send heartbeat. Returns full worker data including current friendly_name."""
         payload: dict = {"comfyui_running": comfyui_running}
@@ -288,6 +289,10 @@ class QueueClient:
             payload["sd_scripts"] = sd_scripts_status
         if a1111_status is not None:
             payload["a1111"] = a1111_status
+        # What the last sync concluded about this worker's LoRA directory. A cached verdict,
+        # not a fresh check — see lora_sync.inventory().
+        if loras is not None:
+            payload["loras"] = loras
         resp = await self._request_with_retry(
             "POST", f"/workers/{worker_id}/heartbeat", json=payload
         )

--- a/tests/test_lora_catalog_sync.py
+++ b/tests/test_lora_catalog_sync.py
@@ -318,3 +318,93 @@ async def test_eager_kinds_is_overridable(lora_dir):
     }])
     assert await lora_sync.sync_lora_catalog(q, eager_kinds=("character", "content")) is True
     assert q.downloaded == ["s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors"]
+
+
+# ---------------------------------------------------------------------------------------
+# The inventory reported to the API (daemon#165).
+#
+# The states carry intent, not just presence. Since #164 a content LoRA that is absent is
+# absent BY DESIGN, and a page that paints that red is amber on every worker forever — at
+# which point nobody reads it, and the one state worth seeing (stale) is lost in the noise.
+# ---------------------------------------------------------------------------------------
+
+
+def _state(name):
+    return next((i["state"] for i in lora_sync.inventory()["items"] if i["name"] == name), None)
+
+
+async def test_a_deferred_content_lora_is_not_reported_as_a_fault(lora_dir):
+    """Absent by design. This is the normal state for content LoRAs after #164."""
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    await lora_sync.sync_lora_catalog(FakeQueue([{
+        "name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+        "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors",
+    }]))
+    assert _state("sfbehind_LTX2_3_v0_1.safetensors") == "deferred"
+
+
+async def test_a_present_but_outdated_lora_reports_stale_even_when_deferred(lora_dir):
+    """The state this whole feature is for.
+
+    A worker holding an outdated k3lly2026_v2 renders the PREVIOUS character, successfully.
+    Choosing not to download it does not make a wrong file on disk acceptable, so deferral
+    must not swallow this into "deferred".
+    """
+    _write(str(lora_dir / "sfbehind_LTX2_3_v0_1.safetensors"), b"OLD")
+    await lora_sync.sync_lora_catalog(FakeQueue([{
+        "name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+        "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG,
+        "etag": hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest(),
+        "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors",
+    }]))
+    assert _state("sfbehind_LTX2_3_v0_1.safetensors") == "stale"
+
+
+async def test_a_multipart_object_reports_unverifiable_not_current(lora_dir):
+    """"current" would overstate it: that verdict rests on size alone, so a same-size
+    retrain would have gone unnoticed. The difference is the whole point of saying so."""
+    _write(str(lora_dir / "big.safetensors"), b"X")
+    await lora_sync.sync_lora_catalog(FakeQueue([{
+        "name": "big.safetensors", "kind": "content", "key": "content/big.safetensors",
+        "size": BIG, "etag": "abc-7", "multipart": True,
+        "uri": "s3://ltx-loras/content/big.safetensors",
+    }]), eager_kinds=("character", "content"))
+    assert _state("big.safetensors") == "unverifiable"
+
+
+async def test_an_on_demand_fetch_updates_the_report(lora_dir):
+    """The disk changes hours after boot. Without this the page shows "deferred" for a LoRA
+    already downloaded — confidently wrong, which is worse than showing nothing."""
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    obj = {"name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+           "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG, "etag": md5,
+           "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors"}
+    await lora_sync.sync_lora_catalog(FakeQueue([obj]))
+    assert _state("sfbehind_LTX2_3_v0_1.safetensors") == "deferred"
+
+    await lora_sync.ensure_named_loras_present(["sfbehind_LTX2_3_v0_1"], FakeQueue([obj]))
+    assert _state("sfbehind_LTX2_3_v0_1.safetensors") == "current"
+
+
+async def test_the_report_is_stamped_so_the_page_can_say_as_of(lora_dir):
+    """A cached verdict presented as live truth is a lie with a timestamp missing."""
+    _write(str(lora_dir / "k3lly2026_v2.safetensors"), b"X")
+    md5 = hashlib.md5(b"X" + b"\0" * (BIG - 1)).hexdigest()
+    await lora_sync.sync_lora_catalog(FakeQueue([{
+        "name": "k3lly2026_v2.safetensors", "kind": "character",
+        "key": "character/k3lly2026_v2.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors",
+    }]))
+    inv = lora_sync.inventory()
+    assert inv["synced_at"] and inv["dir"]
+
+
+async def test_a_failed_download_reports_missing_not_current(lora_dir):
+    """A character LoRA that should be here and is not. The genuinely broken case."""
+    await lora_sync.sync_lora_catalog(FakeQueue([{
+        "name": "k3lly2026_v2.safetensors", "kind": "character",
+        "key": "character/k3lly2026_v2.safetensors", "size": BIG, "etag": "0" * 32,
+        "multipart": False, "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors",
+    }]))
+    assert _state("k3lly2026_v2.safetensors") == "missing"


### PR DESCRIPTION
Daemon half of #165. A worker is the only thing that can see its own LoRA directory, so the console cannot diff for it — it has to be told.

**Reported as a cache of the last sync's verdict, never a fresh computation.** The honest answer to "do I hold the right `k3lly2026_v2`?" is an md5 of 650 MB; computing that per heartbeat would hash gigabytes a minute to draw a status page. `sync_lora_catalog()` already reaches that verdict — this stores it, stamped with `synced_at` so the page can say "as of 09:00" rather than implying live truth.

Built from the same `_needs_download()` call the sync already makes, not a second pass. Two implementations of "is this current" drift — the `recipes.json` trap in the storyboard wiki, where served and parsed copies disagreed while a verification that counted rows instead of comparing content passed happily.

### The states carry intent

```
current       present, md5 matches the ETag
deferred      absent BY DESIGN — content, fetched on demand (#164)
unverifiable  present, multipart ETag, so the verdict rests on size alone
stale         present but the content differs
missing       should be here and is not
```

That distinction *is* the feature. Since #164 an absent content LoRA is the normal state, and a page painting it red would be amber on every worker forever — at which point nobody reads it and `stale` is lost in the noise.

**`stale` is the one worth building for:** a worker holding an outdated LoRA renders the previous character, successfully, and nothing else surfaces that.

### Two subtleties

**Deferral does not swallow staleness.** Choosing not to download a file does not make a *wrong file already on disk* acceptable, so a deferred-but-outdated LoRA reports `stale`, not `deferred`.

**On-demand fetch updates the cache.** Since #163 the disk changes hours after boot. Without this the page would show `deferred` for something already downloaded — confidently wrong, which is worse than showing nothing.

6 new tests, 110 total.