### PR TITLE
segments: surface what the engine already reports

### DIFF
--- a/daemon/ltx_executor.py
+++ b/daemon/ltx_executor.py
@@ -53,6 +53,52 @@ async def _start_image_bytes(segment: SegmentClaim, queue: QueueClient) -> bytes
     return data
 
 
+def _engine_detail(job: dict) -> list[str]:
+    """The parts of the engine's job view worth putting in the segment's own record.
+
+    FUSION COVERAGE is the one that matters. A LoRA whose keys do not line up against the
+    checkpoint fuses NOTHING and says nothing about it — no error, no warning, the run looks
+    completely normal and comes back as the base model with none of the character in it.
+    Now that a pose can choose its own base model (console#404), "did it fuse?" is a routine
+    question, and 480/480 is exactly as informative as 0/480. Only the zero case was ever
+    promoted anywhere a person could see it; both belong on the segment.
+
+    STAGES say what each pass actually ran — read off the resolved graph by the engine, not
+    echoed from the request, so a step count the workflow could not express shows up here
+    rather than being silently ignored.
+
+    Deliberately quiet when there is nothing to say: no LoRAs means no lines, so this does
+    not add noise to renders that have none.
+    """
+    out: list[str] = []
+
+    for lo in job.get("loras") or []:
+        name = lo.get("name", "?")
+        fused, targeted = lo.get("fused"), lo.get("targeted")
+        s1, s2 = lo.get("strength_stage_1"), lo.get("strength_stage_2")
+        at = f" @{s1}/{s2}" if s1 is not None and s2 is not None else ""
+        if fused is None or targeted is None:
+            # The engine could not read the checkpoint to compare against. Said out loud,
+            # because "no coverage line" and "coverage of zero" must not look the same.
+            out.append(f"lora {name}{at}: fusion coverage unavailable")
+        elif fused == 0:
+            out.append(f"lora {name}{at}: FUSED 0/{targeted} — this render carries NONE of it")
+        else:
+            out.append(f"lora {name}{at}: fused {fused}/{targeted} weights")
+
+    stages = job.get("stages") or []
+    if stages:
+        parts = []
+        for st in stages:
+            n = st.get("stage", "?")
+            steps = st.get("steps")
+            sched = st.get("schedule", "")
+            parts.append(f"stage {n}: {steps} steps ({sched})" if steps is not None
+                         else f"stage {n}: {sched}")
+        out.append("passes — " + ", ".join(parts))
+
+    return out
+
 async def execute_ltx_segment(segment: SegmentClaim, queue: QueueClient) -> None:
     """Render one segment on ltx-engine and report the result."""
     recipe = segment.ltx_recipe or {}
@@ -118,6 +164,13 @@ async def execute_ltx_segment(segment: SegmentClaim, queue: QueueClient) -> None
         # was signed off — so it goes in the segment's own log, not just the engine's.
         for note in job.get("notes") or []:
             await progress.log(f"[4/6] {note}")
+
+        # The engine reports more than its notes, and until now the rest was dropped on the
+        # floor — readable only by shelling into the container and reading
+        # /workspace/logs/ltx-engine.log. That is how answering "did the character LoRA
+        # actually apply on this render?" became a docker exec (console#392).
+        for line in _engine_detail(job):
+            await progress.log(f"[4/6] {line}")
 
         await progress.log("[5/6] Downloading video...")
         video_data = await client.fetch_video(job_id)

--- a/tests/test_engine_detail.py
+++ b/tests/test_engine_detail.py
@@ -1,0 +1,54 @@
+"""What the engine already knows, put where a person can read it (console#392).
+
+`GET /job/{id}` on ltx-engine returns `stages` and `loras` with fusion coverage. The daemon
+read only `notes`, so the rest existed solely in /workspace/logs/ltx-engine.log inside the
+container — which is how answering "did the character LoRA actually apply?" became a
+docker exec.
+
+The fusion count is the one that matters. A LoRA whose keys do not line up against the
+checkpoint fuses NOTHING and says nothing about it: no error, no warning, the run looks
+normal and comes back as the base model with none of the character in it.
+"""
+from daemon.ltx_executor import _engine_detail
+
+
+def test_a_full_fuse_is_reported_not_just_a_failure():
+    """480/480 is exactly as informative as 0/480 when comparing base models. Only the zero
+    case was ever visible, which is half an answer."""
+    out = _engine_detail({"loras": [
+        {"name": "k3lly2026_v2.safetensors", "strength_stage_1": 0.8,
+         "strength_stage_2": 1.5, "fused": 480, "targeted": 480}]})
+    assert any("fused 480/480" in l for l in out)
+    assert any("@0.8/1.5" in l for l in out)
+
+
+def test_a_zero_fuse_is_stated_in_terms_of_what_it_means():
+    """"fused 0/480" is a number. "carries NONE of it" is what the number means, and the
+    person reading a disappointing render needs the second one."""
+    out = _engine_detail({"loras": [
+        {"name": "k3lly2026_v2.safetensors", "fused": 0, "targeted": 480}]})
+    assert any("FUSED 0/480" in l and "carries NONE" in l for l in out)
+
+
+def test_unavailable_coverage_is_not_silently_the_same_as_zero():
+    """The engine could not read the checkpoint to compare against. "no line" and "zero"
+    must not look alike — one is a missing measurement, the other is a broken render."""
+    out = _engine_detail({"loras": [
+        {"name": "x.safetensors", "fused": None, "targeted": None}]})
+    assert any("unavailable" in l for l in out)
+    assert not any("0/" in l for l in out)
+
+
+def test_stages_describe_what_each_pass_ran():
+    out = _engine_detail({"stages": [
+        {"stage": 1, "steps": 8, "schedule": "distilled sigma table"},
+        {"stage": 2, "steps": 3, "schedule": "distilled sigma table"}]})
+    line = next(l for l in out if l.startswith("passes"))
+    assert "stage 1: 8 steps" in line and "stage 2: 3 steps" in line
+
+
+def test_it_is_silent_when_there_is_nothing_to_say():
+    """A render with no LoRAs must not gain empty lines. This runs on every segment, so
+    noise here is noise on everything."""
+    assert _engine_detail({}) == []
+    assert _engine_detail({"loras": [], "stages": []}) == []


### PR DESCRIPTION
Tier 1 of console#392.

`GET /job/{id}` on ltx-engine **already returns** `stages` and `loras` with fusion coverage. The daemon read only `notes`, so the rest existed solely in `/workspace/logs/ltx-engine.log` inside the container.

That's how answering *"which base model did job 905e9265 use, and did the character LoRA apply?"* became a `docker exec` into the box. Now:

```
[4/6] recipe 'Missionary - 10Eros' · base 10Eros_v1.5_bf16 · char k3lly2026_v2 @0.8/1.5 · content none · graph a7b8d9f5
[4/6] lora k3lly2026_v2.safetensors @0.8/1.5: fused 480/480 weights
[4/6] passes — stage 1: 8 steps (distilled sigma table), stage 2: 3 steps (distilled sigma table)
```

### Why fusion coverage is the line that matters

A LoRA whose keys don't line up against the checkpoint **fuses nothing and says nothing about it** — no error, no warning, the run looks completely normal and comes back as the base model with none of the character in it.

Now that a pose can choose its own base model (console#404), "did it fuse?" is a routine question. **`480/480` is exactly as informative as `0/480`** — and only the zero case was ever promoted anywhere visible, which is half an answer.

A zero fuse is stated in terms of what it *means* ("carries NONE of it"), not just as a ratio. Unavailable coverage is distinguished from zero, because a missing measurement and a broken render are different things.

**Silent when there's nothing to say** — no LoRAs means no lines, so this adds no noise to renders that have none. Tested, since it runs on every segment.

### Not in this change

Tier 2 — live step progress during the ten-minute `[4/6]` gap — needs a websocket client against ComfyUI, because the engine polls `/queue` which is binary. Design is on the ticket.

5 tests, 131 total.