### PR TITLE
segments: reclaim the engine's local media after a successful upload

### DIFF
--- a/daemon/ltx_client.py
+++ b/daemon/ltx_client.py
@@ -172,6 +172,19 @@ class LtxClient:
         result: dict[str, Any] = r.json()
         return result
 
+    async def purge(self, job_id: str) -> dict:
+        """Drop the engine's local media for a finished job (console#380).
+
+        Only ever called AFTER a successful upload: the local file is the only copy until
+        that upload lands, and reclaiming disk is not worth risking a render.
+
+        The engine keeps graph.json and prompt.txt — ~7 MB across 500 jobs against 2.7 GB of
+        media, and the only local record of what a render actually did.
+        """
+        r = await self._client.post(f"/job/{job_id}/purge", timeout=30.0)
+        r.raise_for_status()
+        return r.json()
+
     async def checkpoints(self) -> list[str]:
         """Base models this worker can actually load.
 

--- a/daemon/ltx_executor.py
+++ b/daemon/ltx_executor.py
@@ -195,6 +195,22 @@ async def execute_ltx_segment(segment: SegmentClaim, queue: QueueClient) -> None
         )
         logger.info("Segment %d complete in %.1fs", segment.index, time.monotonic() - started)
 
+        # Reclaim the engine's local copies now that S3 has them (console#380). AFTER the
+        # upload, never before — the local file is the only copy until that call returns.
+        #
+        # Failure here is logged and swallowed. The segment is already complete and
+        # uploaded; turning a successful render into a failure over disk housekeeping would
+        # be a much worse outcome than 5 MB left behind, which the next sweep collects
+        # anyway.
+        try:
+            purged = await client.purge(job_id)
+            if purged.get("removed"):
+                logger.info("Purged %d local file(s), %.1f MB reclaimed",
+                            len(purged["removed"]), purged.get("freed_bytes", 0) / 1e6)
+        except Exception as e:
+            logger.warning("Could not purge engine job %s (%s) — leaving it for the sweep",
+                           job_id, e)
+
     except Exception as e:
         error_msg = f"{type(e).__name__}: {e}"
         logger.exception("LTX segment %s failed", segment.id)

--- a/tests/test_engine_detail.py
+++ b/tests/test_engine_detail.py
@@ -52,3 +52,30 @@ def test_it_is_silent_when_there_is_nothing_to_say():
     noise here is noise on everything."""
     assert _engine_detail({}) == []
     assert _engine_detail({"loras": [], "stages": []}) == []
+
+
+class TestPurgeIsNonFatal:
+    """Reclaiming disk must never turn a successful render into a failure (console#380).
+
+    The purge runs AFTER the upload. At that point the segment is complete and S3 has the
+    video; the local copy is a duplicate. Failing the segment over housekeeping would trade
+    a finished render for 5 MB, and the next sweep collects it anyway.
+    """
+
+    def test_the_purge_is_wrapped_and_only_warns(self):
+        import inspect
+        from daemon import ltx_executor as mod
+        src = inspect.getsource(mod.execute_ltx_segment)
+        i = src.index("client.purge(")
+        window = src[i - 400:i + 400]
+        assert "try:" in window
+        assert "logger.warning" in window
+        assert "raise" not in window.split("except")[-1], "a purge failure must not propagate"
+
+    def test_it_runs_after_the_upload_not_before(self):
+        """The local file is the only copy until the upload returns."""
+        import inspect
+        from daemon import ltx_executor as mod
+        src = inspect.getsource(mod.execute_ltx_segment)
+        assert src.index("upload_segment_output") < src.index("client.purge("), \
+            "purge must come after the upload"


### PR DESCRIPTION
Daemon half of console#380. Pairs with wanly-gpu-docker `feat/purge-render-artifacts`.

Calls the engine's purge once S3 has the video — **after** the upload, never before, because the local file is the only copy until that call returns. Reclaiming disk isn't worth risking a render.

**Failure is logged and swallowed.** The segment is already complete and uploaded; turning a successful render into a failure over disk housekeeping would trade a finished render for 5 MB, which the next sweep collects anyway.

Two tests pin the ordering and the non-fatality, because both are the kind of thing a later refactor tidies away without noticing.

2 tests, 133 total.