### PR TITLE
workers: report which artifact kinds this worker can fetch on demand

### DIFF
--- a/daemon/main.py
+++ b/daemon/main.py
@@ -21,6 +21,16 @@ from daemon.ltx_client import LtxClient
 # spend. See console#404 — the console needs a real list to offer, and the daemon is the only
 # thing that can see one, because the engine binds to 127.0.0.1 inside the container.
 _CHECKPOINTS: list[str] = []
+
+# Artifact kinds this worker can FETCH on demand, as opposed to the ones it already holds.
+# The API will not hand a worker a segment whose models it cannot load (console#422), and a
+# LoRA this box has never seen must not count against it: lora_sync downloads those inside
+# the claim, and refusing the work would make the queue wait for a restart it does not need.
+#
+# A constant, not a probe, because it describes what this CODE can do. When on-demand
+# checkpoint fetching lands (console#423) it gains "checkpoint" here and the gate opens by
+# itself — the API holds no second opinion about a daemon's abilities.
+FETCHABLE_KINDS: list[str] = ["lora"]
 from daemon.resource_sync import sync_resources
 from daemon.sd_scripts_monitor import get_status as get_sd_scripts_status
 from daemon.a1111_monitor import get_status as get_a1111_status
@@ -125,7 +135,8 @@ async def heartbeat_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_
         try:
             data = await queue.heartbeat(worker_id, comfyui_running, gpu_stats, sd_scripts_status, a1111_status,
                                          loras=lora_inventory(),
-                                         checkpoints=_CHECKPOINTS or None)
+                                         checkpoints=_CHECKPOINTS or None,
+                                         fetchable_kinds=FETCHABLE_KINDS)
             beat_count += 1
 
             # Pick up renames from the registry

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -377,6 +377,7 @@ class QueueClient:
         a1111_status: dict | None = None,
         loras: dict | None = None,
         checkpoints: list[str] | None = None,
+        fetchable_kinds: list[str] | None = None,
     ) -> dict:
         """Send heartbeat. Returns full worker data including current friendly_name."""
         payload: dict = {"comfyui_running": comfyui_running}
@@ -394,6 +395,16 @@ class QueueClient:
         # to localhost, so the daemon is the only thing that can ask it.
         if checkpoints is not None:
             payload["checkpoints"] = checkpoints
+        # Artifact kinds this worker can GET, not just the ones it already holds. The API
+        # refuses to hand a worker a segment whose models it cannot load (console#422), and
+        # without this it would also refuse one naming a LoRA this box has never seen — work
+        # the daemon would have handled by itself, since it downloads those at claim time.
+        #
+        # Declared here rather than assumed there on purpose: when this daemon learns to
+        # fetch checkpoints (console#423) it adds "checkpoint" to this list and the gate
+        # opens, with no API change and no coordinated deploy.
+        if fetchable_kinds is not None:
+            payload["fetchable_kinds"] = fetchable_kinds
         resp = await self._request_with_retry(
             "POST", f"/workers/{worker_id}/heartbeat", json=payload
         )

--- a/tests/test_heartbeat_fetchable_kinds.py
+++ b/tests/test_heartbeat_fetchable_kinds.py
@@ -1,0 +1,47 @@
+"""The heartbeat says what this worker can FETCH, not only what it holds (console#422).
+
+The API refuses to hand a worker a segment whose models it cannot load. Without this field
+it would also refuse one naming a LoRA this box has never seen — work the daemon downloads
+inside the claim anyway — and the worker would sit idle waiting for a restart it does not
+need. A silent starve, on the one path where silence looks exactly like an empty queue.
+"""
+import uuid
+
+import httpx
+
+from daemon import main
+from daemon.queue_client import QueueClient
+
+
+class _Capture:
+    def __init__(self):
+        self.payload = None
+
+    async def request(self, method, url, **kwargs):
+        self.payload = kwargs.get("json")
+        return httpx.Response(200, json={"friendly_name": "w"},
+                              request=httpx.Request(method, "http://x"))
+
+
+async def _beat(**kwargs) -> dict:
+    client = QueueClient()
+    cap = _Capture()
+    client.client = cap
+    await client.heartbeat(uuid.uuid4(), True, **kwargs)
+    return cap.payload
+
+
+class TestWhatTheHeartbeatCarries:
+    async def test_fetchable_kinds_are_sent_when_given(self):
+        assert (await _beat(fetchable_kinds=["lora"]))["fetchable_kinds"] == ["lora"]
+
+    async def test_absent_rather_than_null_when_not_given(self):
+        """Every optional field here works this way: the API reads a missing key as "no
+        change", so sending null would overwrite what a previous beat established."""
+        assert "fetchable_kinds" not in await _beat()
+
+    def test_this_daemon_declares_loras_and_not_checkpoints(self):
+        """LoRAs are fetched at claim time (lora_sync.ensure_named_loras_present); a 46 GB
+        checkpoint is not, and claiming a segment that needs one would fail ten minutes in.
+        console#423 is what flips the second half of this."""
+        assert main.FETCHABLE_KINDS == ["lora"]


### PR DESCRIPTION
Daemon half of DavidJBarnes/wanly-console#422. Pairs with wanly-api#249.

The API now refuses to hand a worker any segment whose models it cannot load. Checkpoints it either has or does not — but **a LoRA it has never seen is not a reason to refuse**: `lora_sync.ensure_named_loras_present` downloads those inside the claim, and withholding the work would make the queue wait for a restart it does not need.

So the heartbeat carries `fetchable_kinds`, `["lora"]` today.

Declared by the worker rather than assumed by the API, because when this daemon learns to fetch checkpoints (console#423) it adds `"checkpoint"` to that list and the gate opens by itself — no API change, no coordinated deploy, and no second opinion up there about what this code can do.

Omitted rather than sent as `null` when unset, like every optional field beside it: the API reads a missing key as "no change".

**Safe to merge in either order with wanly-api#249.** This only adds a field; an API that does not read it ignores it, and an API that does treats its absence as "fetches nothing" — which still claims everything this worker already holds.

**Verified:** 136 passed (3 new — the field is sent, it is omitted rather than nulled when unset, and this daemon declares loras but not checkpoints). The `E402` ruff findings in `daemon/main.py` are pre-existing and present on main.

https://claude.ai/code/session_011m6VWR2d8jn7hMQ2xQthPR