### PR TITLE
checkpoints: forward the pose's base model, and report which ones this worker can load

### DIFF
--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -147,6 +147,26 @@ class LtxClient:
         result: dict[str, Any] = r.json()
         return result
 
+    async def checkpoints(self) -> list[str]:
+        """Base models this worker can actually load.
+
+        Asked of the engine rather than globbed off disk, because the engine asks ComfyUI,
+        and ComfyUI answers from the folder mapping in extra_model_paths.yaml. A file the
+        mapping does not cover is invisible to a render however present it is on the
+        filesystem — so this lists what will LOAD, not what exists.
+
+        The daemon is the only thing that can ask: the engine binds to 127.0.0.1 inside the
+        container, so nothing upstream can reach it. That is why this is reported through
+        the heartbeat rather than fetched by the API (console#404).
+        """
+        r = await self._client.get("/checkpoints", timeout=30.0)
+        r.raise_for_status()
+        names = r.json().get("checkpoints") or []
+        # Bare names, matching how a recipe stores one and how the console shows it. The
+        # engine re-appends the extension when it resolves the file.
+        return sorted({n[: -len(".safetensors")] if n.endswith(".safetensors") else n
+                       for n in names})
+
     async def submit(
         self,
         *,

--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -71,6 +71,16 @@ def build_submit_payload(
         for key in ("recipe", "character"):
             if recipe.get(key):
                 payload[key] = recipe[key]
+        # The pose's base model. Forwarded as-is; the engine appends .safetensors when
+        # missing and moves every loader that names the file, because 2.3 checkpoints are
+        # monoliths rather than a transformer plus separate parts.
+        #
+        # Worth knowing when reading a render that came back wrong: character LoRAs were
+        # trained against sulphur, and against another base a LoRA whose keys do not line up
+        # fuses NOTHING, silently. The engine logs its fusion count per render — that number
+        # is the thing to check first, not the prompt.
+        if recipe.get("checkpoint"):
+            payload["checkpoint"] = str(recipe["checkpoint"]).strip()
         # `is not None`, not truthiness: img_compression 0 is a real setting — it bypasses
         # the conditioning-frame encode — and a falsy check would drop it, leaving the engine
         # on its workflow default while the pose said otherwise.

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -13,6 +13,14 @@ from daemon.node_checker import check_and_install_nodes
 from daemon.queue_client import QueueClient
 from daemon.gpu_stats import get_gpu_stats
 from daemon.lora_sync import inventory as lora_inventory, sync_lora_catalog
+from daemon.ltx_client import LtxClient
+
+# Base models this worker can load, asked of the engine once it is healthy and then reported
+# on every heartbeat. Cached rather than re-fetched: the set only changes when someone puts a
+# 46 GB file on the box, and asking ComfyUI costs a round trip that a heartbeat should not
+# spend. See console#404 — the console needs a real list to offer, and the daemon is the only
+# thing that can see one, because the engine binds to 127.0.0.1 inside the container.
+_CHECKPOINTS: list[str] = []
 from daemon.resource_sync import sync_resources
 from daemon.sd_scripts_monitor import get_status as get_sd_scripts_status
 from daemon.a1111_monitor import get_status as get_a1111_status
@@ -116,7 +124,8 @@ async def heartbeat_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_
 
         try:
             data = await queue.heartbeat(worker_id, comfyui_running, gpu_stats, sd_scripts_status, a1111_status,
-                                         loras=lora_inventory())
+                                         loras=lora_inventory(),
+                                         checkpoints=_CHECKPOINTS or None)
             beat_count += 1
 
             # Pick up renames from the registry
@@ -484,6 +493,17 @@ async def run():
     # Before the GPU loop starts, so a fresh pod is useful on its first claim instead of
     # failing the first character segment it is handed. Non-fatal by design — see
     # sync_lora_catalog(): a restart loop is a worse failure than a missing LoRA.
+    # Ask the engine what base models it can load, for the console's dropdown. Non-fatal:
+    # a worker that cannot answer simply offers nothing, and the field falls back to the
+    # stack default rather than blocking a render.
+    if settings.engine == "ltx":
+        try:
+            _CHECKPOINTS[:] = await LtxClient().checkpoints()
+            logger.info("Checkpoints available: %s", ", ".join(_CHECKPOINTS) or "none")
+        except Exception as e:
+            logger.warning("Could not list checkpoints from ltx-engine (%s) — "
+                           "the console will offer none from this worker", e)
+
     if not await sync_lora_catalog(queue):
         logger.warning(
             "LoRA sync incomplete — this worker may fail segments that name a missing LoRA"

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -288,6 +288,7 @@ class QueueClient:
         sd_scripts_status: dict | None = None,
         a1111_status: dict | None = None,
         loras: dict | None = None,
+        checkpoints: list[str] | None = None,
     ) -> dict:
         """Send heartbeat. Returns full worker data including current friendly_name."""
         payload: dict = {"comfyui_running": comfyui_running}
@@ -301,6 +302,10 @@ class QueueClient:
         # not a fresh check — see lora_sync.inventory().
         if loras is not None:
             payload["loras"] = loras
+        # Base models this worker can load. Reported rather than fetched: the engine binds
+        # to localhost, so the daemon is the only thing that can ask it.
+        if checkpoints is not None:
+            payload["checkpoints"] = checkpoints
         resp = await self._request_with_retry(
             "POST", f"/workers/{worker_id}/heartbeat", json=payload
         )

--- a/tests/test_content_lora_payload.py
+++ b/tests/test_content_lora_payload.py
@@ -76,3 +76,16 @@ def test_strengths_without_a_lora_are_not_sent_alone():
     misleading record of what ran."""
     p = _payload(content_s1=0.3, content_s2=1.1)
     assert "content_s1" not in p and "content_s2" not in p
+
+
+def test_the_pose_checkpoint_is_forwarded():
+    """Without this the engine falls back to its default and every render uses one base
+    model — which is exactly the state that made sulphur-vs-10Eros impossible to compare."""
+    p = _payload(checkpoint="10Eros_v1.5_bf16")
+    assert p["checkpoint"] == "10Eros_v1.5_bf16"
+
+
+def test_no_checkpoint_means_the_engine_default():
+    """Every pose today. The key must be absent rather than null, so the engine applies its
+    own default rather than being handed one to interpret."""
+    assert "checkpoint" not in _payload()


### PR DESCRIPTION
Daemon half of console#404.

**Forwards** the pose's `checkpoint` to the engine. Without it the engine falls back to its default and every render uses one base model — the state that made a sulphur-vs-10Eros comparison impossible. Sent only when the pose sets one, so the key is absent rather than null for every existing pose.

**Reports** what base models this worker can load, through the heartbeat. The daemon is the only thing that can ask: the engine binds to `127.0.0.1` inside the container, so the API cannot reach it. Same gap, same fix as the LoRA inventory.

Asked of the engine rather than globbed off disk, because the engine asks ComfyUI and ComfyUI answers from the folder mapping — a file the mapping doesn't cover is invisible to a render however present it is. This lists what will **load**, not what exists.

Fetched once at boot and cached: the set only changes when someone puts a 46 GB file on the box, and a heartbeat shouldn't spend a round trip re-asking.

Non-fatal. A worker that can't answer reports nothing and the console offers fewer options — a render must not depend on a dropdown being complete.

> Worth knowing when a render comes back wrong: character LoRAs were trained against sulphur, and against another base a LoRA can fuse **nothing**, silently. The engine logs its fusion count per render; that number is the first thing to check, not the prompt.

116 tests.