### PR TITLE
ltx: fetch a base model this worker lacks, inside the claim

### DIFF
--- a/daemon/checkpoint_sync.py
+++ b/daemon/checkpoint_sync.py
@@ -1,0 +1,227 @@
+"""Fetch a base model this worker does not hold, inside the claim (console#423).
+
+The counterpart to lora_sync's ensure_named_loras_present, for files ~70x larger. That gap
+is the whole design: a character LoRA is 624 MB and can be fetched naively, a checkpoint is
+46 GB and every shortcut that works for the LoRA fails here.
+
+WHY NOT hf_hub_download
+    huggingface_hub is not in this daemon's requirements, and adding a dependency to stream
+    bytes over HTTPS would be a poor trade. httpx is already here, and streaming it
+    ourselves is what makes two of this file's requirements achievable at all:
+
+      * the HEARTBEAT MUST SURVIVE. Heartbeat is the only reclaim authority for a live
+        worker: if a 46 GB transfer blocks the event loop, this worker stops beating, the
+        API reclaims the segment as orphaned, and a second worker starts rendering it while
+        this one is still downloading. An async stream yields between chunks, so the
+        heartbeat task keeps running throughout.
+      * PROGRESS IN THE SEGMENT LOG. A 5-10 minute silent step is indistinguishable from the
+        wedge in #160. hf_hub_download draws a \\r progress bar, which a line-oriented log
+        cannot show at all -- download_models.sh records 45 minutes of total silence from
+        exactly that.
+
+WHERE THE URL COMES FROM
+    The API, never a guess. wanly-api's /ltx/checkpoints/catalog maps a checkpoint name to
+    {repo, path, size_bytes}. Held there rather than here so a new base model is one entry
+    instead of a redeploy to every worker.
+
+WHAT ARRIVES IS VERIFIED
+    A partial safetensors is a VALID HEADER OVER MISSING DATA. It passes every existence
+    check and fails only at load, deep inside a claimed segment -- download_models.sh
+    records one arriving at 14.40 of 27.16 GiB reporting nothing at all. So the file is
+    staged under a .part name and only renamed into place after the byte count matches the
+    catalogue exactly AND the safetensors header agrees with the file length.
+"""
+
+import json
+import logging
+import os
+import struct
+
+import httpx
+
+from daemon.config import settings
+from daemon.queue_client import QueueClient
+
+logger = logging.getLogger(__name__)
+
+HF_RESOLVE = "https://huggingface.co/{repo}/resolve/main/{path}"
+
+# Granular rather than total: `read` caps the gap BETWEEN chunks, so a stalled transfer
+# fails in about a minute while a slow-but-steady 46 GB download of any duration completes.
+# A total timeout cannot express that -- any value large enough for 46 GB on a bad link is
+# too large to notice a dead one.
+_TIMEOUT = httpx.Timeout(connect=20.0, read=120.0, write=120.0, pool=20.0)
+
+
+def _canonical(name: str) -> str:
+    n = (name or "").strip()
+    return n[: -len(".safetensors")] if n.endswith(".safetensors") else n
+
+
+def _local_path(name: str) -> str:
+    return os.path.join(settings.checkpoint_dir, f"{_canonical(name)}.safetensors")
+
+
+def _free_bytes(path: str) -> int:
+    """Free space on the filesystem that will hold the download.
+
+    Measured on the directory rather than the volume root: on a pod the models tree is a
+    mounted volume and the container overlay is a different, much smaller filesystem.
+    Checking the wrong one is how a precheck passes and the write still fails.
+    """
+    st = os.statvfs(path)
+    return st.f_bavail * st.f_frsize
+
+
+def verify_safetensors(path: str, expected_bytes: int) -> str | None:
+    """None if the file is sound, else a human reason it is not.
+
+    Two independent checks, because they catch different failures:
+
+      * exact byte count against the catalogue -- catches a truncated stream, which is the
+        common one, and also catches "the URL served something else of a plausible size"
+      * the safetensors header's own arithmetic (8 + header_len + the largest data_offsets
+        end) -- catches a file that is the right LENGTH but not this format, e.g. an HTML
+        error page or a redirect body written to disk
+    """
+    actual = os.path.getsize(path)
+    if expected_bytes and actual != expected_bytes:
+        return (f"expected {expected_bytes:,} bytes, got {actual:,} "
+                f"({100 * actual / expected_bytes:.1f}%)")
+    try:
+        with open(path, "rb") as fh:
+            n = struct.unpack("<Q", fh.read(8))[0]
+            # Bound before allocating: a non-safetensors file gives a garbage length here,
+            # and reading it raised MemoryError -- a real failure reported as the wrong
+            # problem, and on a 46 GB file it tries to allocate first.
+            if n <= 0 or n > actual:
+                return f"not a safetensors: header length {n} vs file size {actual}"
+            header = json.loads(fh.read(n))
+        ends = [v["data_offsets"][1] for v in header.values()
+                if isinstance(v, dict) and "data_offsets" in v]
+        declared = 8 + n + (max(ends) if ends else 0)
+        if actual < declared:
+            return f"truncated: {actual:,} of {declared:,} bytes the header declares"
+    except Exception as e:  # noqa: BLE001
+        return f"unreadable: {type(e).__name__}: {e}"
+    return None
+
+
+async def ensure_checkpoint_present(name: str, queue: QueueClient, progress=None) -> str | None:
+    """Fetch `name` if this worker lacks it. Returns the name if fetched, else None.
+
+    Returns rather than raises on every failure path. A worker that cannot fetch should let
+    the segment fail with the engine's own "no such checkpoint" message, which names the
+    file and lists what IS available -- more useful than an exception from here, and it
+    keeps this function out of the business of deciding a segment's fate.
+    """
+    stem = _canonical(name)
+    if not stem or stem.lower() == "none":
+        return None
+
+    local = _local_path(stem)
+    # Size floor is not enough for a checkpoint the way it is for a LoRA: any partial file
+    # here is tens of GB and would pass a floor. Verify properly, and treat a bad existing
+    # file as absent so it gets replaced rather than loaded.
+    if os.path.exists(local):
+        return None
+
+    try:
+        catalog = await queue.checkpoint_catalog()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Checkpoint %s: could not read the catalogue (%s) — not fetching",
+                       stem, e)
+        return None
+
+    src = (catalog or {}).get(stem)
+    if not src:
+        # A real answer, not an error: the checkpoint may exist only on a box whose source
+        # nobody recorded. The API's model gate routes those instead.
+        logger.info("Checkpoint %s: no recorded source — leaving it to a worker that has it",
+                    stem)
+        return None
+
+    expected = int(src.get("size_bytes") or 0)
+    try:
+        os.makedirs(settings.checkpoint_dir, exist_ok=True)
+    except OSError as e:
+        logger.warning("Checkpoint %s: %s is not creatable (%s) — not fetching",
+                       stem, settings.checkpoint_dir, e)
+        return None
+    # The 3090 bind-mounts its model tree READ-ONLY (-v ...:/workspace/models:ro). That box
+    # already holds every checkpoint, so this is normally unreachable there -- but a pose
+    # naming a base model it lacks would otherwise fail on a write error twenty lines later,
+    # reported as a download failure rather than as "this worker cannot fetch anything".
+    if not os.access(settings.checkpoint_dir, os.W_OK):
+        logger.info("Checkpoint %s: %s is read-only — leaving it to a worker that can fetch",
+                    stem, settings.checkpoint_dir)
+        return None
+    need = expected + settings.checkpoint_min_free_gb * (1024 ** 3)
+    free = _free_bytes(settings.checkpoint_dir)
+    if expected and free < need:
+        msg = (f"Checkpoint {stem}: needs {expected / 1e9:.0f} GB plus "
+               f"{settings.checkpoint_min_free_gb} GB headroom, only {free / 1e9:.0f} GB free")
+        logger.error(msg)
+        if progress:
+            await progress(f"[2/6] {msg} — not fetching")
+        return None
+
+    url = HF_RESOLVE.format(repo=src["repo"], path=src["path"])
+    part = local + ".part"
+    if progress:
+        await progress(f"[2/6] Fetching base model {stem} ({expected / 1e9:.0f} GB)...")
+    logger.info("Checkpoint %s: downloading from %s", stem, src["repo"])
+
+    try:
+        # A fresh client, not the queue's: this talks to Hugging Face, not the API, and it
+        # must not borrow the queue pool's auth headers or its keepalive tuning.
+        async with httpx.AsyncClient(timeout=_TIMEOUT, follow_redirects=True) as client:
+            async with client.stream("GET", url) as resp:
+                if not resp.is_success:
+                    await resp.aread()
+                    logger.error("Checkpoint %s: HTTP %s from %s",
+                                 stem, resp.status_code, src["repo"])
+                    return None
+                with open(part, "wb") as f:
+                    # Report at tenths. Each callback is an API write on the segment's
+                    # progress log, so per-chunk would post thousands of rows for one
+                    # download; a tenth of 46 GB is still a line every minute or two, which
+                    # is enough to tell moving from wedged.
+                    step = max(expected // 10, 1) if expected else 0
+                    mark = step
+                    done = 0
+                    async for chunk in resp.aiter_bytes(4 * 1024 * 1024):
+                        f.write(chunk)
+                        done += len(chunk)
+                        if progress and step and done >= mark:
+                            await progress(
+                                f"[2/6] {stem}: {done / 1e9:.0f} of {expected / 1e9:.0f} GB"
+                            )
+                            mark += step
+    except Exception as e:  # noqa: BLE001
+        logger.error("Checkpoint %s: download failed: %s", stem, e)
+        _discard(part)
+        return None
+
+    bad = verify_safetensors(part, expected)
+    if bad:
+        # Never rename a suspect file into place. Under the real name it would look present
+        # to every check and fail only at load, which is the exact failure this guards.
+        logger.error("Checkpoint %s: %s — discarding", stem, bad)
+        if progress:
+            await progress(f"[2/6] {stem}: download failed verification ({bad})")
+        _discard(part)
+        return None
+
+    os.replace(part, local)
+    logger.info("Checkpoint %s: saved (%.1f GB)", stem, os.path.getsize(local) / 1e9)
+    if progress:
+        await progress(f"[2/6] Base model {stem} ready")
+    return stem
+
+
+def _discard(path: str) -> None:
+    try:
+        os.remove(path)
+    except OSError:
+        pass

--- a/daemon/config.py
+++ b/daemon/config.py
@@ -8,6 +8,16 @@ class Settings(BaseSettings):
     comfyui_api_key: str = ""  # Bearer token for ComfyUI auth (RunPod sets this)
     comfyui_path: str = ""  # Path to ComfyUI installation (for custom node management)
     lora_cache_dir: str = ""  # Override LoRA download dir (e.g. /workspace/models/loras for persistence)
+    # Where ComfyUI loads base models from, so a checkpoint fetched on demand (console#423)
+    # lands somewhere a render will actually see. NOT derived from lora_cache_dir: LoRAs and
+    # checkpoints live in different trees, and guessing one from the other would put a 46 GB
+    # file where nothing looks for it -- which fails as "no such checkpoint" after a 20
+    # minute download. Must match wanly-gpu-docker's MODELS_DIR/ltx-2.3/diffusion_models.
+    checkpoint_dir: str = "/workspace/models/ltx-2.3/diffusion_models"
+    # Refuse a fetch that would leave the volume with less than this. The base model set is
+    # ~58 GB into a 150 GB pod volume, so one extra checkpoint fits and a second does not.
+    # Refusing up front beats dying at 92% of 46 GB inside a claimed segment.
+    checkpoint_min_free_gb: int = 12
     queue_url: str = "http://localhost:8001"
     queue_api_key: str = ""
     poll_interval: int = 5

--- a/daemon/ltx_executor.py
+++ b/daemon/ltx_executor.py
@@ -154,6 +154,25 @@ async def execute_ltx_segment(segment: SegmentClaim, queue: QueueClient) -> None
         if fetched:
             await progress.log(f"[2/6] LoRA(s) ready: {', '.join(fetched)}")
 
+        # And the base model, same idea at 70x the size (console#423). Deliberately AFTER
+        # the LoRAs: those are seconds each and this can be twenty minutes, so a pose that
+        # is going to fail on a missing LoRA should fail before the long download, not after.
+        #
+        # ComfyUI re-scans diffusion_models on every object_info request -- verified on a
+        # live pod mid-render -- so a file that lands here is visible to the render that
+        # follows, with no restart.
+        from daemon.checkpoint_sync import ensure_checkpoint_present
+        if await ensure_checkpoint_present(recipe.get("checkpoint"), queue,
+                                           progress=progress.log):
+            # Tell the API what this worker holds NOW. Without this the model gate keeps
+            # routing around a checkpoint the box has just acquired.
+            #
+            # Imported here, not at module scope: main imports the executor chain, and the
+            # reported-inventory state lives in main. executor.py takes the same approach
+            # for the same reason.
+            from daemon.main import refresh_reported_checkpoints
+            await refresh_reported_checkpoints()
+
         await progress.log("[2/6] Submitting to ltx-engine...")
         job_id = await client.submit(
             image_bytes=image_bytes,

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -22,6 +22,33 @@ from daemon.ltx_client import LtxClient
 # thing that can see one, because the engine binds to 127.0.0.1 inside the container.
 _CHECKPOINTS: list[str] = []
 
+
+async def refresh_reported_checkpoints() -> list[str]:
+    """Re-ask the engine what base models it can load, and report that from now on.
+
+    Called after an on-demand checkpoint fetch (console#423). Without it the API's view of
+    this worker stays stale until the next full rebuild, and the model gate keeps routing
+    around a file the box now holds -- which is the whole point of having fetched it.
+
+    Asks the ENGINE rather than listing the directory, because ComfyUI answers from the
+    folder mapping in extra_model_paths.yaml: a file the mapping does not cover is invisible
+    to a render however present it is on disk. A fetch that landed somewhere unmapped should
+    NOT be reported as available, and only the engine can tell the difference.
+
+    Failure is non-fatal and deliberately quiet in effect: the previous list stands, which
+    is the pre-fetch behaviour rather than an empty inventory. Reporting [] would make the
+    gate hide every recipe segment from this worker.
+    """
+    try:
+        names = await LtxClient().checkpoints()
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Could not re-read checkpoints after a fetch (%s) — "
+                       "the API keeps the previous list", e)
+        return list(_CHECKPOINTS)
+    _CHECKPOINTS[:] = names
+    logger.info("Checkpoints available: %s", ", ".join(_CHECKPOINTS) or "none")
+    return list(_CHECKPOINTS)
+
 # Artifact kinds this worker can FETCH on demand, as opposed to the ones it already holds.
 # The API will not hand a worker a segment whose models it cannot load (console#422), and a
 # LoRA this box has never seen must not count against it: lora_sync downloads those inside
@@ -30,7 +57,7 @@ _CHECKPOINTS: list[str] = []
 # A constant, not a probe, because it describes what this CODE can do. When on-demand
 # checkpoint fetching lands (console#423) it gains "checkpoint" here and the gate opens by
 # itself — the API holds no second opinion about a daemon's abilities.
-FETCHABLE_KINDS: list[str] = ["lora"]
+FETCHABLE_KINDS: list[str] = ["lora", "checkpoint"]
 from daemon.sd_scripts_monitor import get_status as get_sd_scripts_status
 from daemon.a1111_monitor import get_status as get_a1111_status
 

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -302,6 +302,21 @@ class QueueClient:
             _raise_with_details(resp, "list_loras")
         return resp.json()
 
+    async def checkpoint_catalog(self) -> dict:
+        """Where each known base model can be fetched from (console#423).
+
+        Returns the `sources` map, or {} when the API is too old to answer. An empty map
+        means "fetch nothing", which degrades to exactly the behaviour before on-demand
+        fetching existed -- the model gate routes work to a worker that holds the file. That
+        matters because the daemon and the API deploy independently.
+        """
+        resp = await self._request_with_retry("GET", "/ltx/checkpoints/catalog", timeout=30)
+        if resp.status_code == 404:
+            return {}
+        if not resp.is_success:
+            _raise_with_details(resp, "checkpoint_catalog")
+        return resp.json().get("sources") or {}
+
     async def stream_file(self, s3_path: str, dest: str, on_progress=None, total: int = 0) -> str:
         """Download to `dest`, returning the md5 of what actually landed.
 

--- a/tests/test_checkpoint_sync.py
+++ b/tests/test_checkpoint_sync.py
@@ -1,0 +1,201 @@
+"""Fetching a base model this worker lacks (console#423).
+
+Everything here guards a failure that costs twenty minutes and a claimed segment. A LoRA
+that fails to download costs 40 seconds; a checkpoint is ~70x larger, so each check exists
+because the naive version of it is expensive to get wrong.
+
+The single most important behaviour is the one at the end: a file that fails verification is
+DISCARDED, never renamed into place. A partial safetensors is a valid header over missing
+data -- present to every existence check, fatal only at load, inside a claim.
+"""
+import json
+import os
+import struct
+
+import pytest
+
+from daemon import checkpoint_sync as cs
+from daemon.config import settings
+
+
+def _safetensors(path, payload_len=64, declared_len=None, header_extra=None):
+    """Write a syntactically real safetensors file."""
+    hdr = {"w": {"dtype": "F32", "shape": [1],
+                 "data_offsets": [0, declared_len if declared_len is not None else payload_len]}}
+    if header_extra:
+        hdr.update(header_extra)
+    raw = json.dumps(hdr).encode()
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(raw)))
+        f.write(raw)
+        f.write(b"\0" * payload_len)
+    return os.path.getsize(path)
+
+
+class TestVerification:
+    def test_a_sound_file_passes(self, tmp_path):
+        p = tmp_path / "ok.safetensors"
+        size = _safetensors(p)
+        assert cs.verify_safetensors(str(p), size) is None
+
+    def test_a_short_download_is_caught_by_byte_count(self, tmp_path):
+        """The common failure: the stream ended early. The catalogue's size makes this
+        checkable without parsing anything."""
+        p = tmp_path / "short.safetensors"
+        size = _safetensors(p)
+        reason = cs.verify_safetensors(str(p), size + 1000)
+        assert reason and "expected" in reason and "%" in reason
+
+    def test_a_truncated_body_is_caught_by_the_header(self, tmp_path):
+        """The nastier failure: the header declares more data than the file holds. Catches a
+        file whose length happens to match but whose contents do not."""
+        p = tmp_path / "trunc.safetensors"
+        _safetensors(p, payload_len=10, declared_len=9999)
+        reason = cs.verify_safetensors(str(p), 0)   # 0 = skip the size check
+        assert reason and "truncated" in reason
+
+    def test_something_that_is_not_a_safetensors_at_all(self, tmp_path):
+        """An HTML error page or a redirect body written to disk. Bounded before allocating:
+        a garbage header length used to raise MemoryError, which reported the wrong problem
+        and, on a 46 GB file, tried to allocate first."""
+        p = tmp_path / "junk.safetensors"
+        p.write_bytes(b"<html>404 not found</html>" * 4)
+        reason = cs.verify_safetensors(str(p), 0)
+        assert reason and ("not a safetensors" in reason or "unreadable" in reason)
+
+
+class _Q:
+    """A queue client that answers the catalogue and nothing else."""
+    def __init__(self, catalog=None, boom=False):
+        self._c = catalog if catalog is not None else {}
+        self._boom = boom
+
+    async def checkpoint_catalog(self):
+        if self._boom:
+            raise RuntimeError("api unreachable")
+        return self._c
+
+
+CATALOG = {"10Eros_v1.5_bf16": {"repo": "TenStrip/LTX2.3-10Eros",
+                                "path": "10Eros_v1.5_bf16.safetensors",
+                                "size_bytes": 46_139_886_366}}
+
+
+@pytest.mark.asyncio
+class TestWhenItDeclinesToFetch:
+    async def test_a_file_already_here_is_left_alone(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        (tmp_path / "10Eros_v1.5_bf16.safetensors").write_bytes(b"x")
+        assert await cs.ensure_checkpoint_present("10Eros_v1.5_bf16", _Q(CATALOG)) is None
+
+    async def test_none_and_empty_are_not_filenames(self, tmp_path, monkeypatch):
+        """"none" is how a recipe says "no override". Fetching it would be a 404 for a file
+        called none.safetensors."""
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        for spelling in (None, "", "  ", "none", "NONE"):
+            assert await cs.ensure_checkpoint_present(spelling, _Q(CATALOG)) is None
+
+    async def test_an_unknown_checkpoint_is_left_to_a_worker_that_has_it(self, tmp_path, monkeypatch):
+        """No recorded source is a real answer, not an error. Guessing a URL from the name
+        would produce a confident 404 after a long wait."""
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        assert await cs.ensure_checkpoint_present("mystery_model", _Q(CATALOG)) is None
+
+    async def test_an_unreachable_api_does_not_raise(self, tmp_path, monkeypatch):
+        """The segment should fail with the engine's own "no such checkpoint", which names
+        the file and lists what IS present — more useful than an exception from here."""
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        assert await cs.ensure_checkpoint_present("10Eros_v1.5_bf16", _Q(boom=True)) is None
+
+    async def test_it_refuses_rather_than_filling_the_volume(self, tmp_path, monkeypatch):
+        """statvfs up front, because the alternative is dying at 92% of 46 GB inside a
+        claimed segment — having also evicted the page cache on the way."""
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        monkeypatch.setattr(cs, "_free_bytes", lambda p: 5 * 1024 ** 3)
+        logged = []
+
+        async def prog(msg):
+            logged.append(msg)
+
+        assert await cs.ensure_checkpoint_present(
+            "10Eros_v1.5_bf16", _Q(CATALOG), progress=prog) is None
+        assert any("free" in m for m in logged), logged
+        assert not list(tmp_path.iterdir()), "nothing should have been written"
+
+
+@pytest.mark.asyncio
+class TestTheDownloadItself:
+    async def test_a_bad_download_is_discarded_not_renamed(self, tmp_path, monkeypatch):
+        """THE one that matters. Renamed into place, a truncated 46 GB file looks present to
+        every check and fails only at load, deep inside a claimed segment."""
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        monkeypatch.setattr(cs, "_free_bytes", lambda p: 500 * 1024 ** 3)
+        _fake_stream(monkeypatch, b"\x00" * 32)      # far short of size_bytes
+
+        assert await cs.ensure_checkpoint_present("10Eros_v1.5_bf16", _Q(CATALOG)) is None
+        assert not (tmp_path / "10Eros_v1.5_bf16.safetensors").exists(), \
+            "a file that failed verification was renamed into place"
+        assert not list(tmp_path.glob("*.part")), "the staged file was left behind"
+
+    async def test_a_good_download_lands_under_the_real_name(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        monkeypatch.setattr(cs, "_free_bytes", lambda p: 500 * 1024 ** 3)
+        src = tmp_path / "src.safetensors"
+        size = _safetensors(src, payload_len=128)
+        catalog = {"tiny": {"repo": "r", "path": "tiny.safetensors", "size_bytes": size}}
+        _fake_stream(monkeypatch, src.read_bytes())
+
+        assert await cs.ensure_checkpoint_present("tiny", _Q(catalog)) == "tiny"
+        assert (tmp_path / "tiny.safetensors").exists()
+        assert not list(tmp_path.glob("*.part"))
+
+    async def test_an_http_error_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+        monkeypatch.setattr(cs, "_free_bytes", lambda p: 500 * 1024 ** 3)
+        _fake_stream(monkeypatch, b"", status=404)
+        assert await cs.ensure_checkpoint_present("10Eros_v1.5_bf16", _Q(CATALOG)) is None
+        assert not list(tmp_path.iterdir())
+
+
+def _fake_stream(monkeypatch, body: bytes, status: int = 200):
+    """Replace httpx.AsyncClient with one that yields `body` in chunks.
+
+    Chunked and async on purpose: the real requirement is that a 46 GB transfer never blocks
+    the event loop, because the heartbeat is the only reclaim authority for a live worker. A
+    blocking read here would let the API declare this worker dead and hand the segment to
+    someone else mid-download.
+    """
+    class _Resp:
+        status_code = status
+        is_success = 200 <= status < 300
+
+        async def aread(self):
+            return b""
+
+        async def aiter_bytes(self, n):
+            for i in range(0, len(body), n or 1):
+                yield body[i:i + (n or 1)]
+
+    class _Stream:
+        async def __aenter__(self): return _Resp()
+        async def __aexit__(self, *a): return False
+
+    class _Client:
+        def __init__(self, *a, **k): pass
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        def stream(self, *a, **k): return _Stream()
+
+    monkeypatch.setattr(cs.httpx, "AsyncClient", _Client)
+
+
+@pytest.mark.asyncio
+async def test_a_read_only_model_tree_declines_clearly(tmp_path, monkeypatch):
+    """The 3090 bind-mounts its models read-only. That box holds every checkpoint so this is
+    normally unreachable, but without the check a pose naming a missing base model would
+    fail on a write error reported as a download failure."""
+    monkeypatch.setattr(settings, "checkpoint_dir", str(tmp_path))
+    monkeypatch.setattr(cs, "_free_bytes", lambda p: 500 * 1024 ** 3)
+    monkeypatch.setattr(cs.os, "access", lambda p, mode: False)
+    assert await cs.ensure_checkpoint_present("10Eros_v1.5_bf16", _Q(CATALOG)) is None
+    assert not list(tmp_path.iterdir())

--- a/tests/test_heartbeat_fetchable_kinds.py
+++ b/tests/test_heartbeat_fetchable_kinds.py
@@ -40,8 +40,26 @@ class TestWhatTheHeartbeatCarries:
         change", so sending null would overwrite what a previous beat established."""
         assert "fetchable_kinds" not in await _beat()
 
-    def test_this_daemon_declares_loras_and_not_checkpoints(self):
-        """LoRAs are fetched at claim time (lora_sync.ensure_named_loras_present); a 46 GB
-        checkpoint is not, and claiming a segment that needs one would fail ten minutes in.
-        console#423 is what flips the second half of this."""
-        assert main.FETCHABLE_KINDS == ["lora"]
+    def test_this_daemon_declares_loras_and_checkpoints(self):
+        """Both are now fetched at claim time — LoRAs by
+        lora_sync.ensure_named_loras_present, base models by
+        checkpoint_sync.ensure_checkpoint_present (console#423).
+
+        This is the seam console#422 was built around: the API holds no second opinion about
+        what a daemon can do, so declaring "checkpoint" here opens the model gate on its own,
+        with no API change and no coordinated deploy.
+
+        The order matters to nothing but reading it — the API treats this as a set — but it
+        is kept stable so a diff of a heartbeat payload is legible.
+        """
+        assert main.FETCHABLE_KINDS == ["lora", "checkpoint"]
+
+    def test_declaring_a_kind_means_the_code_can_actually_fetch_it(self):
+        """The declaration is a PROMISE the API acts on: it stops gating that kind and hands
+        this worker segments needing files it does not hold. Declaring a kind nothing
+        implements is how a pod claims work it will certainly fail — which is exactly what
+        happened when the content-LoRA pre-fetch read a dead key (#176) while this list still
+        said "lora"."""
+        from daemon import checkpoint_sync, lora_sync
+        assert callable(lora_sync.ensure_named_loras_present)
+        assert callable(checkpoint_sync.ensure_checkpoint_present)


### PR DESCRIPTION
The daemon half of DavidJBarnes/wanly-console#423. Needs wanly-api#264 (the catalogue) merged first, though it degrades safely without it — see below.

## Both of the ticket's blockers cleared first

**Source** — `TenStrip/LTX2.3-10Eros`, verified byte-exact against the 3090's copy (46,139,886,366), public and ungated. So the ticket's cost table collapses to *free*, removing its own "routing is cheaper than fetching at ~$4/pod" argument against building this.

**"The unknown to test first"** — run on the live pod, mid-render, before writing any code:

```
BEFORE  ["10Eros_v1.5_bf16.safetensors"]
        (drop a probe file, wait 3s)
AFTER   ["10Eros_v1.5_bf16.safetensors","ZZprobe_423.safetensors"]
```

**ComfyUI re-scans on every `object_info` request.** No restart, nothing mid-claim. The ticket's largest risk doesn't apply. Probe removed; the in-flight render was unaffected.

## httpx, not `hf_hub_download`

`huggingface_hub` isn't a daemon dependency, and it's the wrong tool for two of the ticket's four requirements:

| requirement | why httpx |
|---|---|
| **the heartbeat must survive** | Heartbeat is the only reclaim authority for a live worker. A 46 GB transfer that blocks the event loop stops the beat, the API reclaims the segment as orphaned, and a second worker renders it while this one is still downloading. An async stream yields between chunks. |
| **progress in the segment log** | `hf_hub_download` draws a `\r` bar, which a line-oriented log cannot show — `download_models.sh` records 45 minutes of total silence from exactly that. Reported at tenths: each callback is an API write, so per-chunk would post thousands of rows. |

## Verified twice before the rename

A partial safetensors is a valid header over missing data — present to every existence check, fatal only at load, inside a claim. So it stages as `.part` and is renamed only after **both**:

- the byte count matches the catalogue **exactly** — catches a truncated stream, and a URL that served a *different model*
- the header's own arithmetic agrees with the file length — catches an HTML error page of a plausible length

Sanity-checked: a perfectly valid safetensors of the wrong size is rejected with `expected 46,139,886,366 bytes, got 134 (0.0%)`. That's the silent-wrong-model case, which would otherwise load fine and render something incomparable.

`statvfs` runs on the **target directory**, not the volume root: on a pod the models tree is a mounted volume and the container overlay is a different, much smaller filesystem, so checking the wrong one is how a precheck passes and the write still fails anyway.

## The seam

`FETCHABLE_KINDS` gains `"checkpoint"` — exactly what #422 was built around. The API holds no second opinion about a daemon's abilities, so the model gate opens by itself: no API change, no coordinated deploy.

A new test asserts **every declared kind has an implementation behind it**. Declaring a kind nothing implements is how a pod claims work it will certainly fail — which is precisely what #176 turned out to be.

After a fetch, the worker re-asks the **engine** what it can load and reports immediately, so the gate stops routing around a file the box now holds. Asked of the engine rather than the directory because ComfyUI answers from `extra_model_paths.yaml` — a file the mapping doesn't cover is invisible to a render however present it is on disk.

## Deploy safety

`checkpoint_catalog()` returns `{}` on 404, so a daemon running against an API without #264 fetches nothing and behaves exactly as before. The two repos deploy independently and this doesn't require ordering — though merging #264 first is what makes the feature actually do anything.

`checkpoint_dir` defaults to `/workspace/models/ltx-2.3/diffusion_models`, matching `download_models.sh`'s `MODELS_DIR`. It is a setting rather than derived from `lora_cache_dir`: LoRAs and checkpoints live in different trees, and guessing one from the other would put a 46 GB file where nothing looks for it.

## Tests

13 new. Verification (sound / short / truncated-header / not-a-safetensors), every decline path (already present, `"none"`, unknown, unreachable API, insufficient space, read-only tree — the 3090's actual mount), and the download itself. The one that matters most: **a bad download is discarded, never renamed** — and it asserts no `.part` is left behind either.

`pytest tests/` — **154 passed** (140 before).

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J