### PR TITLE
loras: a character LoRA of 'none' must not reach the engine as a filename

### DIFF
--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -87,6 +87,17 @@ def build_submit_payload(
         if recipe.get("img_compression") is not None:
             payload["img_compression"] = int(recipe["img_compression"])
         lora = recipe.get("char_lora")
+        # "none" is how a render says "no character" — useful for judging what the LoRA is
+        # actually contributing, and for a shot whose start frame already carries the
+        # identity (console#412).
+        #
+        # It has to be filtered HERE, not left to the engine. `if lora` alone passes,
+        # because the STRING "none" is truthy, and the entry would then be normalised to
+        # "none.safetensors" — which is no longer the literal "none" the engine's own
+        # want_char check looks for, so it would sail past that and 422 on a file that does
+        # not exist, ten minutes into a claimed segment.
+        if lora and str(lora).strip().lower() == "none":
+            lora = None
         s1, s2 = recipe.get("char_s1"), recipe.get("char_s2")
         if lora and s1 is not None and s2 is not None:
             # The engine matches LoRAs by EXACT filename. Its own recipe path appends the

--- a/tests/test_content_lora_payload.py
+++ b/tests/test_content_lora_payload.py
@@ -96,3 +96,23 @@ def test_no_checkpoint_means_the_engine_default():
     """Every pose today. The key must be absent rather than null, so the engine applies its
     own default rather than being handed one to interpret."""
     assert "checkpoint" not in _payload()
+
+
+def test_a_character_lora_of_none_is_not_sent():
+    """"none" means render without a character LoRA (console#412).
+
+    It must be filtered here rather than left to the engine: `if lora` alone passes, because
+    the STRING "none" is truthy, and the entry would then be normalised to
+    "none.safetensors" — no longer the literal "none" the engine's want_char check looks
+    for. It would sail past that and 422 on a file that does not exist, ten minutes into a
+    claimed segment.
+    """
+    for spelling in ("none", "NONE", " None "):
+        p = _payload(char_lora=spelling)
+        assert "loras" not in p or p["loras"] == [], f"{spelling!r} was forwarded as a LoRA"
+
+
+def test_a_real_character_lora_is_still_sent():
+    """The guard must not swallow the normal case."""
+    p = _payload(char_lora="k3lly2026_v2")
+    assert p["loras"][0]["name"] == "k3lly2026_v2.safetensors"


### PR DESCRIPTION
Daemon half of console#412. Pairs with wanly-console#413.

`"none"` means render on the checkpoint alone — useful for judging what the LoRA is actually contributing, and for a shot whose start frame already carries the identity.

**The engine has always understood it.** `want_char = char_name.lower() not in ("", "none")` has excluded it all along, so I expected this ticket to be a one-line dropdown addition.

**But the daemon would have mangled it.** `if lora` alone passes, because the string `"none"` is **truthy**. The entry was then normalised to `none.safetensors` — no longer the literal `"none"` the engine's `want_char` check looks for — so it would sail straight past that guard and 422 on a file that doesn't exist, ten minutes into a claimed segment.

Filtered here, before normalisation, in any casing. Verified end to end:

```
normal   daemon loras=['k3lly2026_v2.safetensors']  -> engine char node: present
none     daemon loras=[]                            -> engine char node: ABSENT
NONE     daemon loras=[]                            -> engine char node: ABSENT
         note: char none · content none
```

The note says `char none` rather than going silent — "no character LoRA" and "nothing reported" must not look the same.

2 tests, 126 total.