### PR TITLE
Report what code this worker is running

### DIFF
--- a/daemon/build_identity.py
+++ b/daemon/build_identity.py
@@ -1,0 +1,67 @@
+"""What code this worker is actually running (wanly-gpu-docker#72).
+
+Two workers ran different code for 14 hours and nothing said so. It surfaced as a 422 on a
+content LoRA that looked random: a RunPod pod fetched it correctly while the 3090 could not,
+because the pod's daemon was current and the 3090's had been cloned before the fix existed.
+Working that out meant SSHing into both boxes and reading git.
+
+TWO VALUES, because there are two update channels and they drift separately:
+
+    daemon commit   this checkout, re-cloned from main by start.sh at every container boot
+    image ref       start.sh, download_models.sh and the engine, baked into the image and
+                    only changed by a pull + recreate
+
+`docker restart` moves the first and not the second. The 3090 spent 37 hours in exactly that
+state, and a single "version" string could not have expressed it.
+
+Read ONCE at import. Both are fixed for the life of the process -- the checkout cannot change
+under a running daemon and neither can the image -- so re-reading them on every heartbeat
+would spend a subprocess every 30 seconds to re-answer a settled question.
+"""
+
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+# Baked into the image at build time by the Docker build (ARG -> ENV). Absent when the daemon
+# runs outside the image, which is a real case for local development and must not look like
+# an image whose ref is the string "None".
+_IMAGE_ENV = "WANLY_IMAGE_REF"
+
+
+def _read_commit() -> str | None:
+    """The short sha of the daemon checkout, or None if this is not a git checkout.
+
+    None is a real answer: it means "cannot tell", which is different from a commit and must
+    not be dressed up as one. start.sh clones with --depth 1, so only HEAD is available --
+    describe/tags would fail on a shallow clone and are deliberately not attempted.
+    """
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    try:
+        out = subprocess.run(
+            ["git", "-C", here, "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except Exception as e:  # noqa: BLE001 - git missing, or a hung filesystem
+        logger.debug("could not read the daemon commit: %s", e)
+        return None
+    if out.returncode != 0:
+        return None
+    return (out.stdout or "").strip() or None
+
+
+def _read_image() -> str | None:
+    value = (os.environ.get(_IMAGE_ENV) or "").strip()
+    return value or None
+
+
+DAEMON_COMMIT: str | None = _read_commit()
+IMAGE_REF: str | None = _read_image()
+
+
+def describe() -> str:
+    """One line for the boot log. Says "unknown" rather than omitting a field, because a
+    missing line reads as "nothing to report" and an unknown one reads as a question."""
+    return (f"daemon={DAEMON_COMMIT or 'unknown'} image={IMAGE_REF or 'unknown'}")

--- a/daemon/main.py
+++ b/daemon/main.py
@@ -6,6 +6,7 @@ import socket
 import sys
 
 from daemon.comfyui_client import ComfyUIClient
+from daemon import build_identity
 from daemon.config import settings
 from daemon.executor import execute_segment
 from daemon.model_validator import cleanup_partial_downloads, validate_models
@@ -162,7 +163,9 @@ async def heartbeat_loop(queue, comfyui, worker_id, friendly_name_ref, shutdown_
             data = await queue.heartbeat(worker_id, comfyui_running, gpu_stats, sd_scripts_status, a1111_status,
                                          loras=lora_inventory(),
                                          checkpoints=_CHECKPOINTS or None,
-                                         fetchable_kinds=FETCHABLE_KINDS)
+                                         fetchable_kinds=FETCHABLE_KINDS,
+                                         daemon_commit=build_identity.DAEMON_COMMIT,
+                                         image_ref=build_identity.IMAGE_REF)
             beat_count += 1
 
             # Pick up renames from the registry
@@ -565,6 +568,10 @@ async def run():
     # expensive failure here is silence: a worker on the wrong engine still produces plausible
     # output that is not comparable to anything.
     logger.info("ENGINE=%s", settings.engine)
+    # Said out loud at boot as well as reported upstream. When two workers disagree, the
+    # first question is what each is running, and the boot log is where that gets checked
+    # before anyone thinks to look at the API (wanly-gpu-docker#72).
+    logger.info("BUILD %s", build_identity.describe())
 
     # Pre-flight: validate all required models.
     #

--- a/daemon/queue_client.py
+++ b/daemon/queue_client.py
@@ -393,6 +393,8 @@ class QueueClient:
         loras: dict | None = None,
         checkpoints: list[str] | None = None,
         fetchable_kinds: list[str] | None = None,
+        daemon_commit: str | None = None,
+        image_ref: str | None = None,
     ) -> dict:
         """Send heartbeat. Returns full worker data including current friendly_name."""
         payload: dict = {"comfyui_running": comfyui_running}
@@ -406,6 +408,13 @@ class QueueClient:
         # not a fresh check — see lora_sync.inventory().
         if loras is not None:
             payload["loras"] = loras
+        # What code this worker is running (wanly-gpu-docker#72). Omitted when unknown rather
+        # than sent as null: the API reads a missing key as "no change", so a daemon that
+        # cannot tell must not overwrite a value a previous beat established.
+        if daemon_commit:
+            payload["daemon_commit"] = daemon_commit
+        if image_ref:
+            payload["image_ref"] = image_ref
         # Base models this worker can load. Reported rather than fetched: the engine binds
         # to localhost, so the daemon is the only thing that can ask it.
         if checkpoints is not None:

--- a/tests/test_build_identity.py
+++ b/tests/test_build_identity.py
@@ -1,0 +1,92 @@
+"""The daemon must say what code it is running (wanly-gpu-docker#72).
+
+Two workers ran different code for 14 hours and nothing said so. It surfaced as a 422 that
+looked random, and diagnosing it meant SSHing into both boxes and reading git.
+
+The failure this guards is not an exception -- it is a field quietly going missing, which
+puts us straight back to "SSH in and check". So these tests are about what actually reaches
+the payload.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from daemon import build_identity
+from daemon.queue_client import QueueClient
+
+
+class TestReadingIt:
+    def test_an_absent_image_env_is_none_not_the_string_none(self):
+        """The daemon also runs outside the image in development. "None" as a value would be
+        reported as if it were a real image ref."""
+        with patch.dict("os.environ", {}, clear=True):
+            assert build_identity._read_image() is None
+        with patch.dict("os.environ", {"WANLY_IMAGE_REF": "   "}):
+            assert build_identity._read_image() is None
+        with patch.dict("os.environ", {"WANLY_IMAGE_REF": "sha256:abc"}):
+            assert build_identity._read_image() == "sha256:abc"
+
+    def test_a_non_git_checkout_reports_none_rather_than_guessing(self, tmp_path):
+        """None means "cannot tell", which is different from a commit and must not be dressed
+        up as one."""
+        with patch("daemon.build_identity.os.path.abspath",
+                   return_value=str(tmp_path / "x" / "y")):
+            assert build_identity._read_commit() is None
+
+    def test_describe_says_unknown_rather_than_omitting(self):
+        """A missing field in the boot log reads as "nothing to report"; an explicit unknown
+        reads as a question worth asking."""
+        with patch.object(build_identity, "DAEMON_COMMIT", None), \
+             patch.object(build_identity, "IMAGE_REF", None):
+            assert "unknown" in build_identity.describe()
+
+
+@pytest.mark.asyncio
+class TestWhatTheHeartbeatCarries:
+    async def _payload(self, **kw):
+        q = QueueClient.__new__(QueueClient)
+        captured = {}
+
+        async def fake(method, url, **kwargs):
+            captured.update(kwargs.get("json") or {})
+            class R:
+                is_success = True
+                status_code = 200
+                @staticmethod
+                def json(): return {}
+            return R()
+
+        q._request_with_retry = AsyncMock(side_effect=fake)
+        import uuid as _u
+        await q.heartbeat(_u.uuid4(), True, **kw)
+        return captured
+
+    async def test_both_are_sent_when_known(self):
+        p = await self._payload(daemon_commit="a044cef", image_ref="sha256:abc")
+        assert p["daemon_commit"] == "a044cef"
+        assert p["image_ref"] == "sha256:abc"
+
+    async def test_unknown_values_are_omitted_not_nulled(self):
+        """The API reads a missing key as "no change". Sending null would blank a value a
+        previous beat established — the trap every optional worker field documents."""
+        p = await self._payload(daemon_commit=None, image_ref=None)
+        assert "daemon_commit" not in p
+        assert "image_ref" not in p
+
+    async def test_they_can_be_reported_independently(self):
+        """`docker restart` re-clones the daemon and reuses the image, so a new commit on an
+        old image is a real state — it is the one the 3090 was in for 37 hours."""
+        p = await self._payload(daemon_commit="a044cef")
+        assert p["daemon_commit"] == "a044cef"
+        assert "image_ref" not in p
+
+
+def test_the_heartbeat_call_actually_passes_them():
+    """The wiring, not just the plumbing. Everything above can pass while main() never
+    supplies the values — which would leave the field permanently null and look, from the
+    API, exactly like a daemon too old to report it."""
+    import inspect
+    from daemon import main as main_mod
+    src = inspect.getsource(main_mod.heartbeat_loop)
+    assert "daemon_commit=build_identity.DAEMON_COMMIT" in src
+    assert "image_ref=build_identity.IMAGE_REF" in src


### PR DESCRIPTION
The daemon half of DavidJBarnes/wanly-gpu-docker#72's remaining criteria. Pairs with wanly-api#267 (stores it) and wanly-gpu-docker#75 (bakes the image ref).

## Why

Two workers ran different code for 14 hours and nothing said so. It surfaced as a 422 on a content LoRA that looked random — a pod fetched it correctly while the 3090 could not, because the pod's daemon was current and the 3090's had been cloned before the fix existed. Working that out meant SSHing into both boxes and reading git.

## Two values, because there are two update channels

```
daemon commit   this checkout — re-cloned from main by start.sh at every container boot
image ref       start.sh, download_models.sh, the engine — only on pull + recreate
```

`docker restart` moves the first and not the second. The 3090 spent **37 hours** in exactly that state, and one "version" string could not have expressed it.

## Decisions

**Read once at import.** Neither can change under a running process, so re-reading them every 30 seconds would spend a subprocess to re-answer a settled question.

**Unknown is reported as absent, never null or the string `"None"`.** The API reads a missing key as "no change", so a daemon that can't tell must not overwrite what a previous beat established. And the daemon runs outside the image in development, where there's no image ref at all. A non-git checkout likewise yields `None` rather than a guess — "cannot tell" is a different answer from a commit.

**Shallow-clone aware.** `start.sh` clones `--depth 1`, so only `HEAD` is available; `describe`/tags would fail and aren't attempted.

**Also logged at boot.** When two workers disagree, the first question is what each is running, and the boot log is where that gets checked before anyone thinks to query the API.

## Tests

Seven. The important one is `test_the_heartbeat_call_actually_passes_them` — everything else can pass while `main()` never supplies the values, which from the API looks *identical* to a daemon too old to report at all. **Verified it fails when the wiring is removed.**

`pytest tests/` — **165 passed**.

https://claude.ai/code/session_0131f2kPHynizfoKezqVxa2J