### PR TITLE
daemon: a wedged HTTP client now recovers, or takes the worker out

### DIFF
--- a/daemon/main.py
+++ b/daemon/main.py
@@ -199,6 +199,24 @@ async def job_poll_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_e
             shutdown_event.set()
             break
 
+        # A worker that cannot reach the API is not available, and the expensive failure is
+        # that it keeps SAYING it is. On 2026-09-02 one sat registered and healthy-looking
+        # for 4.6 hours claiming nothing, with work queued behind it — nothing errored,
+        # nothing paged, the queue simply stopped (#160).
+        #
+        # Exiting rather than looping: the daemon is PID 1, so a clean exit restarts the
+        # container under its restart policy, which rebuilds every connection from scratch.
+        # That is the action a human took by hand to fix this last time, and there is no
+        # reason to make them do it again.
+        if queue.is_wedged():
+            logger.error(
+                "Cannot reach the API after %d consecutive failures — exiting so this "
+                "worker stops advertising itself as available. It will restart and "
+                "re-register with fresh connections.", queue._fail_streak,
+            )
+            shutdown_event.set()
+            break
+
         # Don't claim work if ComfyUI isn't running
         if not await comfyui.check_health():
             if poll_count == 0 or poll_count % 60 == 0:

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import logging
+import time
 import uuid
 from typing import Optional
 
@@ -48,19 +49,64 @@ def _raise_with_details(resp: httpx.Response, context: str) -> None:
 class QueueClient:
     """HTTP client for the wanly-api (queue + worker registry)."""
 
+    # After this many CONSECUTIVE transport failures the client itself is presumed wedged and
+    # is rebuilt. Not 1 or 2: a reaped keepalive connection and a brief network blip are both
+    # normal and already handled by the single retry below, and rebuilding on those would
+    # throw away a healthy pool constantly.
+    #
+    # 6 is roughly half a minute of solid failure at the claim loop's cadence — long enough
+    # to be real, short enough that a worker is not silently useless for hours (#160).
+    _REBUILD_AFTER = 6
+
+    # And after this many, the worker is not merely unlucky. It has been unable to reach the
+    # API across several fresh connection pools, so it should stop claiming to be available.
+    _GIVE_UP_AFTER = 40
+
     def __init__(self):
         self.base_url = settings.queue_url
-        headers = {}
+        self._headers = {}
         if settings.queue_api_key:
-            headers["X-API-Key"] = settings.queue_api_key
+            self._headers["X-API-Key"] = settings.queue_api_key
+        self.client = self._new_client()
+        # Consecutive transport failures. Reset by ANY success, so this counts a sustained
+        # inability to talk to the API rather than a total over the worker's life.
+        self._fail_streak = 0
+        self._wedged_since: float | None = None
+
+    def _new_client(self) -> httpx.AsyncClient:
         # keepalive_expiry below the far end's idle timeout: httpx otherwise hands out a
         # connection the server has already closed, and only finds out after writing the
         # request — surfacing as "Server disconnected without sending a response". Retiring
         # them locally first removes most of that class. See #105.
         limits = httpx.Limits(max_keepalive_connections=5, keepalive_expiry=30.0)
-        self.client = httpx.AsyncClient(
-            base_url=self.base_url, timeout=10, headers=headers, limits=limits
+        return httpx.AsyncClient(
+            base_url=self.base_url, timeout=10, headers=self._headers, limits=limits
         )
+
+    def is_wedged(self) -> bool:
+        """Has this worker been unable to reach the API for long enough to stop pretending?
+
+        A worker that cannot claim is not available, and the expensive failure mode is that
+        it keeps SAYING it is: on 2026-09-02 one sat registered and healthy-looking for 4.6
+        hours, claiming nothing, while work was queued behind it. Nothing errored and nothing
+        paged — the queue simply stopped.
+        """
+        return self._fail_streak >= self._GIVE_UP_AFTER
+
+    async def _rebuild_client(self) -> None:
+        """Replace the connection pool.
+
+        This is what `docker restart` achieved by accident when a wedged worker was fixed by
+        hand. The pool, not the process, was the broken thing — so replace the pool.
+        """
+        old = self.client
+        self.client = self._new_client()
+        try:
+            await old.aclose()
+        except Exception:
+            # Closing a pool that is already broken can itself raise. The new client is
+            # already in place, so this must not propagate.
+            pass
 
     async def _request_with_retry(self, method: str, url: str, **kwargs) -> httpx.Response:
         """Issue a request, retrying once on a transport-level failure.
@@ -71,13 +117,55 @@ class QueueClient:
         since claiming is not idempotent.
         """
         try:
-            return await self.client.request(method, url, **kwargs)
+            resp = await self.client.request(method, url, **kwargs)
         except (httpx.TransportError, httpx.RemoteProtocolError) as e:
+            self._note_failure(method, url, e)
+            try:
+                resp = await self.client.request(method, url, **kwargs)
+            except (httpx.TransportError, httpx.RemoteProtocolError) as e2:
+                # Both attempts failed. Count it and, past the threshold, rebuild the pool
+                # before giving up on this call — the next one then starts fresh instead of
+                # inheriting whatever is broken.
+                self._note_failure(method, url, e2)
+                if self._fail_streak >= self._REBUILD_AFTER:
+                    await self._rebuild_client()
+                raise
+        self._note_success()
+        return resp
+
+    def _note_success(self) -> None:
+        if self._fail_streak:
+            held = time.monotonic() - (self._wedged_since or time.monotonic())
+            if self._fail_streak >= self._REBUILD_AFTER:
+                logger.info("API reachable again after %d consecutive failures (%.0fs)",
+                            self._fail_streak, held)
+            self._fail_streak = 0
+            self._wedged_since = None
+
+    def _note_failure(self, method: str, url: str, exc: Exception) -> None:
+        """Count it, and make the log louder as the streak grows.
+
+        The old behaviour logged every failure at INFO, identically, forever. 4.6 hours of
+        that is indistinguishable from 4.6 hours of ordinary polling unless somebody reads
+        the timestamps — which is exactly what happened. A streak is a different event from
+        a blip and should not look the same.
+        """
+        self._fail_streak += 1
+        if self._wedged_since is None:
+            self._wedged_since = time.monotonic()
+        held = time.monotonic() - self._wedged_since
+
+        if self._fail_streak < self._REBUILD_AFTER:
             logger.info(
                 "%s %s failed at the transport layer (%s); retrying once on a fresh connection",
-                method, url, type(e).__name__,
+                method, url, type(exc).__name__,
             )
-            return await self.client.request(method, url, **kwargs)
+        elif self._fail_streak % 10 == 0 or self._fail_streak == self._REBUILD_AFTER:
+            logger.error(
+                "%s %s: %d CONSECUTIVE transport failures over %.0fs (%s). "
+                "Rebuilding the connection pool; this worker is claiming nothing.",
+                method, url, self._fail_streak, held, type(exc).__name__,
+            )
 
     async def claim_next(
         self, worker_id: uuid.UUID, worker_name: str | None = None, kind: str | None = None

--- a/tests/test_wedged_client.py
+++ b/tests/test_wedged_client.py
@@ -1,0 +1,87 @@
+"""A worker that cannot reach the API must stop pretending it can (#160).
+
+On 2026-09-02 a worker sat registered and healthy-looking for 4.6 hours, claiming nothing,
+with work queued behind it. Every request failed with RemoteProtocolError while the API was
+demonstrably reachable — verified from inside that worker's own container. Only the daemon's
+HTTP client was broken, and it never recovered.
+
+Nothing errored and nothing paged. The queue just stopped, next to a worker that looked fine.
+That is the failure this file guards.
+"""
+import httpx
+import pytest
+
+from daemon.queue_client import QueueClient
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr("daemon.queue_client.settings.queue_url", "http://example.invalid")
+    return QueueClient()
+
+
+class TestFailureStreak:
+    def test_a_single_blip_does_not_trip_anything(self, client):
+        """A reaped keepalive connection is normal and already handled by the one retry.
+        Rebuilding the pool on those would throw away a healthy one constantly."""
+        client._note_failure("GET", "/x", httpx.ConnectError("blip"))
+        assert client._fail_streak == 1
+        assert client._fail_streak < QueueClient._REBUILD_AFTER
+        assert not client.is_wedged()
+
+    def test_any_success_resets_the_streak(self, client):
+        """This counts a SUSTAINED inability to talk to the API, not a lifetime total. A
+        worker that fails five times and then works is not wedged."""
+        for _ in range(5):
+            client._note_failure("GET", "/x", httpx.ConnectError("x"))
+        client._note_success()
+        assert client._fail_streak == 0
+        assert not client.is_wedged()
+
+    def test_it_gives_up_only_after_a_long_streak(self, client):
+        """Between rebuild and give-up there is a lot of room on purpose: a rebuilt pool
+        deserves a real chance before the worker takes itself out of the fleet."""
+        for _ in range(QueueClient._GIVE_UP_AFTER - 1):
+            client._note_failure("GET", "/x", httpx.ConnectError("x"))
+        assert not client.is_wedged()
+        client._note_failure("GET", "/x", httpx.ConnectError("x"))
+        assert client.is_wedged()
+
+    def test_rebuild_comes_well_before_give_up(self):
+        """Rebuilding is cheap and often sufficient — it is what `docker restart` achieved
+        by accident. Exiting is the last resort, not the first."""
+        assert QueueClient._REBUILD_AFTER < QueueClient._GIVE_UP_AFTER
+
+
+class TestPoolRebuild:
+    @pytest.mark.asyncio
+    async def test_rebuilding_replaces_the_pool(self, client):
+        """The pool was the broken thing, not the process. Replacing it is the whole fix."""
+        before = client.client
+        await client._rebuild_client()
+        assert client.client is not before
+
+    @pytest.mark.asyncio
+    async def test_rebuilding_survives_a_pool_that_fails_to_close(self, client, monkeypatch):
+        """Closing an already-broken pool can itself raise. The new client is in place by
+        then, so that must not propagate and undo the recovery."""
+        async def boom():
+            raise RuntimeError("pool already broken")
+        monkeypatch.setattr(client.client, "aclose", boom)
+        await client._rebuild_client()          # must not raise
+        assert client.client is not None
+
+
+class TestLogEscalation:
+    def test_a_long_streak_logs_at_error_not_info(self, client, caplog):
+        """4.6 hours of identical INFO lines is indistinguishable from ordinary polling
+        unless somebody reads the timestamps — which is exactly what happened. A streak is a
+        different event from a blip and must not look the same."""
+        import logging
+        caplog.set_level(logging.INFO, logger="daemon.queue_client")
+        for _ in range(QueueClient._REBUILD_AFTER):
+            client._note_failure("GET", "/segments/next", httpx.ConnectError("x"))
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert errors, "a sustained streak must escalate above INFO"
+        assert "CONSECUTIVE" in errors[-1].getMessage()
+        assert "claiming nothing" in errors[-1].getMessage()


### PR DESCRIPTION
Fixes #160.

On 2026-09-02 a worker sat **registered and healthy-looking for 4.6 hours**, claiming nothing, with work queued behind it:

```
22:53:15  Segment 0 complete in 600.9s      <- last real work
23:13:52  Waiting for work... (polled 240 times)
23:14 -> 03:45   every request failed, nothing else logged
```

Every call died with `RemoteProtocolError` while the API was **demonstrably reachable** — verified with curl from inside that worker's own container (`/health` 200, `/segments/next` a clean 401). Only the daemon's HTTP client was broken, and it never recovered.

Nothing errored. Nothing paged. The queue just stopped, next to a worker that looked fine. A crash would have been noticed in minutes.

### Three changes, escalating

| after | action | why |
|---|---|---|
| 6 consecutive failures | **rebuild the connection pool** | this is what `docker restart` achieved by accident — the pool was broken, not the process |
| 6, then every 10 | **log at ERROR** with streak length and duration | identical INFO lines for 4.6 hours are indistinguishable from ordinary polling |
| 40 | **exit** | the worker has failed across several fresh pools; it should stop advertising itself |

**Not 1 or 2 for the rebuild.** A reaped keepalive connection and a brief blip are both normal and already handled by the existing single retry; rebuilding on those would discard a healthy pool constantly.

**Exiting rather than looping**, because the daemon is PID 1 — a clean exit restarts the container under its restart policy, rebuilding every connection from scratch. That is exactly the action a human took to fix this last time.

**The streak resets on any success**, so it measures a sustained inability to reach the API rather than a lifetime total.

7 tests, 123 total. One of them covers a pool that raises while being closed — an already-broken pool can fail to `aclose()`, and the new client is in place by then, so that must not propagate and undo the recovery.