### PR TITLE
loras: forward the pose's content LoRA list, in order

### DIFF
--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -110,25 +110,39 @@ def build_submit_payload(
                 "strength_stage_2": float(s2),
             }]
 
-        # The POSE's content LoRA — motion and act — chained ahead of the character LoRA on both
-        # stage branches. Sent as its own field, not appended to `loras`: that list is the
-        # CHARACTER LoRA on this path and the engine reads loras[0] as such, so a second entry
-        # would be silently taken for a character.
-        content = recipe.get("content_lora")
-        if content and str(content).strip().lower() != "none":
-            content = str(content).strip()
-            # Same extension normalisation, and for the same reason: names are stored bare
-            # because that is how they are displayed, and the engine matches files exactly.
-            if not content.endswith(".safetensors"):
-                content = f"{content}.safetensors"
-            payload["content_lora"] = content
-            # `is not None`, exactly as img_compression above. A content strength of 0 is a REAL
-            # setting: it loads the LoRA and gives it no weight, which is how you measure what it
-            # contributes. A falsy check would drop it and the engine would apply its 0.6
-            # default, so the measurement would silently be of a different configuration.
-            for key, field in (("content_s1", "content_s1"), ("content_s2", "content_s2")):
-                if recipe.get(key) is not None:
-                    payload[field] = float(recipe[key])
+        # The POSE's content LoRAs — motion and act — chained ahead of the character LoRA on
+        # both stage branches, IN ORDER. They stack: motion, act and framing are separable
+        # and a pose may want several (console#410). Order is part of the configuration, so
+        # it is forwarded exactly as stored.
+        #
+        # Sent as their own field, not appended to `loras`. On this path the engine reads
+        # loras[0] as the CHARACTER LoRA, so a content LoRA added to that list would be
+        # loaded as a character — both load, the render succeeds, and it is the wrong person.
+        contents = []
+        for entry in (recipe.get("content_loras") or []):
+            if not isinstance(entry, dict):
+                continue
+            name = str(entry.get("name") or "").strip()
+            if not name or name.lower() == "none":
+                # "none" is how a pose says off. Forwarded, the engine would look for
+                # 'none.safetensors' and the segment would die ten minutes into a claim.
+                continue
+            # Same extension normalisation as the character LoRA, for the same reason: names
+            # are stored bare because that is how they are displayed, and the engine matches
+            # files exactly. A real render died on `no such lora 'pay_v2_e05'` while the
+            # .safetensors sat in the very list the error printed.
+            item = {"name": name if name.endswith(".safetensors") else f"{name}.safetensors"}
+            # `is not None`, not truthiness: a strength of 0 is a REAL setting — it loads the
+            # LoRA and gives it no weight, which is how you measure what it contributes. A
+            # falsy check would drop it and the engine would apply its own 0.6 default, so
+            # the measurement would silently be of a different configuration.
+            for k in ("s1", "s2"):
+                if entry.get(k) is not None:
+                    item[k] = float(entry[k])
+            contents.append(item)
+        if contents:
+            payload["content_loras"] = contents
+
     return payload
 
 

--- a/tests/test_content_lora_payload.py
+++ b/tests/test_content_lora_payload.py
@@ -24,23 +24,21 @@ def _payload(**recipe):
 
 def test_a_pose_without_a_content_lora_sends_none():
     """Every pose today. The engine then renders on the checkpoint plus the character."""
-    p = _payload()
-    assert "content_lora" not in p
-    assert "content_s1" not in p and "content_s2" not in p
+    assert "content_loras" not in _payload()
 
 
 def test_none_in_any_spelling_is_not_sent_as_a_filename():
-    """"none" is how the stack says off. Sent through, the engine would look for
+    """"none" is how a pose says off. Sent through, the engine would look for
     'none.safetensors' and the segment would die ten minutes in."""
     for spelling in ("none", "NONE", " None ", ""):
-        assert "content_lora" not in _payload(content_lora=spelling)
+        assert "content_loras" not in _payload(content_loras=[{"name": spelling}])
 
 
 def test_the_content_lora_is_its_own_field_not_a_second_entry_in_loras():
     """`loras[0]` is the CHARACTER LoRA on this path. A content LoRA appended there would
     be read as a character — both load, the render succeeds, and it is the wrong person."""
-    p = _payload(content_lora="sfbehind_LTX2_3_v0_1")
-    assert p["content_lora"] == "sfbehind_LTX2_3_v0_1.safetensors"
+    p = _payload(content_loras=[{"name": "sfbehind_LTX2_3_v0_1"}])
+    assert p["content_loras"][0]["name"] == "sfbehind_LTX2_3_v0_1.safetensors"
     assert len(p["loras"]) == 1
     assert p["loras"][0]["name"] == "k3lly2026_v2.safetensors"
 
@@ -48,15 +46,16 @@ def test_the_content_lora_is_its_own_field_not_a_second_entry_in_loras():
 def test_the_extension_is_added_because_the_engine_matches_files_exactly():
     """A real render died on `no such lora 'pay_v2_e05'` while the .safetensors sat in the
     very list the error printed."""
-    assert _payload(content_lora="sfbehind_LTX2_3_v0_1")["content_lora"].endswith(".safetensors")
-    already = _payload(content_lora="sfbehind_LTX2_3_v0_1.safetensors")["content_lora"]
-    assert already == "sfbehind_LTX2_3_v0_1.safetensors"   # not doubled
+    p = _payload(content_loras=[{"name": "sfbehind_LTX2_3_v0_1"}])
+    assert p["content_loras"][0]["name"].endswith(".safetensors")
+    already = _payload(content_loras=[{"name": "sfbehind_LTX2_3_v0_1.safetensors"}])
+    assert already["content_loras"][0]["name"] == "sfbehind_LTX2_3_v0_1.safetensors"  # not doubled
 
 
 def test_both_strengths_are_forwarded_independently():
-    p = _payload(content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.3, content_s2=1.1)
-    assert p["content_s1"] == 0.3
-    assert p["content_s2"] == 1.1
+    p = _payload(content_loras=[{"name": "sfbehind_LTX2_3_v0_1", "s1": 0.3, "s2": 1.1}])
+    assert p["content_loras"][0]["s1"] == 0.3
+    assert p["content_loras"][0]["s2"] == 1.1
 
 
 def test_a_strength_of_zero_is_forwarded_and_not_dropped():
@@ -66,16 +65,24 @@ def test_a_strength_of_zero_is_forwarded_and_not_dropped():
     the engine applies its own 0.6 default and the measurement is of another configuration
     entirely, with nothing in any log to say so.
     """
-    p = _payload(content_lora="sfbehind_LTX2_3_v0_1", content_s1=0.0, content_s2=0.0)
-    assert p["content_s1"] == 0.0
-    assert p["content_s2"] == 0.0
+    p = _payload(content_loras=[{"name": "sfbehind_LTX2_3_v0_1", "s1": 0.0, "s2": 0.0}])
+    assert p["content_loras"][0]["s1"] == 0.0
+    assert p["content_loras"][0]["s2"] == 0.0
 
 
-def test_strengths_without_a_lora_are_not_sent_alone():
-    """They would configure a LoRA that is not being loaded — noise in the payload, and a
-    misleading record of what ran."""
-    p = _payload(content_s1=0.3, content_s2=1.1)
-    assert "content_s1" not in p and "content_s2" not in p
+def test_the_order_of_the_list_is_preserved():
+    """Order is part of the configuration: the same LoRAs applied in a different order are a
+    different render, so the payload must not reorder or deduplicate."""
+    p = _payload(content_loras=[{"name": "first"}, {"name": "second"}, {"name": "third"}])
+    assert [c["name"] for c in p["content_loras"]] == [
+        "first.safetensors", "second.safetensors", "third.safetensors"]
+
+
+def test_a_none_entry_is_dropped_without_disturbing_the_rest():
+    """A pose may carry an off entry among live ones. Skipping it must not reorder what
+    remains."""
+    p = _payload(content_loras=[{"name": "a"}, {"name": "none"}, {"name": "b"}])
+    assert [c["name"] for c in p["content_loras"]] == ["a.safetensors", "b.safetensors"]
 
 
 def test_the_pose_checkpoint_is_forwarded():


### PR DESCRIPTION
Daemon half of console#410.

Sent as their own field, **not** appended to `loras`: on this path the engine reads `loras[0]` as the CHARACTER LoRA, so a content LoRA added to that list would be loaded as a character — both load, the render succeeds, and it's the wrong person.

**Order is forwarded exactly as stored**, because it's part of the configuration. Two tests cover it: the payload neither reorders nor deduplicates, and skipping a `"none"` entry among live ones doesn't disturb the order of what remains.

**Strengths use `is not None`**, the rule `img_compression` documents: 0 is a real setting — the LoRA loads and gives it no weight, which is how you measure what it contributes. A falsy check would drop it and the engine would apply its own 0.6, so the measurement would silently be of a different configuration.

`"none"` in any spelling is skipped rather than forwarded; the engine would look for `none.safetensors` and the segment would die ten minutes into a claim.

124 tests.