### PR TITLE
loras: show the on-demand download on the job page, while it happens

### DIFF
--- a/daemon/lora_sync.py
+++ b/daemon/lora_sync.py
@@ -366,7 +366,7 @@ async def sync_lora_catalog(queue: QueueClient, eager_kinds: tuple[str, ...] = (
 
 
 async def ensure_named_loras_present(
-    names: list[str | None], queue: QueueClient
+    names: list[str | None], queue: QueueClient, progress=None
 ) -> list[str]:
     """Fetch any of `names` this worker does not already hold. Returns what was fetched.
 
@@ -382,6 +382,12 @@ async def ensure_named_loras_present(
 
     Missing LoRAs are fetched, not merely reported: a worker that could have downloaded the
     file and instead failed the segment is a worker that made the queue wait for a restart.
+
+    `progress` is the SEGMENT's progress log, not the daemon's. This download happens inside
+    a claimed segment and can take minutes on a 400 MB LoRA — without it the job page sits at
+    "[1/6] Start image ready" for five minutes and looks wedged, which is indistinguishable
+    from the real wedge in #160. Saying "downloading a LoRA, 40% of 408 MB" is the difference
+    between a slow step and a broken worker.
     """
     lora_dir = _loras_dir()
     os.makedirs(lora_dir, exist_ok=True)
@@ -406,6 +412,10 @@ async def ensure_named_loras_present(
         return []
 
     logger.info("LoRA on-demand: %s not present locally — fetching", ", ".join(wanted))
+    if progress:
+        await progress(
+            f"[2/6] {len(wanted)} LoRA(s) not on this worker — fetching: {', '.join(wanted)}"
+        )
     try:
         catalog = {o["name"]: o for o in await queue.list_loras()}
     except Exception as e:
@@ -423,12 +433,23 @@ async def ensure_named_loras_present(
                 "       %s: not in the bucket at all — the pose names a LoRA that was "
                 "never uploaded", name,
             )
+            if progress:
+                await progress(f"[2/6] {name} is not in the bucket — never uploaded")
             continue
         local = os.path.join(lora_dir, name)
         _cleanup_partials(lora_dir, name)
         tmp = local + ".tmp"
+        mb = remote.get("size", 0) / (1024 * 1024)
+        if progress:
+            await progress(f"[2/6] Downloading {name} ({mb:.0f} MB)...")
+
+        async def _tick(done, total, _name=name):
+            if progress and total:
+                await progress(f"[2/6] {_name}: {done * 100 // total}% of {total / (1024 * 1024):.0f} MB")
+
         try:
-            got = await queue.stream_file(remote["uri"], tmp)
+            got = await queue.stream_file(remote["uri"], tmp,
+                                          on_progress=_tick, total=remote.get("size", 0))
         except Exception as e:
             logger.error("       %s: download failed: %s", name, e)
             if os.path.exists(tmp):

--- a/daemon/ltx_executor.py
+++ b/daemon/ltx_executor.py
@@ -86,11 +86,16 @@ async def execute_ltx_segment(segment: SegmentClaim, queue: QueueClient) -> None
         # Fetching it here turns "this segment fails until someone restarts the pod" into a
         # one-off download. Costs a stat() per LoRA in the normal case, where both are
         # already on disk.
+        # progress.log is passed in so the DOWNLOAD is visible on the job page, not just its
+        # completion. A 400 MB LoRA takes minutes; without this the segment sits at
+        # "[1/6] Start image ready" the whole time and is indistinguishable from a wedged
+        # worker. See console#392.
         fetched = await ensure_named_loras_present(
-            [recipe.get("char_lora"), recipe.get("content_lora")], queue
+            [recipe.get("char_lora"), recipe.get("content_lora")], queue,
+            progress=progress.log,
         )
         if fetched:
-            await progress.log(f"[2/6] Fetched missing LoRA(s): {', '.join(fetched)}")
+            await progress.log(f"[2/6] LoRA(s) ready: {', '.join(fetched)}")
 
         await progress.log("[2/6] Submitting to ltx-engine...")
         job_id = await client.submit(

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -214,7 +214,7 @@ class QueueClient:
             _raise_with_details(resp, "list_loras")
         return resp.json()
 
-    async def stream_file(self, s3_path: str, dest: str) -> str:
+    async def stream_file(self, s3_path: str, dest: str, on_progress=None, total: int = 0) -> str:
         """Download to `dest`, returning the md5 of what actually landed.
 
         Streams rather than using download_file(): that returns bytes, and a 700 MB LoRA
@@ -227,7 +227,6 @@ class QueueClient:
         """
         timeout = httpx.Timeout(connect=15.0, read=60.0, write=60.0, pool=15.0)
         digest = hashlib.md5()
-        total = 0
         with open(dest, "wb") as f:
             async with self.client.stream(
                 "GET", "/files", params={"path": s3_path},
@@ -236,11 +235,20 @@ class QueueClient:
                 if not resp.is_success:
                     await resp.aread()
                     _raise_with_details(resp, f"stream_file {s3_path}")
+                # Report at quarters, not per chunk. Each callback is an API write on the
+                # segment's progress log, so per-chunk would post hundreds of rows for one
+                # download; quarters are enough to show it is moving and not wedged.
+                step = max(total // 4, 1) if total else 0
+                next_mark = step
+                done = 0
                 async for chunk in resp.aiter_bytes(1024 * 1024):
                     f.write(chunk)
                     digest.update(chunk)
-                    total += len(chunk)
-        logger.info("       streamed %.1f MB from %s", total / (1024 * 1024), s3_path)
+                    done += len(chunk)
+                    if on_progress and step and done >= next_mark:
+                        await on_progress(done, total)
+                        next_mark += step
+        logger.info("       streamed %.1f MB from %s", done / (1024 * 1024), s3_path)
         return digest.hexdigest()
 
     async def register(

--- a/tests/test_lora_catalog_sync.py
+++ b/tests/test_lora_catalog_sync.py
@@ -33,8 +33,13 @@ class FakeQueue:
     async def list_loras(self):
         return self.catalog
 
-    async def stream_file(self, uri, dest):
+    async def stream_file(self, uri, dest, on_progress=None, total: int = 0):
+        # Signature must track QueueClient.stream_file. When it drifted, the real code
+        # raised TypeError and the download loop's `except Exception` reported it as a
+        # failed transfer — a fake that is wrong in a way the tests cannot see.
         self.downloaded.append(uri)
+        if on_progress and total:
+            await on_progress(total, total)
         return _write(dest, self.content)
 
 
@@ -408,3 +413,64 @@ async def test_a_failed_download_reports_missing_not_current(lora_dir):
         "multipart": False, "uri": "s3://ltx-loras/character/k3lly2026_v2.safetensors",
     }]))
     assert _state("k3lly2026_v2.safetensors") == "missing"
+
+
+# ---------------------------------------------------------------------------------------
+# Download progress reaches the SEGMENT's log, not just the daemon's (console#392).
+#
+# This download happens inside a claimed segment and takes minutes on a 400 MB LoRA. Without
+# these lines the job page sits at "[1/6] Start image ready" the whole time, which is
+# indistinguishable from the wedged-worker failure in #160 — a slow step and a broken one
+# must not look the same.
+# ---------------------------------------------------------------------------------------
+
+
+async def test_the_job_page_is_told_before_the_download_starts(lora_dir):
+    """Announced up front, with the size, so a five-minute gap has a stated reason."""
+    lines: list[str] = []
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "sfbehind_LTX2_3_v0_1.safetensors", "kind": "content",
+        "key": "content/sfbehind_LTX2_3_v0_1.safetensors", "size": BIG, "etag": md5,
+        "multipart": False, "uri": "s3://ltx-loras/content/sfbehind_LTX2_3_v0_1.safetensors",
+    }])
+    await lora_sync.ensure_named_loras_present(
+        ["sfbehind_LTX2_3_v0_1"], q, progress=lambda m: _collect(lines, m))
+
+    assert any("not on this worker" in ln for ln in lines)
+    assert any("Downloading sfbehind_LTX2_3_v0_1.safetensors" in ln and "MB" in ln
+               for ln in lines)
+
+
+async def test_progress_is_reported_while_it_transfers(lora_dir):
+    """A percentage moving is what distinguishes "slow" from "hung"."""
+    lines: list[str] = []
+    md5 = hashlib.md5(b"NEW" + b"\0" * (BIG - 3)).hexdigest()
+    q = FakeQueue([{
+        "name": "x.safetensors", "kind": "content", "key": "content/x.safetensors",
+        "size": BIG, "etag": md5, "multipart": False, "uri": "s3://ltx-loras/content/x.safetensors",
+    }])
+    await lora_sync.ensure_named_loras_present(["x"], q, progress=lambda m: _collect(lines, m))
+    assert any("%" in ln for ln in lines)
+
+
+async def test_a_lora_that_was_never_uploaded_says_so_on_the_job_page(lora_dir):
+    """Otherwise the segment just fails later in the engine with `no such lora`, and the
+    cause — never published — is only visible to someone with shell on the box."""
+    lines: list[str] = []
+    await lora_sync.ensure_named_loras_present(
+        ["ghost"], FakeQueue([]), progress=lambda m: _collect(lines, m))
+    assert any("not in the bucket" in ln for ln in lines)
+
+
+async def test_nothing_is_posted_when_everything_is_present(lora_dir):
+    """The overwhelmingly common claim. It must not add noise to every segment's log."""
+    _write(str(lora_dir / "k3lly2026_v2.safetensors"), b"X")
+    lines: list[str] = []
+    await lora_sync.ensure_named_loras_present(
+        ["k3lly2026_v2"], FakeQueue([]), progress=lambda m: _collect(lines, m))
+    assert lines == []
+
+
+async def _collect(sink: list, msg: str) -> None:
+    sink.append(msg)


### PR DESCRIPTION
In the same vein as console#392. Spotted live: a job pulled a LoRA the worker did not have, and the job page showed nothing for the duration.

**The gap.** The fetch only logged after it finished, so a 400 MB LoRA left the segment sitting at `[1/6] Start image ready` for five minutes with nothing said — indistinguishable from the wedged-worker failure in #160. A slow step and a broken one must not look the same.

**Before**
```
[17:43:38] [1/6] Start image ready (2757021 bytes)
                                                     <- five silent minutes
[17:48:31] [2/6] Submitting to ltx-engine...
```

**After**
```
[17:43:38] [1/6] Start image ready (2757021 bytes)
[17:43:38] [2/6] 1 LoRA(s) not on this worker — fetching: ltxdeepthroat_v01.safetensors
[17:43:38] [2/6] Downloading ltxdeepthroat_v01.safetensors (408 MB)...
[17:44:52] [2/6] ltxdeepthroat_v01.safetensors: 25% of 408 MB
[17:46:06] [2/6] ltxdeepthroat_v01.safetensors: 50% of 408 MB
[17:47:20] [2/6] ltxdeepthroat_v01.safetensors: 75% of 408 MB
[17:48:31] [2/6] LoRA(s) ready: ltxdeepthroat_v01.safetensors
[17:48:31] [2/6] Submitting to ltx-engine...
```

**Quarters, not per chunk.** Each line is an API write on the segment's progress log; per-chunk would post hundreds of rows for one download. The point is to show movement, not to stream bytes.

**A LoRA that is not in the bucket says so here too.** Previously that surfaced only as the engine's later `no such lora`, with the actual cause — never published — visible only to someone with a shell on the box.

**Silent when everything is present**, which is the overwhelmingly common claim. There's a test that fails if this starts adding a line to every segment.

### One thing worth reading

The `FakeQueue` in the tests had a `stream_file` whose signature had drifted from the real one. The consequence was worse than a stale fake: the real code raised `TypeError`, and the download loop's `except Exception` reported it as a *failed transfer*. Three tests went red in a way that pointed at the wrong thing entirely.

Fixed the double, and left a comment on it saying the signature must track `QueueClient.stream_file`.

4 new tests, 114 total.